### PR TITLE
Update prisma mapper internals

### DIFF
--- a/prisma/package-lock.json
+++ b/prisma/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cerbos/orm-prisma",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cerbos/orm-prisma",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@cerbos/core": "^0.24.0",

--- a/prisma/package.json
+++ b/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerbos/orm-prisma",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "https://cerbos.dev",
   "description": "Prisma adapter for Cerbos query plans",
   "private": false,


### PR DESCRIPTION
  - Fix in handling so relation-backed filters keep equality for single values while still emitting { in: [...] } for multi-value cases, and ensure except yields the right nested  NOT structure.
  - Expand the Prisma adapter test suite with fixture-backed scenarios covering scalar in, relation in (single and multi-value), and nested except behaviour to lock down the new logic.
  - Refresh the README to document except, describe how in is normalised and provides an collection-operator example.