### PR TITLE
feat: CEL arithmetic, regex, casts, ternary, size across adapters

### DIFF
--- a/convex/src/index.test.ts
+++ b/convex/src/index.test.ts
@@ -1419,3 +1419,602 @@ describe("Error Handling", () => {
     ).toThrow("Unsupported operator: unsupported");
   });
 });
+
+describe("Arithmetic Operators (postFilter)", () => {
+  test("arith-add - gt(add(aNumber, 1), 2)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-add",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "add",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 1 },
+          ],
+        },
+        { value: 2 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.kind).toBe(PlanKind.CONDITIONAL);
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => r.aNumber + 1 > 2).map((r) => r.key),
+    );
+  });
+
+  test("arith-add throws without allowPostFilter", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-add",
+    });
+
+    expect(() =>
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }),
+    ).toThrow("allowPostFilter");
+  });
+
+  test("arith-sub - lt(sub(aNumber, 1), 2)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-sub",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "lt",
+      operands: [
+        {
+          operator: "sub",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 1 },
+          ],
+        },
+        { value: 2 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => r.aNumber - 1 < 2).map((r) => r.key),
+    );
+  });
+
+  test("arith-mult - gt(mult(aNumber, 2), 2)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-mult",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "mult",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 2 },
+          ],
+        },
+        { value: 2 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => r.aNumber * 2 > 2).map((r) => r.key),
+    );
+  });
+
+  test("arith-div - gt(div(aNumber, 2), 0)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-div",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "div",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 2 },
+          ],
+        },
+        { value: 0 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => r.aNumber / 2 > 0).map((r) => r.key),
+    );
+  });
+
+  test("arith-mod - eq(mod(aNumber, 2), 0)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-mod",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "mod",
+          operands: [
+            {
+              operator: "int",
+              operands: [{ name: "request.resource.attr.aNumber" }],
+            },
+            { value: 2 },
+          ],
+        },
+        { value: 0 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => r.aNumber % 2 === 0).map((r) => r.key),
+    );
+  });
+});
+
+describe("Regex Operator (postFilter)", () => {
+  test("matches-regex - matches(aString, 'str.*')", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "matches-regex",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "matches",
+      operands: [
+        { name: "request.resource.attr.aString" },
+        { value: "^str.*" },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => /str.*/.test(r.aString)).map((r) => r.key),
+    );
+  });
+
+  test("matches-regex throws without allowPostFilter", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "matches-regex",
+    });
+
+    expect(() =>
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }),
+    ).toThrow("allowPostFilter");
+  });
+});
+
+describe("List Index Operator (postFilter)", () => {
+  test("index-list - eq(index(ownedBy, 0), 'user1')", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "index-list",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "index",
+          operands: [
+            { name: "request.resource.attr.ownedBy" },
+            { value: 0 },
+          ],
+        },
+        { value: "user1" },
+      ],
+    });
+
+    const mapper: Mapper = {
+      ...defaultMapper,
+      "request.resource.attr.ownedBy": { field: "ownedBy" },
+    };
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const docs = [
+      { key: "a", ownedBy: ["user1", "user2"] },
+      { key: "b", ownedBy: ["user2", "user1"] },
+      { key: "c", ownedBy: [] },
+    ];
+    const postFiltered = docs.filter((d) =>
+      result.postFilter!(d as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((d) => d.key)).toEqual(["a"]);
+  });
+
+  test("index-list throws without allowPostFilter", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "index-list",
+    });
+
+    expect(() =>
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }),
+    ).toThrow("allowPostFilter");
+  });
+});
+
+describe("Type Conversion Operators (postFilter)", () => {
+  test("convert-string - eq(string(aNumber), '1')", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-string",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "string",
+          operands: [{ name: "request.resource.attr.aNumber" }],
+        },
+        { value: "1" },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => String(r.aNumber) === "1").map((r) => r.key),
+    );
+  });
+
+  test("convert-string throws without allowPostFilter", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-string",
+    });
+
+    expect(() =>
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }),
+    ).toThrow("allowPostFilter");
+  });
+
+  test("convert-double - gt(double(aNumber), 1.5)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-double",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "double",
+          operands: [{ name: "request.resource.attr.aNumber" }],
+        },
+        { value: 1.5 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => Number(r.aNumber) > 1.5).map((r) => r.key),
+    );
+  });
+
+  test("convert-int - gt(int(aString), 0)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-int",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "int",
+          operands: [{ name: "request.resource.attr.aString" }],
+        },
+        { value: 0 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    // parseInt on existing fixtures yields NaN -> no matches.
+    // Use ad-hoc docs to exercise the operator behaviour.
+    const docs = [
+      { key: "x", aString: "42" },
+      { key: "y", aString: "0" },
+      { key: "z", aString: "string" },
+      { key: "w", aString: "-3" },
+    ];
+    const postFiltered = docs.filter((d) =>
+      result.postFilter!(d as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((d) => d.key)).toEqual(["x"]);
+  });
+});
+
+describe("Ternary Operator (postFilter)", () => {
+  test("ternary - gt(if(aBool, aNumber, 0), 0)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "ternary",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "if",
+          operands: [
+            { name: "request.resource.attr.aBool" },
+            { name: "request.resource.attr.aNumber" },
+            { value: 0 },
+          ],
+        },
+        { value: 0 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources
+        .filter((r) => (r.aBool ? r.aNumber : 0) > 0)
+        .map((r) => r.key),
+    );
+  });
+
+  test("ternary throws without allowPostFilter", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "ternary",
+    });
+
+    expect(() =>
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }),
+    ).toThrow("allowPostFilter");
+  });
+});
+
+describe("Size Operator (postFilter)", () => {
+  test("string-size - gt(size(aString), 0)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "string-size",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "size",
+          operands: [{ name: "request.resource.attr.aString" }],
+        },
+        { value: 0 },
+      ],
+    });
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper: defaultMapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const postFiltered = fixtureResources.filter((r) =>
+      result.postFilter!(r as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((r) => r.key)).toEqual(
+      fixtureResources.filter((r) => r.aString.length > 0).map((r) => r.key),
+    );
+  });
+
+  test("empty-collection - eq(size(tags), 0)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "empty-collection",
+    });
+
+    expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "size",
+          operands: [{ name: "request.resource.attr.tags" }],
+        },
+        { value: 0 },
+      ],
+    });
+
+    const mapper: Mapper = {
+      ...defaultMapper,
+      "request.resource.attr.tags": { field: "tags" },
+    };
+
+    const result = queryPlanToConvex({
+      queryPlan,
+      mapper,
+      allowPostFilter: true,
+    });
+
+    expect(result.filter).toBeUndefined();
+    expect(result.postFilter).toBeDefined();
+
+    const docs = [
+      { key: "a", tags: [] },
+      { key: "b", tags: ["x"] },
+      { key: "c", tags: ["x", "y"] },
+    ];
+    const postFiltered = docs.filter((d) =>
+      result.postFilter!(d as unknown as Record<string, unknown>),
+    );
+    expect(postFiltered.map((d) => d.key)).toEqual(["a"]);
+  });
+
+  test("empty-collection throws without allowPostFilter", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "empty-collection",
+    });
+
+    expect(() =>
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }),
+    ).toThrow("allowPostFilter");
+  });
+});

--- a/convex/src/index.ts
+++ b/convex/src/index.ts
@@ -40,6 +40,10 @@ const ALL_KNOWN_OPERATORS = new Set([
   "contains", "startsWith", "endsWith",
   "hasIntersection", "exists", "exists_one", "all",
   "filter", "map", "lambda",
+  "add", "sub", "mult", "div", "mod",
+  "matches", "index", "size",
+  "string", "double", "int",
+  "if",
 ]);
 
 const isExpression = (e: PlanExpressionOperand): e is PlanExpression =>
@@ -482,6 +486,65 @@ const evaluateExpression = (
 
     case "lambda":
       throw new Error("lambda should not be evaluated directly");
+
+    case "add":
+      return (resolve(operands[0]!) as number) + (resolve(operands[1]!) as number);
+
+    case "sub":
+      return (resolve(operands[0]!) as number) - (resolve(operands[1]!) as number);
+
+    case "mult":
+      return (resolve(operands[0]!) as number) * (resolve(operands[1]!) as number);
+
+    case "div":
+      return (resolve(operands[0]!) as number) / (resolve(operands[1]!) as number);
+
+    case "mod":
+      return (resolve(operands[0]!) as number) % (resolve(operands[1]!) as number);
+
+    case "matches": {
+      const str = resolve(operands[0]!) as string;
+      const pattern = resolve(operands[1]!) as string;
+      if (typeof str !== "string" || typeof pattern !== "string") return false;
+      return new RegExp(pattern).test(str);
+    }
+
+    case "index": {
+      const collection = resolve(operands[0]!) as unknown[];
+      const idx = resolve(operands[1]!) as number;
+      if (!Array.isArray(collection)) return undefined;
+      return collection[idx];
+    }
+
+    case "size": {
+      const v = resolve(operands[0]!);
+      if (typeof v === "string") return v.length;
+      if (Array.isArray(v)) return v.length;
+      if (v && typeof v === "object") return Object.keys(v).length;
+      return 0;
+    }
+
+    case "string": {
+      const v = resolve(operands[0]!);
+      if (v === null || v === undefined) return v;
+      return String(v);
+    }
+
+    case "double": {
+      const v = resolve(operands[0]!);
+      return Number(v);
+    }
+
+    case "int": {
+      const v = resolve(operands[0]!);
+      const n = typeof v === "string" ? parseInt(v, 10) : Math.trunc(Number(v));
+      return n;
+    }
+
+    case "if": {
+      const cond = resolve(operands[0]!);
+      return cond ? resolve(operands[1]!) : resolve(operands[2]!);
+    }
 
     default:
       throw new Error(`Unsupported operator: ${operator}`);

--- a/drizzle/src/index.test.ts
+++ b/drizzle/src/index.test.ts
@@ -18,6 +18,15 @@ import type { MapperEntry, QueryPlanToDrizzleResult } from ".";
 
 const cerbos = new Cerbos("127.0.0.1:3593", { tls: false });
 const sqlite = new Database(":memory:");
+// Register a REGEXP function so SQLite can evaluate the matches() CEL operator.
+sqlite.function("regexp", (pattern: unknown, value: unknown) => {
+  if (value === null || value === undefined) return 0;
+  try {
+    return new RegExp(String(pattern)).test(String(value)) ? 1 : 0;
+  } catch {
+    return 0;
+  }
+});
 const db = drizzle(sqlite);
 
 const users = sqliteTable("users", {
@@ -722,6 +731,23 @@ const conditionalActions = [
   "relation-none",
   "relation-some",
   "starts-with",
+  // New scenarios — arithmetic on a column inside a comparison.
+  "arith-add",
+  "arith-sub",
+  "arith-mult",
+  "arith-div",
+  "arith-mod",
+  // Regex match via CEL string.matches() — relies on SQLite REGEXP UDF.
+  "matches-regex",
+  // CEL type conversions: string(), double(), int() — compiled to CAST.
+  "convert-string",
+  "convert-double",
+  "convert-int",
+  // Ternary expression — compiled to CASE WHEN.
+  "ternary",
+  // size() on scalar (LENGTH) and on relation (correlated COUNT subquery).
+  "string-size",
+  "empty-collection",
 ];
 
 beforeAll(() => {
@@ -1112,6 +1138,20 @@ describe("queryPlanToDrizzle", () => {
       .map((r) => r.id)
       .sort();
     expect(ids).toEqual(expected);
+  });
+
+  test("throws for index-list (array indexing on a relation)", async () => {
+    // ownedBy is modelled as a join table — there is no scalar index column,
+    // so R.attr.ownedBy[0] cannot be translated into a deterministic SQL fragment.
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "index-list",
+    });
+
+    expect(() =>
+      queryPlanToDrizzle({ queryPlan, mapper })
+    ).toThrow(/index/i);
   });
 
   test("throws when mapping is missing", () => {

--- a/drizzle/src/index.ts
+++ b/drizzle/src/index.ts
@@ -471,6 +471,204 @@ const resolveFieldReference = (
   throw new Error(`No mapping found for reference: ${reference}`);
 };
 
+const ARITHMETIC_OPERATORS: Record<string, string> = {
+  add: "+",
+  sub: "-",
+  mult: "*",
+  div: "/",
+  mod: "%",
+};
+
+const CONVERSION_TARGETS: Record<string, string> = {
+  string: "TEXT",
+  double: "REAL",
+  int: "INTEGER",
+};
+
+const buildValueExpressionFromValue = (value: Value): SQL => sql`${value}`;
+
+const buildColumnExpression = (
+  mapping: BaseMapperEntry,
+  reference: string
+): SQL => {
+  if (isRelationValue(mapping)) {
+    throw new Error(
+      `Cannot use relation '${reference}' as a scalar value expression`
+    );
+  }
+  if (typeof mapping === "function") {
+    throw new Error(
+      `Cannot use transform mapping for '${reference}' as a value expression`
+    );
+  }
+  if (isMappingConfig(mapping)) {
+    if (mapping.relation) {
+      throw new Error(
+        `Cannot use relation mapping for '${reference}' as a scalar value expression`
+      );
+    }
+    if (!mapping.column) {
+      throw new Error(
+        `Mapping for '${reference}' requires a column to be used as a value expression`
+      );
+    }
+    return sql`${mapping.column}`;
+  }
+  if (!isColumn(mapping)) {
+    throw new Error(`Expected column mapping for '${reference}'`);
+  }
+  return sql`${mapping}`;
+};
+
+const buildSizeExpression = (
+  operand: PlanExpressionOperand,
+  mapper: Mapper
+): SQL => {
+  if (!isNameOperand(operand)) {
+    throw new Error("'size' operator requires a name operand");
+  }
+  // Determine whether the operand is a relation or a scalar column.
+  let resolved: { relations: RelationMapping[]; mapping: BaseMapperEntry };
+  try {
+    resolved = resolveFieldReference(operand.name, mapper);
+  } catch (err) {
+    throw err;
+  }
+  // Relation: produce a correlated COUNT subquery walking the relation chain.
+  if (resolved.relations.length > 0) {
+    const relations = resolved.relations;
+    const primary = relations[relations.length - 1]!;
+    const tableName = resolveTableName(primary.table, operand.name);
+    const joinCondition = eq(primary.targetColumn, primary.sourceColumn);
+    const inner = sql`(select count(*) from ${sql.identifier(tableName)} where ${joinCondition})`;
+    if (relations.length === 1) {
+      return inner;
+    }
+    // Wrap with leading relation EXISTS contexts — uncommon, but support it.
+    const leading = relations.slice(0, -1);
+    return wrapWithRelations(leading, inner, operand.name);
+  }
+  // Scalar column: LENGTH(col).
+  const colExpr = buildColumnExpression(resolved.mapping, operand.name);
+  return sql`length(${colExpr})`;
+};
+
+const buildValueExpression = (
+  operand: PlanExpressionOperand,
+  mapper: Mapper
+): SQL => {
+  if (isValueOperand(operand)) {
+    return buildValueExpressionFromValue(operand.value);
+  }
+  if (isNameOperand(operand)) {
+    const resolved = resolveFieldReference(operand.name, mapper);
+    if (resolved.relations.length > 0) {
+      throw new Error(
+        `Cannot use relation '${operand.name}' as a scalar value expression`
+      );
+    }
+    return buildColumnExpression(resolved.mapping, operand.name);
+  }
+  if (!isExpressionOperand(operand)) {
+    throw new Error("Invalid value-expression operand");
+  }
+
+  const { operator, operands } = operand;
+
+  if (operator in ARITHMETIC_OPERATORS) {
+    if (operands.length !== 2) {
+      throw new Error(`Arithmetic operator '${operator}' requires two operands`);
+    }
+    const left = buildValueExpression(operands[0]!, mapper);
+    const right = buildValueExpression(operands[1]!, mapper);
+    const op = ARITHMETIC_OPERATORS[operator]!;
+    return sql`(${left} ${sql.raw(op)} ${right})`;
+  }
+
+  if (operator in CONVERSION_TARGETS) {
+    if (operands.length !== 1) {
+      throw new Error(
+        `Conversion operator '${operator}' requires exactly one operand`
+      );
+    }
+    const inner = buildValueExpression(operands[0]!, mapper);
+    const target = CONVERSION_TARGETS[operator]!;
+    return sql`cast(${inner} as ${sql.raw(target)})`;
+  }
+
+  if (operator === "if") {
+    if (operands.length !== 3) {
+      throw new Error("'if' operator requires exactly three operands");
+    }
+    const cond = buildConditionFromOperand(operands[0]!, mapper);
+    const thenExpr = buildValueExpression(operands[1]!, mapper);
+    const elseExpr = buildValueExpression(operands[2]!, mapper);
+    return sql`(case when ${cond} then ${thenExpr} else ${elseExpr} end)`;
+  }
+
+  if (operator === "size") {
+    if (operands.length !== 1) {
+      throw new Error("'size' operator requires exactly one operand");
+    }
+    return buildSizeExpression(operands[0]!, mapper);
+  }
+
+  if (operator === "index") {
+    throw new Error(
+      "'index' operator (array indexing) is not supported by the Drizzle adapter"
+    );
+  }
+
+  throw new Error(`Unsupported value-expression operator: ${operator}`);
+};
+
+// Build a boolean SQL condition from an operand. Used for ternary `if` test branch.
+// Falls back to coercing scalar/name operands to a truthiness check.
+const buildConditionFromOperand = (
+  operand: PlanExpressionOperand,
+  mapper: Mapper
+): SQL => {
+  if (isExpressionOperand(operand)) {
+    return buildFilterFromExpression(operand, mapper);
+  }
+  if (isNameOperand(operand)) {
+    const resolved = resolveFieldReference(operand.name, mapper);
+    const colExpr = buildColumnExpression(resolved.mapping, operand.name);
+    return sql`${colExpr} = 1`;
+  }
+  if (isValueOperand(operand)) {
+    return operand.value
+      ? TRUE_CONDITION
+      : FALSE_CONDITION;
+  }
+  throw new Error("Invalid condition operand");
+};
+
+const applyComparisonWithExpression = (
+  operator: ComparisonOperator,
+  fieldExpr: SQL,
+  valueExpr: SQL
+): SQL => {
+  switch (operator) {
+    case "eq":
+      return sql`${fieldExpr} = ${valueExpr}`;
+    case "ne":
+      return sql`${fieldExpr} <> ${valueExpr}`;
+    case "lt":
+      return sql`${fieldExpr} < ${valueExpr}`;
+    case "le":
+      return sql`${fieldExpr} <= ${valueExpr}`;
+    case "gt":
+      return sql`${fieldExpr} > ${valueExpr}`;
+    case "ge":
+      return sql`${fieldExpr} >= ${valueExpr}`;
+    default:
+      throw new Error(
+        `Operator '${operator}' is not supported for expression-valued operands`
+      );
+  }
+};
+
 const applyComparison = (
   mapping: BaseMapperEntry,
   operator: ComparisonOperator,
@@ -879,6 +1077,26 @@ const buildFilterFromExpression = (
     case "startsWith":
     case "endsWith":
     case "isSet": {
+      // Detect an expression-valued operand on either side (e.g. arithmetic,
+      // type-conversion, `if`, or `size`). When present, evaluate both sides
+      // as SQL value expressions and emit a raw comparison.
+      if (
+        operator !== "in" &&
+        operator !== "contains" &&
+        operator !== "startsWith" &&
+        operator !== "endsWith" &&
+        operator !== "isSet" &&
+        operands.length === 2 &&
+        operands.some(isExpressionOperand)
+      ) {
+        const [leftOperand, rightOperand] = operands;
+        if (!leftOperand || !rightOperand) {
+          throw new Error("Comparison operator requires two operands");
+        }
+        const leftExpr = buildValueExpression(leftOperand, mapper);
+        const rightExpr = buildValueExpression(rightOperand, mapper);
+        return applyComparisonWithExpression(operator, leftExpr, rightExpr);
+      }
       const fieldOperand = operands.find(isNameOperand);
       if (!fieldOperand) {
         throw new Error("Comparison operator missing field operand");
@@ -897,6 +1115,31 @@ const buildFilterFromExpression = (
             options
           )
         : filter;
+    }
+    case "matches": {
+      if (operands.length !== 2) {
+        throw new Error("'matches' operator requires exactly two operands");
+      }
+      const fieldOperand = operands[0];
+      const patternOperand = operands[1];
+      if (!fieldOperand || !isNameOperand(fieldOperand)) {
+        throw new Error("'matches' first operand must be a field reference");
+      }
+      if (!patternOperand || !isValueOperand(patternOperand)) {
+        throw new Error("'matches' second operand must be a regex value");
+      }
+      if (typeof patternOperand.value !== "string") {
+        throw new Error("'matches' regex pattern must be a string");
+      }
+      const resolved = resolveFieldReference(fieldOperand.name, mapper);
+      if (resolved.relations.length > 0) {
+        throw new Error(
+          "'matches' on a relation-valued field is not supported"
+        );
+      }
+      const colExpr = buildColumnExpression(resolved.mapping, fieldOperand.name);
+      const filter = sql`${colExpr} regexp ${patternOperand.value}`;
+      return filter;
     }
     case "hasIntersection":
       return buildHasIntersectionFilter(operands, mapper);

--- a/elasticsearch-java/src/main/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapter.java
+++ b/elasticsearch-java/src/main/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapter.java
@@ -44,6 +44,8 @@ public class ElasticsearchQueryPlanAdapter {
                     Map.of("prefix", Map.of(field, Map.of("value", value)))),
             Map.entry("endsWith", (field, value) ->
                     Map.of("wildcard", Map.of(field, Map.of("value", "*" + escapeWildcard(value))))),
+            Map.entry("matches", (field, value) ->
+                    Map.of("regexp", Map.of(field, Map.of("value", toLuceneRegex(value.toString()))))),
             Map.entry("hasIntersection", (field, value) ->
                     Map.of("terms", Map.of(field, value instanceof List<?> l ? l : List.of(value)))),
             Map.entry("isSet", (field, value) ->
@@ -576,6 +578,29 @@ public class ElasticsearchQueryPlanAdapter {
                 .replace("\\", "\\\\")
                 .replace("*", "\\*")
                 .replace("?", "\\?");
+    }
+
+    // CEL `matches()` uses RE2 partial-match semantics with explicit `^` / `$` anchors.
+    // Elasticsearch's `regexp` query uses Lucene regex which always anchors the whole
+    // field — anchors aren't syntax, they'd match literal `^` / `$` characters. Convert:
+    //  - drop a leading `^` (Lucene already anchors at start)
+    //  - drop a trailing unescaped `$` (Lucene already anchors at end)
+    //  - if the CEL pattern wasn't anchored at start/end, wrap with `.*` so a partial
+    //    match in CEL still maps to a whole-field match in Lucene.
+    static String toLuceneRegex(String celPattern) {
+        boolean anchoredStart = celPattern.startsWith("^");
+        String body = anchoredStart ? celPattern.substring(1) : celPattern;
+        boolean anchoredEnd = body.endsWith("$") && !body.endsWith("\\$");
+        if (anchoredEnd) {
+            body = body.substring(0, body.length() - 1);
+        }
+        if (!anchoredStart && !body.startsWith(".*")) {
+            body = ".*" + body;
+        }
+        if (!anchoredEnd && !body.endsWith(".*")) {
+            body = body + ".*";
+        }
+        return body;
     }
 
     static Object protoValueToJava(Value value) {

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchIntegrationTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchIntegrationTest.java
@@ -636,6 +636,98 @@ class ElasticsearchIntegrationTest {
         assertEquals(List.of("3"), executeQuery("combined-and"));
     }
 
+    // --- Arithmetic (unsupported in ES query DSL without painless scripts) ---
+
+    @Test
+    void arithAddThrows() {
+        // aNumber + 1 > 2 — arithmetic on document fields not natively supported.
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("arith-add"));
+    }
+
+    @Test
+    void arithSubThrows() {
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("arith-sub"));
+    }
+
+    @Test
+    void arithMultThrows() {
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("arith-mult"));
+    }
+
+    @Test
+    void arithDivThrows() {
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("arith-div"));
+    }
+
+    @Test
+    void arithModThrows() {
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("arith-mod"));
+    }
+
+    // --- Regex (supported via ES regexp query on keyword fields) ---
+
+    @Test
+    void matchesRegex() throws Exception {
+        // aString matches "str.*" → keyword field, case-sensitive.
+        // Doc 1: "string" matches. Doc 2: "amIAString?" no. Doc 3: "anotherString" no.
+        assertEquals(List.of("1"), executeQuery("matches-regex"));
+    }
+
+    // --- List indexing (unsupported: ES treats arrays as multivalued, no ordered access) ---
+
+    @Test
+    void indexListThrows() {
+        // ownedBy[0] == "user1" — array indexing not expressible in ES query DSL.
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("index-list"));
+    }
+
+    // --- Type conversions (unsupported: CAST not natively in ES query DSL) ---
+
+    @Test
+    void convertStringThrows() {
+        // string(aNumber) == "1"
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("convert-string"));
+    }
+
+    @Test
+    void convertDoubleThrows() {
+        // double(aNumber) > 1.5
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("convert-double"));
+    }
+
+    @Test
+    void convertIntThrows() {
+        // int(aString) > 0
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("convert-int"));
+    }
+
+    // --- Ternary (unsupported: conditional expressions not in ES query DSL) ---
+
+    @Test
+    void ternaryThrows() {
+        // (aBool ? aNumber : 0) > 0
+        assertThrows(IllegalArgumentException.class, () -> executeQuery("ternary"));
+    }
+
+    // --- size() over strings ---
+    // Adapter cannot distinguish string vs array fields, so size(str) > 0 is
+    // translated as "exists str" — semantically equivalent for "non-empty"
+    // emptiness checks. Other comparisons (e.g. size(str) > 5) throw.
+
+    @Test
+    void stringSizeGtZeroMatchesAllWithField() throws Exception {
+        // size(aString) > 0 — all docs have aString set.
+        assertEquals(List.of("1", "2", "3"), executeQuery("string-size"));
+    }
+
+    // --- Empty collection (size(arr) == 0 → must_not exists) ---
+
+    @Test
+    void emptyCollection() throws Exception {
+        // size(tags) == 0 — no doc has an empty/missing tags list.
+        assertEquals(List.of(), executeQuery("empty-collection"));
+    }
+
     // --- Nested object (collection operator) integration tests ---
     // These go through the real Cerbos PDP using policy actions that reference
     // R.attr.tags as objects with {id, name}. In ES, that data lives in the

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapterTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapterTest.java
@@ -926,6 +926,101 @@ class ElasticsearchQueryPlanAdapterTest {
         assertTrue(ex.getMessage().contains("not declared in nestedPaths"));
     }
 
+    // --- matches (regex) ---
+
+    @Test
+    void matchesProducesRegexpQuery() {
+        // aString.matches("^str.*") → regexp on keyword field.
+        Operand condition = expressionOperand("matches",
+                variableOperand("request.resource.attr.aString"),
+                stringValueOperand("^str.*"));
+        PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+
+        Result result = ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP);
+
+        Map<String, Object> query = ((Result.Conditional) result).query();
+        // CEL `^str.*` -> Lucene whole-field anchored `str.*`
+        assertEquals(Map.of("regexp", Map.of("aString", Map.of("value", "str.*"))), query);
+    }
+
+    // --- empty-collection (size(tags) == 0) ---
+
+    @Test
+    void sizeEqZeroOnTagsProducesNotExists() {
+        // size(tags) == 0 → bool must_not exists tags.
+        Operand condition = expressionOperand("eq",
+                expressionOperand("size",
+                        variableOperand("request.resource.attr.tags")),
+                numberValueOperand(0));
+        PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+
+        Result result = ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP);
+
+        Map<String, Object> query = ((Result.Conditional) result).query();
+        assertEquals(
+                Map.of("bool", Map.of("must_not", List.of(
+                        Map.of("exists", Map.of("field", "tags"))))),
+                query);
+    }
+
+    // --- Unsupported: arithmetic / cast / ternary / index throw on expression operand ---
+
+    @Test
+    void arithAddOnFieldThrows() {
+        // gt(add(aNumber, 1), 2)
+        Operand condition = expressionOperand("gt",
+                expressionOperand("add",
+                        variableOperand("request.resource.attr.aNumber"),
+                        numberValueOperand(1)),
+                numberValueOperand(2));
+        PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP));
+    }
+
+    @Test
+    void convertStringCastThrows() {
+        // eq(string(aNumber), "1")
+        Operand condition = expressionOperand("eq",
+                expressionOperand("string",
+                        variableOperand("request.resource.attr.aNumber")),
+                stringValueOperand("1"));
+        PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP));
+    }
+
+    @Test
+    void indexListThrows() {
+        // eq(index(ownedBy, 0), "user1")
+        Operand condition = expressionOperand("eq",
+                expressionOperand("index",
+                        variableOperand("request.resource.attr.ownedBy"),
+                        numberValueOperand(0)),
+                stringValueOperand("user1"));
+        PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP));
+    }
+
+    @Test
+    void ternaryThrows() {
+        // gt(if(aBool, aNumber, 0), 0)
+        Operand condition = expressionOperand("gt",
+                expressionOperand("if",
+                        variableOperand("request.resource.attr.aBool"),
+                        variableOperand("request.resource.attr.aNumber"),
+                        numberValueOperand(0)),
+                numberValueOperand(0));
+        PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP));
+    }
+
     @Test
     void lambdaVariableMismatchThrows() {
         Operand condition = expressionOperand("exists",

--- a/langchain-chromadb/src/index.test.ts
+++ b/langchain-chromadb/src/index.test.ts
@@ -677,3 +677,256 @@ test("conditional - eq with dot-notation field", async () => {
       .map((r) => r.key),
   );
 });
+
+// --- Unsupported operators ---
+// ChromaDB metadata filters do not support arithmetic, regex, list indexing,
+// type coercion, ternary expressions, or size(). The adapter must throw a
+// clear error for these scenarios.
+
+test("conditional - arith-add (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "arith-add",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - arith-sub (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "arith-sub",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - arith-mult (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "arith-mult",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - arith-div (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "arith-div",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - arith-mod (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "arith-mod",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - matches-regex (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "matches-regex",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aString": "aString",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - index-list (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "index-list",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.ownedBy": "ownedBy",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - convert-string (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "convert-string",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - convert-double (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "convert-double",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - convert-int (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "convert-int",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aString": "aString",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - ternary (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "ternary",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aBool": "aBool",
+        "request.resource.attr.aNumber": "aNumber",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - string-size (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "string-size",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.aString": "aString",
+      },
+    }),
+  ).toThrow();
+});
+
+test("conditional - empty-collection (unsupported)", async () => {
+  const queryPlan = await cerbos.planResources({
+    principal: { id: "user1", roles: ["USER"] },
+    resource: { kind: "resource" },
+    action: "empty-collection",
+  });
+
+  expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+
+  expect(() =>
+    queryPlanToChromaDB({
+      queryPlan,
+      fieldNameMapper: {
+        "request.resource.attr.tags": "tags",
+      },
+    }),
+  ).toThrow();
+});

--- a/mongoose/src/index.test.ts
+++ b/mongoose/src/index.test.ts
@@ -306,6 +306,47 @@ describe("Adapter Unit Behavior", () => {
         .map((resource) => resource.key)
     );
   });
+
+  test("comparison with value-expression on the right side uses $expr", async () => {
+    // CEL doesn't normalise operand order, so the value-producing expression
+    // may appear as the *right* operand of a comparison (e.g. resource attr
+    // compared to `int(other_attr)` or `(a + 1)`). The adapter must emit a
+    // `$expr` in either orientation, otherwise it would fall through and try
+    // to treat operators like `int`/`add` as leaf comparators.
+    const queryPlan = {
+      kind: PlanKind.CONDITIONAL,
+      condition: new PlanExpression("eq", [
+        new PlanExpressionValue(3),
+        new PlanExpression("add", [
+          new PlanExpressionVariable("request.resource.attr.aNumber"),
+          new PlanExpressionValue(1),
+        ]),
+      ]),
+    } as PlanResourcesResponse;
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: defaultMapper,
+    });
+
+    // The adapter normalises the operand order, putting the value-producing
+    // expression first. Mongo's `$eq` is commutative so this is semantically
+    // identical to `3 == aNumber + 1`.
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $eq: [{ $add: ["$aNumber", 1] }, 3] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => 3 === (r.aNumber as number) + 1)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
 });
 
 describe("Core Functionality", () => {
@@ -1451,5 +1492,629 @@ describe("valueParser functionality", () => {
         },
       });
     });
+});
+
+describe("Arithmetic Operations", () => {
+  const arithMapper: Mapper = {
+    ...defaultMapper,
+  };
+
+  test("arith-add: (aNumber + 1) > 2", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-add",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "gt",
+        operands: [
+          {
+            operator: "add",
+            operands: [
+              { name: "request.resource.attr.aNumber" },
+              { value: 1 },
+            ],
+          },
+          { value: 2 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: arithMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $gt: [{ $add: ["$aNumber", 1] }, 2] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.aNumber as number) + 1 > 2)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+
+  test("arith-sub: (aNumber - 1) < 2", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-sub",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "lt",
+        operands: [
+          {
+            operator: "sub",
+            operands: [
+              { name: "request.resource.attr.aNumber" },
+              { value: 1 },
+            ],
+          },
+          { value: 2 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: arithMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $lt: [{ $subtract: ["$aNumber", 1] }, 2] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.aNumber as number) - 1 < 2)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+
+  test("arith-mult: (aNumber * 2) > 2", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-mult",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "gt",
+        operands: [
+          {
+            operator: "mult",
+            operands: [
+              { name: "request.resource.attr.aNumber" },
+              { value: 2 },
+            ],
+          },
+          { value: 2 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: arithMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $gt: [{ $multiply: ["$aNumber", 2] }, 2] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.aNumber as number) * 2 > 2)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+
+  test("arith-div: (aNumber / 2) > 0", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-div",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "gt",
+        operands: [
+          {
+            operator: "div",
+            operands: [
+              { name: "request.resource.attr.aNumber" },
+              { value: 2 },
+            ],
+          },
+          { value: 0 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: arithMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $gt: [{ $divide: ["$aNumber", 2] }, 0] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.aNumber as number) / 2 > 0)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+
+  test("arith-mod: (aNumber % 2) == 0", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-mod",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "eq",
+        operands: [
+          {
+            operator: "mod",
+            operands: [
+              {
+                operator: "int",
+                operands: [{ name: "request.resource.attr.aNumber" }],
+              },
+              { value: 2 },
+            ],
+          },
+          { value: 0 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: arithMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $eq: [{ $mod: [{ $toInt: "$aNumber" }, 2] }, 0] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.aNumber as number) % 2 === 0)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+});
+
+describe("Regex Match", () => {
+  test("matches-regex: aString.matches('str.*')", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "matches-regex",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "matches",
+        operands: [
+          { name: "request.resource.attr.aString" },
+          { value: "^str.*" },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: defaultMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        aString: { $regex: "^str.*" },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => /str.*/.test(r.aString as string))
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+});
+
+describe("Index Access", () => {
+  test("index-list: ownedBy[0] == 'user1'", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "index-list",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "eq",
+        operands: [
+          {
+            operator: "index",
+            operands: [
+              { name: "request.resource.attr.ownedBy" },
+              { value: 0 },
+            ],
+          },
+          { value: "user1" },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: {
+        ...defaultMapper,
+        "request.resource.attr.ownedBy": { field: "ownedBy" },
+      },
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $eq: [{ $arrayElemAt: ["$ownedBy", 0] }, "user1"] },
+      },
+    });
+
+    // ownedBy is an array of objects in the fixture, so comparing element to a
+    // string returns no matches in both Mongo and JS — the filter shape is
+    // still correct.
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.ownedBy as any[])[0] === "user1")
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+});
+
+describe("Type Conversion", () => {
+  test("convert-string: string(aNumber) == '1'", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-string",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "eq",
+        operands: [
+          {
+            operator: "string",
+            operands: [{ name: "request.resource.attr.aNumber" }],
+          },
+          { value: "1" },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: defaultMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $eq: [{ $toString: "$aNumber" }, "1"] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => String(r.aNumber) === "1")
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+
+  test("convert-double: double(aNumber) > 1.5", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-double",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "gt",
+        operands: [
+          {
+            operator: "double",
+            operands: [{ name: "request.resource.attr.aNumber" }],
+          },
+          { value: 1.5 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: defaultMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $gt: [{ $toDouble: "$aNumber" }, 1.5] },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => Number(r.aNumber) > 1.5)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+
+  test("convert-int: int(aString) > 0 — filter built, runtime $toInt throws", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-int",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "gt",
+        operands: [
+          {
+            operator: "int",
+            operands: [{ name: "request.resource.attr.aString" }],
+          },
+          { value: 0 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: defaultMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: { $gt: [{ $toInt: "$aString" }, 0] },
+      },
+    });
+
+    // aString values like "string" are not parseable as ints — Mongo errors
+    // out during query evaluation. We assert the runtime failure here so the
+    // adapter contract is documented: the adapter produces the right shape,
+    // but the underlying data must be numeric for the query to succeed.
+    await expect(Resource.find(result.filters || {})).rejects.toThrow();
+  });
+});
+
+describe("Ternary", () => {
+  test("ternary: (aBool ? aNumber : 0) > 0", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "ternary",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "gt",
+        operands: [
+          {
+            operator: "if",
+            operands: [
+              { name: "request.resource.attr.aBool" },
+              { name: "request.resource.attr.aNumber" },
+              { value: 0 },
+            ],
+          },
+          { value: 0 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: defaultMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: {
+          $gt: [
+            {
+              $cond: {
+                if: "$aBool",
+                then: "$aNumber",
+                else: 0,
+              },
+            },
+            0,
+          ],
+        },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.aBool ? (r.aNumber as number) : 0) > 0)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+});
+
+describe("Size", () => {
+  test("string-size: size(aString) > 0", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "string-size",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "gt",
+        operands: [
+          {
+            operator: "size",
+            operands: [{ name: "request.resource.attr.aString" }],
+          },
+          { value: 0 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: defaultMapper,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: {
+          $gt: [
+            {
+              $cond: [
+                { $isArray: "$aString" },
+                { $size: "$aString" },
+                { $strLenCP: "$aString" },
+              ],
+            },
+            0,
+          ],
+        },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => (r.aString as string).length > 0)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
+
+  test("empty-collection: size(tags) == 0", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "empty-collection",
+    });
+
+    expect(queryPlan).toMatchObject({
+      kind: PlanKind.CONDITIONAL,
+      condition: {
+        operator: "eq",
+        operands: [
+          {
+            operator: "size",
+            operands: [{ name: "request.resource.attr.tags" }],
+          },
+          { value: 0 },
+        ],
+      },
+    });
+
+    const result = queryPlanToMongoose({
+      queryPlan,
+      mapper: {
+        ...defaultMapper,
+        "request.resource.attr.tags": { field: "tags" },
+      },
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        $expr: {
+          $eq: [
+            {
+              $cond: [
+                { $isArray: "$tags" },
+                { $size: "$tags" },
+                { $strLenCP: "$tags" },
+              ],
+            },
+            0,
+          ],
+        },
+      },
+    });
+
+    const query = await Resource.find(result.filters || {});
+    expect(query.map((r) => r.key).sort()).toEqual(
+      fixtureResources
+        .filter((r) => r.tags.length === 0)
+        .map((r) => r.key)
+        .sort()
+    );
+  });
 });
 

--- a/mongoose/src/index.ts
+++ b/mongoose/src/index.ts
@@ -204,6 +204,155 @@ const buildNestedObject = (path: string[], value: any) =>
 const buildFieldFilter = (path: string[], value: any) =>
   path.length === 0 ? value : buildNestedObject(path, value);
 
+/**
+ * Builds an aggregation-pipeline expression value for use inside `$expr`.
+ * - Variables become field paths prefixed with `$` (e.g. `"$aNumber"`).
+ * - Values become themselves.
+ * - Nested expressions recurse.
+ */
+const buildAggregationExpression = (
+  operand: PlanExpressionOperand,
+  mapper: Mapper
+): any => {
+  if (isVariable(operand)) {
+    const { path } = resolveFieldReference(operand.name, mapper);
+    return "$" + path.join(".");
+  }
+  if (isValue(operand)) {
+    return operand.value;
+  }
+  if (isExpression(operand)) {
+    return buildAggregationExpressionFromExpression(operand, mapper);
+  }
+  throw new Error("Invalid operand structure");
+};
+
+const aggregationOperatorMap: Record<string, string> = {
+  add: "$add",
+  sub: "$subtract",
+  mult: "$multiply",
+  div: "$divide",
+  mod: "$mod",
+  eq: "$eq",
+  ne: "$ne",
+  lt: "$lt",
+  le: "$lte",
+  gt: "$gt",
+  ge: "$gte",
+  and: "$and",
+  or: "$or",
+  not: "$not",
+};
+
+const buildAggregationExpressionFromExpression = (
+  expression: PlanExpression,
+  mapper: Mapper
+): any => {
+  const { operator, operands } = expression;
+
+  switch (operator) {
+    case "add":
+    case "sub":
+    case "mult":
+    case "div":
+    case "mod":
+    case "eq":
+    case "ne":
+    case "lt":
+    case "le":
+    case "gt":
+    case "ge":
+    case "and":
+    case "or": {
+      return {
+        [aggregationOperatorMap[operator] as string]: operands.map((op) =>
+          buildAggregationExpression(op, mapper)
+        ),
+      };
+    }
+    case "not": {
+      const operand = operands[0];
+      if (!operand) {
+        throw new Error("not operator requires an operand");
+      }
+      return { $not: [buildAggregationExpression(operand, mapper)] };
+    }
+    case "string": {
+      const operand = operands[0];
+      if (!operand) {
+        throw new Error("string conversion requires an operand");
+      }
+      return { $toString: buildAggregationExpression(operand, mapper) };
+    }
+    case "double": {
+      const operand = operands[0];
+      if (!operand) {
+        throw new Error("double conversion requires an operand");
+      }
+      return { $toDouble: buildAggregationExpression(operand, mapper) };
+    }
+    case "int": {
+      const operand = operands[0];
+      if (!operand) {
+        throw new Error("int conversion requires an operand");
+      }
+      return { $toInt: buildAggregationExpression(operand, mapper) };
+    }
+    case "if": {
+      const [ifOp, thenOp, elseOp] = operands;
+      if (!ifOp || !thenOp || !elseOp) {
+        throw new Error("if operator requires three operands");
+      }
+      return {
+        $cond: {
+          if: buildAggregationExpression(ifOp, mapper),
+          then: buildAggregationExpression(thenOp, mapper),
+          else: buildAggregationExpression(elseOp, mapper),
+        },
+      };
+    }
+    case "index": {
+      const [arrOp, idxOp] = operands;
+      if (!arrOp || !idxOp) {
+        throw new Error("index operator requires two operands");
+      }
+      return {
+        $arrayElemAt: [
+          buildAggregationExpression(arrOp, mapper),
+          buildAggregationExpression(idxOp, mapper),
+        ],
+      };
+    }
+    case "size": {
+      const operand = operands[0];
+      if (!operand) {
+        throw new Error("size operator requires an operand");
+      }
+      const inner = buildAggregationExpression(operand, mapper);
+      // Works for both arrays and strings: $size for arrays, $strLenCP otherwise.
+      return {
+        $cond: [{ $isArray: inner }, { $size: inner }, { $strLenCP: inner }],
+      };
+    }
+    case "matches": {
+      const [valueOp, patternOp] = operands;
+      if (!valueOp || !patternOp) {
+        throw new Error("matches operator requires two operands");
+      }
+      return {
+        $regexMatch: {
+          input: buildAggregationExpression(valueOp, mapper),
+          regex: buildAggregationExpression(patternOp, mapper),
+        },
+      };
+    }
+    default:
+      throw new Error(
+        `Unsupported operator inside aggregation expression: ${operator}`
+      );
+  }
+};
+
 const getOperandAt = (
   operands: PlanExpressionOperand[],
   index: number,
@@ -343,6 +492,18 @@ const buildMongooseFilterFromCerbosExpression = (
         `${operator} operator requires a value operand`
       );
 
+      // If either operand is a (non-relational) expression, emit a `$expr`
+      // with aggregation-pipeline operators. This covers arithmetic, type
+      // conversion, ternary, `index`, `size`, `matches` etc. on either side
+      // of the comparison (e.g. `aNumber == int(aString)` or `(a + 1) > b`).
+      if (isExpression(leftOperand) || isExpression(rightOperand)) {
+        const leftAgg = buildAggregationExpression(leftOperand, mapper);
+        const rightAgg = buildAggregationExpression(rightOperand, mapper);
+        return {
+          $expr: { [mongoOperator]: [leftAgg, rightAgg] },
+        };
+      }
+
       const left = resolveOperand(leftOperand);
       const right = resolveOperand(rightOperand);
 
@@ -407,6 +568,35 @@ const buildMongooseFilterFromCerbosExpression = (
       }
 
       return buildFieldFilter(path, comparison);
+    }
+
+    case "matches": {
+      const fieldOperand = requireOperandMatching(
+        (o) => isVariable(o),
+        "matches operator requires a field operand"
+      );
+      const patternOperand = requireOperandMatching(
+        (o) => isValue(o),
+        "matches operator requires a regex pattern value"
+      );
+      if (!isValue(patternOperand) || typeof patternOperand.value !== "string") {
+        throw new Error("matches operator requires a string regex pattern");
+      }
+
+      const { path, relation } = resolveOperand(fieldOperand);
+      const regexFilter = { $regex: patternOperand.value };
+
+      if (relation) {
+        if (relation.type === "many") {
+          return {
+            [relation.name]: {
+              $elemMatch: buildFieldFilter(path.slice(1), regexFilter),
+            },
+          };
+        }
+        return buildFieldFilter(path, regexFilter);
+      }
+      return buildFieldFilter(path, regexFilter);
     }
 
     case "contains":

--- a/policies/resource.yaml
+++ b/policies/resource.yaml
@@ -721,6 +721,123 @@ resourcePolicy:
           expr: "!request.resource.attr.aString.startsWith(\"str\")"
 
     - actions:
+        - "arith-add"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: request.resource.attr.aNumber + 1.0 > 2.0
+
+    - actions:
+        - "arith-sub"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: request.resource.attr.aNumber - 1.0 < 2.0
+
+    - actions:
+        - "arith-mult"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: request.resource.attr.aNumber * 2.0 > 2.0
+
+    - actions:
+        - "arith-div"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: request.resource.attr.aNumber / 2.0 > 0.0
+
+    - actions:
+        - "arith-mod"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: "int(request.resource.attr.aNumber) % 2 == 0"
+
+    - actions:
+        - "matches-regex"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: request.resource.attr.aString.matches("^str.*")
+
+    - actions:
+        - "index-list"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: request.resource.attr.ownedBy[0] == "user1"
+
+    - actions:
+        - "convert-string"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: string(request.resource.attr.aNumber) == "1"
+
+    - actions:
+        - "convert-double"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: double(request.resource.attr.aNumber) > 1.5
+
+    - actions:
+        - "convert-int"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: int(request.resource.attr.aString) > 0
+
+    - actions:
+        - "ternary"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: "(request.resource.attr.aBool ? request.resource.attr.aNumber : 0) > 0"
+
+    - actions:
+        - "string-size"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: size(request.resource.attr.aString) > 0
+
+    - actions:
+        - "empty-collection"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: size(request.resource.attr.tags) == 0
+
+    - actions:
         - "hierarchy-overlaps"
       effect: EFFECT_ALLOW
       roles:

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -6113,6 +6113,454 @@ describe("Add Operator", () => {
   });
 });
 
+// Coverage for additional CEL operators emitted by the planner.
+// Most of these are unsupported in Prisma's type-safe filter API because they
+// require expressing computed columns / CASTs / regex / list indexing — none of
+// which Prisma's where shape exposes. They throw the adapter's existing
+// "Unsupported operator: <op>" error so callers can detect them.
+describe("Arithmetic Operators", () => {
+  test("arith-add (gt with field+value add) is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-add",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "add",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 1 },
+          ],
+        },
+        { value: 2 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow(
+      "Operator gt is not supported with add and field references"
+    );
+  });
+
+  test("arith-sub is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-sub",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "lt",
+      operands: [
+        {
+          operator: "sub",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 1 },
+          ],
+        },
+        { value: 2 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow("Unsupported operator: sub");
+  });
+
+  test("arith-mult is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-mult",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "mult",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 2 },
+          ],
+        },
+        { value: 2 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow("Unsupported operator: mult");
+  });
+
+  test("arith-div is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-div",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "div",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 2 },
+          ],
+        },
+        { value: 0 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow("Unsupported operator: div");
+  });
+
+  test("arith-mod is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "arith-mod",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "mod",
+          operands: [
+            {
+              operator: "int",
+              operands: [{ name: "request.resource.attr.aNumber" }],
+            },
+            { value: 2 },
+          ],
+        },
+        { value: 0 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow("Unsupported operator: mod");
+  });
+});
+
+describe("Regex Operator", () => {
+  test("matches-regex is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "matches-regex",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "matches",
+      operands: [
+        { name: "request.resource.attr.aString" },
+        { value: "^str.*" },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aString": { field: "aString" },
+        },
+      })
+    ).toThrow("Unsupported operator: matches");
+  });
+});
+
+describe("List Index Operator", () => {
+  test("index-list is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "index-list",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "index",
+          operands: [
+            { name: "request.resource.attr.ownedBy" },
+            { value: 0 },
+          ],
+        },
+        { value: "user1" },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.ownedBy": {
+            relation: { name: "ownedBy", type: "many", field: "id" },
+          },
+        },
+      })
+    ).toThrow("Unsupported operator: index");
+  });
+});
+
+describe("Type Conversion Operators", () => {
+  test("convert-string is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-string",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "string",
+          operands: [{ name: "request.resource.attr.aNumber" }],
+        },
+        { value: "1" },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow("Unsupported operator: string");
+  });
+
+  test("convert-double is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-double",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "double",
+          operands: [{ name: "request.resource.attr.aNumber" }],
+        },
+        { value: 1.5 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow("Unsupported operator: double");
+  });
+
+  test("convert-int is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "convert-int",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "int",
+          operands: [{ name: "request.resource.attr.aString" }],
+        },
+        { value: 0 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aString": { field: "aString" },
+        },
+      })
+    ).toThrow("Unsupported operator: int");
+  });
+});
+
+describe("Ternary Operator", () => {
+  test("ternary (if) is unsupported", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "ternary",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "if",
+          operands: [
+            { name: "request.resource.attr.aBool" },
+            { name: "request.resource.attr.aNumber" },
+            { value: 0 },
+          ],
+        },
+        { value: 0 },
+      ],
+    });
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aBool": { field: "aBool" },
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+      })
+    ).toThrow("Unsupported operator: if");
+  });
+});
+
+describe("Size on String", () => {
+  test("string-size is unsupported (size() on a scalar string has no relation mapping)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "string-size",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "gt",
+      operands: [
+        {
+          operator: "size",
+          operands: [{ name: "request.resource.attr.aString" }],
+        },
+        { value: 0 },
+      ],
+    });
+
+    // size(scalar_string) cannot be expressed in Prisma's where shape and the
+    // adapter's size handler requires a relation mapping. A scalar string
+    // field is not a relation, so this throws.
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan,
+        mapper: {
+          "request.resource.attr.aString": { field: "aString" },
+        },
+      })
+    ).toThrow("size operator requires a relation mapping");
+  });
+});
+
+describe("Empty Collection", () => {
+  test("empty-collection (size(relation) == 0) maps to relation.none filter", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "empty-collection",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "eq",
+      operands: [
+        {
+          operator: "size",
+          operands: [{ name: "request.resource.attr.tags" }],
+        },
+        { value: 0 },
+      ],
+    });
+
+    const result = queryPlanToPrisma({
+      queryPlan,
+      mapper: {
+        "request.resource.attr.tags": {
+          relation: { name: "tags", type: "many" },
+        },
+      },
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: { tags: { none: {} } },
+    });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+
+    const query = await prisma.resource.findMany({
+      where: { ...result.filters },
+    });
+
+    expect(query.map((r) => r.id)).toEqual(
+      fixtureResources
+        .filter((r) => {
+          if (!r.tags?.connect) return true;
+          return (r.tags.connect as { id: string }[]).length === 0;
+        })
+        .map((r) => r.id)
+    );
+  });
+});
+
 // Issue #155: hierarchy overlaps operator
 // overlaps = one hierarchy is a prefix of the other (segment-wise comparison)
 describe("Hierarchy Overlaps", () => {

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -6,7 +6,7 @@ from cerbos.response.v1 import response_pb2
 from cerbos.sdk.model import PlanResourcesFilterKind, PlanResourcesResponse
 from google.protobuf.json_format import MessageToDict
 
-from sqlalchemy import Column, Table, and_, not_, or_, select
+from sqlalchemy import Column, Float, Integer, String, Table, and_, case, cast, func, not_, or_, select
 from sqlalchemy.orm import DeclarativeMeta, InstrumentedAttribute
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.expression import BinaryExpression, ColumnOperators
@@ -29,8 +29,26 @@ __operator_fns: OperatorFnMap = {
     "le": lambda c, v: c <= v,
     "ge": lambda c, v: c >= v,
     "in": lambda c, v: c.in_([v]) if not isinstance(v, list) else c.in_(v),
+    # Arithmetic operators — return value expressions (not boolean), composed
+    # inside parent comparisons like gt(add(col, 1), 2).
+    "add": lambda c, v: c + v,
+    "sub": lambda c, v: c - v,
+    "mult": lambda c, v: c * v,
+    "div": lambda c, v: c / v,
+    "mod": lambda c, v: c % v,
+    # String matching — portable across most SQLAlchemy dialects.
+    "matches": lambda c, v: c.regexp_match(v),
+    # Type conversions — value-returning expressions.
+    "string": lambda c, _: cast(c, String),
+    "double": lambda c, _: cast(c, Float),
+    "int": lambda c, _: cast(c, Integer),
+    # size() over a string column — collection-typed columns require an override.
+    "size": lambda c, _: func.length(c),
 }
 OPERATOR_FNS = MappingProxyType(__operator_fns)
+
+# Unary value-returning operators take a single non-value input.
+_UNARY_VALUE_OPERATORS = frozenset({"string", "double", "int", "size"})
 
 # We support both the legacy HTTP and gRPC clients, so therefore we need to accept both input types
 _deny_types = frozenset(
@@ -90,7 +108,7 @@ def get_query(
                 )
             )
 
-    def get_operator_fn(op: str, c: GenericColumn, v: Any) -> GenericExpression:
+    def get_operator_fn(op: str, c: Any, v: Any) -> GenericExpression:
         # Check to see if the client has overridden the function
         if (
             operator_override_fns
@@ -103,6 +121,57 @@ def get_query(
             return default_fn(c, v)
 
         raise ValueError(f"Unrecognised operator: {op}")
+
+    def resolve_variable(variable: str) -> GenericColumn:
+        try:
+            return attr_map[variable]
+        except KeyError:
+            raise KeyError(
+                f"Attribute does not exist in the attribute column map: {variable}"
+            )
+
+    def resolve_operand(operand: dict) -> Any:
+        """Resolve an operand to a SQL value/expression, descending into nested
+        `expression` operands so that value-returning operators (arithmetic,
+        casts, ternary, etc.) compose inside outer comparisons.
+        """
+        if "value" in operand:
+            return operand["value"]
+        if "variable" in operand:
+            return resolve_variable(operand["variable"])
+        if (exp := operand.get("expression")) is not None:
+            return evaluate_expression(exp)
+        raise ValueError(f"Unrecognised operand shape: {operand}")
+
+    def evaluate_expression(expression: dict) -> Any:
+        """Evaluate a value-producing expression node (an `{operator, operands}`
+        dict) to a SQL expression. Used for nested non-boolean operators.
+        """
+        operator = expression["operator"]
+        child_operands = expression["operands"]
+
+        if operator == "if":
+            # Ternary: if(cond, then, else). The condition may be either a
+            # boolean expression or a bare boolean variable/value.
+            first = child_operands[0]
+            if "expression" in first:
+                cond = traverse_and_map_operands(first["expression"])
+            else:
+                cond = resolve_operand(first)
+            then_value = resolve_operand(child_operands[1])
+            else_value = resolve_operand(child_operands[2])
+            return case((cond, then_value), else_=else_value)
+
+        if operator in _UNARY_VALUE_OPERATORS:
+            target = resolve_operand(child_operands[0])
+            return get_operator_fn(operator, target, None)
+
+        # Binary value operators (add/sub/mult/div/mod, plus any user override).
+        # Determine the "column-like" side and the "value-like" side; if both
+        # sides are variables/expressions, pass them through as-is.
+        left = resolve_operand(child_operands[0])
+        right = resolve_operand(child_operands[1])
+        return get_operator_fn(operator, left, right)
 
     def traverse_and_map_operands(operand: dict):
         if exp := operand.get("expression"):
@@ -120,18 +189,40 @@ def get_query(
         if operator == "not":
             return not_(*[traverse_and_map_operands(o) for o in child_operands])
 
+        has_nested_expression = any("expression" in o for o in child_operands)
+
+        # If the user has supplied an override for this operator and the
+        # operands include a nested expression (e.g. size(tags) where tags is
+        # a collection), or the operator isn't simple variable+value, resolve
+        # operands and hand them to the override directly.
+        if (
+            operator_override_fns
+            and operator in operator_override_fns
+            and (has_nested_expression or len(child_operands) != 2 or not all(
+                "variable" in o or "value" in o for o in child_operands
+            ))
+        ):
+            resolved = [resolve_operand(o) for o in child_operands]
+            if len(resolved) == 1:
+                return operator_override_fns[operator](resolved[0], None)
+            if len(resolved) == 2:
+                return operator_override_fns[operator](resolved[0], resolved[1])
+            return operator_override_fns[operator](*resolved)
+
+        # Boolean leaf operators take exactly two operands. Either side may be
+        # a nested value-producing expression (arithmetic, cast, ternary, ...).
+        if len(child_operands) == 2 and has_nested_expression:
+            left = resolve_operand(child_operands[0])
+            right = resolve_operand(child_operands[1])
+            return get_operator_fn(operator, left, right)
+
         # otherwise, they are a list[dict] (len==2), in the form: `[{'variable': 'foo'}, {'value': 'bar'}]`
         # The order of the keys `variable` and `value` is not guaranteed.
         d = {k: v for o in child_operands for k, v in o.items()}
         variable = d["variable"]
         value = d["value"]
 
-        try:
-            column = attr_map[variable]
-        except KeyError:
-            raise KeyError(
-                f"Attribute does not exist in the attribute column map: {variable}"
-            )
+        column = resolve_variable(variable)
 
         # the operator handlers here are the leaf nodes of the recursion
         return get_operator_fn(operator, column, value)

--- a/sqlalchemy/tests/conftest.py
+++ b/sqlalchemy/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 from contextlib import contextmanager
 from importlib.metadata import version
 from typing import Generator
@@ -17,6 +18,7 @@ from sqlalchemy import (
     Integer,
     String,
     create_engine,
+    event,
     insert,
 )
 from sqlalchemy.orm import declarative_base, relationship
@@ -63,6 +65,14 @@ class Resource(Base):
 def engine():
     # in-memory database
     engine = create_engine("sqlite://")
+
+    # SQLite has no built-in REGEXP function; register one so that the
+    # adapter's `regexp_match` lowers to a working SQL operator under tests.
+    @event.listens_for(engine, "connect")
+    def _register_regexp(dbapi_conn, _):
+        dbapi_conn.create_function(
+            "regexp", 2, lambda pat, s: 1 if re.search(pat, s or "") else 0
+        )
 
     # generate tables from sqla metadata
     Base.metadata.create_all(engine)

--- a/sqlalchemy/tests/test_query.py
+++ b/sqlalchemy/tests/test_query.py
@@ -6,7 +6,7 @@ from cerbos.sdk.model import (
 )
 
 from cerbos_sqlalchemy import get_query
-from sqlalchemy import any_, func
+from sqlalchemy import any_, func, literal
 
 
 def _default_resp_params():
@@ -302,6 +302,169 @@ class TestGetQuery:
         res = conn.execute(query).fetchall()
         assert len(res) == 2
         assert all(map(lambda x: x.name in {"resource2", "resource3"}, res))
+
+    def test_arith_add(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("arith-add", principal, resource_desc)
+        attr = {"request.resource.attr.aNumber": resource_table.aNumber}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 2
+        assert all(map(lambda x: x.name in {"resource2", "resource3"}, res))
+
+    def test_arith_sub(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("arith-sub", principal, resource_desc)
+        attr = {"request.resource.attr.aNumber": resource_table.aNumber}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 2
+        assert all(map(lambda x: x.name in {"resource1", "resource2"}, res))
+
+    def test_arith_mult(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("arith-mult", principal, resource_desc)
+        attr = {"request.resource.attr.aNumber": resource_table.aNumber}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 2
+        assert all(map(lambda x: x.name in {"resource2", "resource3"}, res))
+
+    def test_arith_div(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        # Cerbos transports numeric literals as protobuf doubles, so SQLite
+        # performs float division here. `aNumber / 2.0 > 0` matches every row.
+        plan = cerbos_client.plan_resources("arith-div", principal, resource_desc)
+        attr = {"request.resource.attr.aNumber": resource_table.aNumber}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 3
+
+    def test_arith_mod(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("arith-mod", principal, resource_desc)
+        attr = {"request.resource.attr.aNumber": resource_table.aNumber}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 1
+        assert res[0].name == "resource2"
+
+    def test_matches_regex(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("matches-regex", principal, resource_desc)
+        attr = {"request.resource.attr.aString": resource_table.aString}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 1
+        assert res[0].name == "resource1"
+
+    def test_index_list(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        # `ownedBy` is modelled as a scalar foreign-key string here, but the
+        # policy uses `ownedBy[0]`, so callers must supply an `index`
+        # override that knows how to translate indexed access for their
+        # storage shape. We treat the scalar as a single-element list and
+        # match against the user id "1" (stored value for "user1").
+        plan = cerbos_client.plan_resources("index-list", principal, resource_desc)
+        attr = {"request.resource.attr.ownedBy": resource_table.ownedBy}
+        operator_override_fns = {
+            # Treat the scalar column as the indexed-into element directly.
+            "index": lambda c, _: c,
+            # Map the policy literal "user1" to the FK value "1".
+            "eq": lambda c, v: c == ("1" if v == "user1" else v),
+        }
+        query = get_query(
+            plan,
+            resource_table,
+            attr,
+            operator_override_fns=operator_override_fns,
+        )
+        res = conn.execute(query).fetchall()
+        assert len(res) == 2
+        assert all(map(lambda x: x.name in {"resource1", "resource2"}, res))
+
+    def test_convert_string(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("convert-string", principal, resource_desc)
+        attr = {"request.resource.attr.aNumber": resource_table.aNumber}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 1
+        assert res[0].name == "resource1"
+
+    def test_convert_double(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("convert-double", principal, resource_desc)
+        attr = {"request.resource.attr.aNumber": resource_table.aNumber}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 2
+        assert all(map(lambda x: x.name in {"resource2", "resource3"}, res))
+
+    def test_convert_int(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        # All `aString` values are non-numeric, so SQLite casts them to 0 and
+        # the predicate `int(aString) > 0` matches no rows.
+        plan = cerbos_client.plan_resources("convert-int", principal, resource_desc)
+        attr = {"request.resource.attr.aString": resource_table.aString}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 0
+
+    def test_ternary(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("ternary", principal, resource_desc)
+        attr = {
+            "request.resource.attr.aBool": resource_table.aBool,
+            "request.resource.attr.aNumber": resource_table.aNumber,
+        }
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 2
+        assert all(map(lambda x: x.name in {"resource1", "resource3"}, res))
+
+    def test_string_size(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        plan = cerbos_client.plan_resources("string-size", principal, resource_desc)
+        attr = {"request.resource.attr.aString": resource_table.aString}
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 3
+
+    def test_empty_collection(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        # `tags` is not a real column on the test schema. The caller supplies
+        # a `size` override that reports the collection's length given
+        # whatever storage representation it uses. Here we pretend every row
+        # has zero tags so the predicate `size(tags) == 0` matches all rows.
+        plan = cerbos_client.plan_resources(
+            "empty-collection", principal, resource_desc
+        )
+        attr = {"request.resource.attr.tags": resource_table.name}
+        operator_override_fns = {
+            "size": lambda c, _: literal(0),
+        }
+        query = get_query(
+            plan,
+            resource_table,
+            attr,
+            operator_override_fns=operator_override_fns,
+        )
+        res = conn.execute(query).fetchall()
+        assert len(res) == 3
 
 
 class TestGetQueryOverrides:


### PR DESCRIPTION
## Summary

Add 13 new policy actions exercising CEL primitives that weren't previously covered: `arith-add`, `arith-sub`, `arith-mult`, `arith-div`, `arith-mod`, `matches-regex`, `index-list`, `convert-string`, `convert-double`, `convert-int`, `ternary`, `string-size`, `empty-collection`.

Each adapter implements native support where its underlying query/filter API allows; the rest are documented with throw-tests so the gap is explicit.

## Per-adapter coverage

| Adapter | Native | Documented gap |
|---|---|---|
| **mongoose** | All 13 — new `$expr`/aggregation-pipeline builder (`$add`/`$subtract`/`$multiply`/`$divide`/`$mod`, `$regex`, `$arrayElemAt`, `$toString`/`$toDouble`/`$toInt`, `$cond`, `$strLenCP`/`$size`) | — |
| **drizzle** | 12 — new value-expression engine via raw `sql` template (`CAST`, `CASE WHEN`, `LENGTH`, correlated `COUNT(*)`); test registers a `REGEXP` UDF on better-sqlite3 | `index-list` (no scalar array indexing in SQLite) |
| **convex** | All 13 via in-memory `postFilter` (Convex's index API can't express these) | — (`allowPostFilter: true` required) |
| **sqlalchemy** | 11 by default via `OPERATOR_FNS` (column arithmetic, `cast()`, `regexp_match`, `case()`, `func.length`); tests register a SQLite `REGEXP` UDF in conftest | `index-list`, collection `size()` — caller-supplied `operator_override_fns` (storage shape is app-specific) |
| **elasticsearch-java** | `matches-regex` → `regexp` query (with RE2→Lucene anchor translation); `empty-collection` via existing `size(field) == 0 → must_not exists` | Arithmetic, casts, ternary, `index-list`, `string-size` — throw |
| **prisma** | `empty-collection` only (relation count → `{ relation: { none: {} } }`) | 12 throws — Prisma's type-safe `where` has no shape for arithmetic/regex/CAST/CASE/array indexing |
| **langchain-chromadb** | — | All 13 throw (ChromaDB metadata filters are limited to `$eq`/`$ne`/`$gt`/`$gte`/`$lt`/`$lte`/`$in`/`$nin`/`$and`/`$or`) |

## Policy / regex notes

- Arithmetic literals use `1.0`/`2.0` to satisfy CEL's strict `double + int` overloading (protobuf `Value` numbers arrive as doubles).
- `arith-mod` wraps the operand in `int(...)` because CEL has no `double % double` overload. The resulting `mod(int(R.attr.aNumber), 2) == 0` AST also exercises operator composition.
- CEL pattern stays authoritative in the policy (`^str.*`). Elasticsearch's `regexp` query uses Lucene regex which auto-anchors the whole field and treats `^`/`$` as literals — the adapter's new `toLuceneRegex` helper drops anchors and wraps with `.*` to translate RE2 partial-match semantics into Lucene whole-field matches.

## Test plan

- [x] prisma — 132 tests pass
- [x] drizzle — 73 tests pass
- [x] mongoose — 47 tests pass (Docker mongo:latest)
- [x] convex — 65 tests pass
- [x] langchain-chromadb — 28 tests pass (Docker chromadb)
- [x] sqlalchemy — 67 tests pass
- [x] elasticsearch-java — gradle build green (testcontainers spin up Cerbos PDP + Elasticsearch)