### PR TITLE
chore(deps): update typescript to v6

### DIFF
--- a/convex/package-lock.json
+++ b/convex/package-lock.json
@@ -20,7 +20,7 @@
         "convex": "^1.21.0",
         "ts-jest": "^29.0.0",
         "ts-node": "^10.4.0",
-        "typescript": "^5.0.0"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5358,9 +5358,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/convex/package.json
+++ b/convex/package.json
@@ -57,7 +57,7 @@
     "convex": "^1.21.0",
     "ts-jest": "^29.0.0",
     "ts-node": "^10.4.0",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.0"
   },
   "dependencies": {
     "@cerbos/core": "^0.31.0",

--- a/drizzle/package-lock.json
+++ b/drizzle/package-lock.json
@@ -25,7 +25,7 @@
         "rimraf": "^6.0.0",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
-        "typescript": "^5.4.0"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5197,9 +5197,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/drizzle/package.json
+++ b/drizzle/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^6.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.0"
+    "typescript": "^6.0.0"
   },
   "peerDependencies": {
     "drizzle-orm": "^0.44.0 || ^0.45.0"

--- a/drizzle/src/index.test.ts
+++ b/drizzle/src/index.test.ts
@@ -1,4 +1,12 @@
 import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+import {
   PlanExpressionOperand,
   PlanKind,
   PlanResourcesResponse,

--- a/langchain-chromadb/package-lock.json
+++ b/langchain-chromadb/package-lock.json
@@ -23,7 +23,7 @@
         "start-server-and-test": "^3.0.0",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.4.0",
-        "typescript": "^5.0.0"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5745,9 +5745,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/langchain-chromadb/package.json
+++ b/langchain-chromadb/package.json
@@ -57,7 +57,7 @@
     "start-server-and-test": "^3.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.4.0",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.0"
   },
   "dependencies": {
     "@cerbos/core": "^0.31.0",

--- a/mongoose/package-lock.json
+++ b/mongoose/package-lock.json
@@ -20,7 +20,7 @@
         "mongoose": "^9.0.0",
         "ts-jest": "^29.0.0",
         "ts-node": "^10.4.0",
-        "typescript": "^5.0.0"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4965,9 +4965,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/mongoose/package.json
+++ b/mongoose/package.json
@@ -54,7 +54,7 @@
     "mongoose": "^9.0.0",
     "ts-jest": "^29.0.0",
     "ts-node": "^10.4.0",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.0"
   },
   "dependencies": {
     "@cerbos/core": "^0.31.0",

--- a/prisma/package-lock.json
+++ b/prisma/package-lock.json
@@ -27,7 +27,7 @@
         "rimraf": "^6.0.0",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.4.0",
-        "typescript": "^5.0.0"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6574,9 +6574,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/prisma/package.json
+++ b/prisma/package.json
@@ -63,7 +63,7 @@
     "rimraf": "^6.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.4.0",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.0"
   },
   "peerDependencies": {
     "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0"


### PR DESCRIPTION
Bumps the `typescript` devDependency to v6 across all TypeScript adapters.

## Why #180 (renovate) failed
TypeScript 6 dropped automatic inclusion of `@types/*` packages into global scope. Four of the five adapters already import jest globals from `@jest/globals`; **drizzle** was the only one relying on ambient `@types/jest` globals, so its `tsc --build` failed with `TS2304: Cannot find name 'expect'` (and `describe`/`test`/`beforeAll`/…).

## Fix
- Import jest globals explicitly in `drizzle/src/index.test.ts` (matches the convention already used by prisma/mongoose/convex/langchain-chromadb).
- Bump `typescript` to `^6.0.0` in all five adapters (devDependency only — no consumer-facing change).

Unlike renovate's #180, no `ignoreDeprecations` is needed — all five adapters build clean under TS 6 with the existing tsconfigs (verified locally). drizzle's 87 tests pass.

Supersedes #180.