### PR TITLE
Allow overriding operator predicates via optional mapping arg

### DIFF
--- a/sqlalchemy/pyproject.toml
+++ b/sqlalchemy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cerbos-sqlalchemy"
-version = "0.1.4"
+version = "0.2.0"
 description = "SQLAlchemy adapter for generating queries with Cerbos: an open core, language-agnostic, scalable authorization solution"
 authors = [
     {name = "Cerbos Developers", email = "sdk+sqlalchemy@cerbos.dev"},

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -43,7 +43,7 @@ def get_query(
     query_plan: PlanResourcesResponse,
     table: GenericTable,
     attr_map: dict[str, GenericColumn],
-    table_mapping: list[tuple[GenericTable, BinaryExpression | ColumnOperators]]
+    table_mapping: list[tuple[GenericTable, GenericExpression]]
     | None = None,
     operator_override_fns: OperatorFnMap | None = None,
 ) -> Select:

--- a/sqlalchemy/tests/test_query.py
+++ b/sqlalchemy/tests/test_query.py
@@ -459,7 +459,6 @@ class TestGetQuery:
                 "in": lambda c, v: c == v,
         }
         query = get_query(plan_resource_resp, contact_table, attr, operator_override_fns=operator_override_fns)
-        print(query.compile(compile_kwargs={"literal_binds": True}))
         res = conn.execute(query).fetchall()
         assert len(res) == 1
         assert res[0].name == "contact1"


### PR DESCRIPTION
The base library provides a base set of operators which are widely supported across a range of SQL dialects. However, in some cases, users may wish to override a particular operator for a more idiomatic/optimised alternative for a given database. An example of this could be postgres users preferring to use `= ANY` over `IN`.

It would be used like so:

```python
from sqlalchemy.sql.expression import any_

query = get_query(
    plan_resource_resp,
    some_table,
    attr_map={
        "request.resource.attr.foo": Table1.foo,
    },
    # override handler functions in the map below
    operator_override_fns={
        "in": lambda c, v: c == any_(v),
    },
)
```

The types are as follows:
```python
from sqlalchemy import Column
from sqlalchemy.orm import InstrumentedAttribute
from sqlalchemy.sql.expression import BinaryExpression, ColumnOperators

GenericColumn = Column | InstrumentedAttribute
GenericExpression = BinaryExpression | ColumnOperators
# and the actual map arg to `get_query` ⬇️
OperatorFnMap = dict[str, Callable[[GenericColumn, Any], GenericExpression]]
```

So in essence, `c` is a sqlalchemy "column type", and `v` is the python value (int, str, bool etc)