### PR TITLE
[Prisma] Handle nested paths

### DIFF
--- a/prisma/package.json
+++ b/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerbos/orm-prisma",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "homepage": "https://cerbos.dev",
   "description": "",
   "private": false,

--- a/prisma/package.json
+++ b/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerbos/orm-prisma",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "homepage": "https://cerbos.dev",
   "description": "",
   "private": false,

--- a/prisma/prisma/schema.prisma
+++ b/prisma/prisma/schema.prisma
@@ -11,13 +11,15 @@ datasource db {
 }
 
 model Resource {
-  id        String  @id @default(cuid())
-  aString   String
-  aNumber   Int
-  aBool     Boolean
-  ownedBy   User[]
-  createdBy User    @relation(fields: [creatorId], references: [id], name: "creator")
-  creatorId String
+  id               String         @id @default(cuid())
+  aString          String
+  aNumber          Int
+  aBool            Boolean
+  ownedBy          User[]
+  createdBy        User           @relation(fields: [creatorId], references: [id], name: "creator")
+  creatorId        String
+  nested           NestedResource @relation(fields: [nestedResourceId], references: [id])
+  nestedResourceId String
 }
 
 model User {
@@ -27,4 +29,12 @@ model User {
   aBool            Boolean
   resources        Resource[]
   createdResources Resource[] @relation(name: "creator")
+}
+
+model NestedResource {
+  id       String     @id @default(cuid())
+  aString  String
+  aNumber  Int
+  aBool    Boolean
+  Resource Resource[]
 }


### PR DESCRIPTION
For the scenario when a query is filtering based on a field on a related table, convert a dot-path to an object eg

*Schema*
```prisma
model Resource {
  id               String         @id @default(cuid())
  nested           NestedResource @relation(fields: [nestedResourceId], references: [id])
  nestedResourceId String
}

model NestedResource {
  id       String     @id @default(cuid())
  aBool    Boolean
  Resource Resource[]
}

```

The query plan says:
`request.resource.attr.nested.aBool` should equal `true`

```ts
const result = queryPlanToPrisma({
   queryPlan,
   fieldNameMapper: {
     "request.resource.attr.nested.aBool": "nested.aBool",
   },
});
```
The query where filter will be

```json
{
   "nested": {
     "aBool": {
         "equal": true
     }
}
```
