### PR TITLE
ci: include workflow files in pull_request path filters

### DIFF
--- a/.github/workflows/chromadb.yaml
+++ b/.github/workflows/chromadb.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - "langchain-chromadb/**"
       - "policies/**"
+      - ".github/workflows/chromadb.yaml"
+      - ".github/workflows/chromadb-publish.yaml"
   push:
     tags:
       - langchain-chromadb/v*

--- a/.github/workflows/convex.yaml
+++ b/.github/workflows/convex.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - "convex/**"
       - "policies/**"
+      - ".github/workflows/convex.yaml"
+      - ".github/workflows/convex-publish.yaml"
   push:
     tags:
       - convex/v*

--- a/.github/workflows/drizzle.yaml
+++ b/.github/workflows/drizzle.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - "drizzle/**"
+      - "policies/**"
+      - ".github/workflows/drizzle.yaml"
+      - ".github/workflows/drizzle-publish.yaml"
   push:
     tags:
       - drizzle/v*

--- a/.github/workflows/elasticsearch-java.yaml
+++ b/.github/workflows/elasticsearch-java.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "elasticsearch-java/**"
       - "policies/**"
+      - ".github/workflows/elasticsearch-java.yaml"
   push:
     tags:
       - elasticsearch-java/v*

--- a/.github/workflows/mongoose.yaml
+++ b/.github/workflows/mongoose.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - "mongoose/**"
       - "policies/**"
+      - ".github/workflows/mongoose.yaml"
+      - ".github/workflows/mongoose-publish.yaml"
   push:
     tags:
       - mongoose/v*

--- a/.github/workflows/prisma.yaml
+++ b/.github/workflows/prisma.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - "prisma/**"
       - "policies/**"
+      - ".github/workflows/prisma.yaml"
+      - ".github/workflows/prisma-publish.yaml"
   push:
     tags:
       - prisma/v*

--- a/.github/workflows/sqlalchemy_pr.yaml
+++ b/.github/workflows/sqlalchemy_pr.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - "sqlalchemy/**"
       - "policies/**"
+      - ".github/workflows/sqlalchemy_pr.yaml"
+      - ".github/workflows/sqlalchemy_release.yaml"
     branches:
       - main
 


### PR DESCRIPTION
## Summary
- Each adapter test workflow now triggers when its own `.github/workflows/*.yaml` changes, so renovate PRs that only bump pinned action SHAs (e.g. #179) actually run tests
- Added the matching `*-publish.yaml` to each adapter's filter so publish-workflow edits get exercised by the test workflow too
- Filled in the missing `policies/**` filter for `drizzle.yaml` (all other adapters already had it)

Fixes #197

## Test plan
- [ ] This PR itself triggers each adapter's test workflow because it touches `.github/workflows/<adapter>.yaml`
- [ ] No `policies/**` or adapter source changes — if any adapter test runs unrelated to its workflow file, that's a surprise worth looking at