### PR TITLE
fix(prisma): mirror value-first comparisons instead of silently inverting them

### DIFF
--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -7563,3 +7563,143 @@ describe("Hierarchy descendentOf", () => {
     });
   });
 });
+
+// The planner preserves policy source order, so a constant can be the FIRST operand of a
+// comparison (`1 < R.attr.aNumber`). Directional operators must be mirrored when the value
+// precedes the field, or the filter is silently inverted. See #256.
+describe("Value-First Operand Order", () => {
+  test("conditional - lt with value first (1 < aNumber means aNumber > 1)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "value-first-lt",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "lt",
+      operands: [{ value: 1 }, { name: "request.resource.attr.aNumber" }],
+    });
+
+    const result = queryPlanToPrisma({
+      queryPlan,
+      mapper: {
+        "request.resource.attr.aNumber": { field: "aNumber" },
+      },
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: { aNumber: { gt: 1 } },
+    });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+
+    const query = await prisma.resource.findMany({
+      where: { ...result.filters },
+    });
+    expect(query.map((r) => r.id).sort()).toEqual(
+      fixtureResources
+        .filter((r) => r.aNumber > 1)
+        .map((r) => r.id)
+        .sort()
+    );
+  });
+
+  test("conditional - size with value first (0 < size(ownedBy) means non-empty)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "value-first-size",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+
+    const result = queryPlanToPrisma({
+      queryPlan,
+      mapper: {
+        "request.resource.attr.ownedBy": {
+          relation: { name: "ownedBy", type: "many", field: "id" },
+        },
+      },
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: { ownedBy: { some: {} } },
+    });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+
+    const query = await prisma.resource.findMany({
+      where: { ...result.filters },
+    });
+    expect(query.map((r) => r.id).sort()).toEqual(
+      fixtureResources
+        .filter(
+          (r) =>
+            Array.isArray(r.ownedBy?.connect) &&
+            (r.ownedBy.connect as { id: string }[]).length > 0
+        )
+        .map((r) => r.id)
+        .sort()
+    );
+  });
+
+  test("conditional - hasIntersection with value first (constant list is operand 0)", async () => {
+    const queryPlan = await cerbos.planResources({
+      principal: { id: "user1", roles: ["USER"] },
+      resource: { kind: "resource" },
+      action: "value-first-intersect",
+    });
+
+    expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+      operator: "hasIntersection",
+      operands: [
+        { value: ["user1", "userX"] },
+        { name: "request.resource.attr.ownedBy" },
+      ],
+    });
+
+    const result = queryPlanToPrisma({
+      queryPlan,
+      mapper: {
+        "request.resource.attr.ownedBy": {
+          relation: { name: "ownedBy", type: "many", field: "id" },
+        },
+      },
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        ownedBy: { some: { id: { in: ["user1", "userX"] } } },
+      },
+    });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+
+    const query = await prisma.resource.findMany({
+      where: { ...result.filters },
+    });
+    expect(query.map((r) => r.id).sort()).toEqual(
+      fixtureResources
+        .filter(
+          (r) =>
+            Array.isArray(r.ownedBy?.connect) &&
+            (r.ownedBy.connect as { id: string }[]).some((o) =>
+              ["user1", "userX"].includes(o.id)
+            )
+        )
+        .map((r) => r.id)
+        .sort()
+    );
+  });
+});

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -16,6 +16,42 @@ const CERBOS_TO_PRISMA_OPERATOR: Record<string, string> = {
   ge: "gte",
 };
 
+// Directional operators mirror when their operands swap sides; symmetric operators are unchanged.
+const MIRRORED_OPERATOR: Record<string, string> = {
+  lt: "gt",
+  gt: "lt",
+  le: "ge",
+  ge: "le",
+};
+
+/**
+ * Normalize a binary comparison to field-side-first. The planner preserves policy source
+ * order, so a constant may precede the field it constrains (`1 < R.attr.x` arrives as
+ * `lt(value, variable)`) — swap the operands and mirror directional operators so downstream
+ * handlers can assume the field/expression side is first. Without this, value-first
+ * comparisons are silently inverted (#256).
+ */
+function normalizeBinaryOperands(
+  operator: string,
+  operands: PlanExpressionOperand[]
+): { operator: string; operands: PlanExpressionOperand[] } {
+  const first = operands[0];
+  const second = operands[1];
+  if (
+    operands.length === 2 &&
+    first !== undefined &&
+    second !== undefined &&
+    isValueOperand(first) &&
+    !isValueOperand(second)
+  ) {
+    return {
+      operator: MIRRORED_OPERATOR[operator] ?? operator,
+      operands: [second, first],
+    };
+  }
+  return { operator, operands };
+}
+
 // Type Definitions
 export type PrismaFilter = Record<string, any>;
 
@@ -652,6 +688,7 @@ function handleRelationalOperator(
   operands: PlanExpressionOperand[],
   mapper: Mapper
 ): PrismaFilter {
+  ({ operator, operands } = normalizeBinaryOperands(operator, operands));
   const prismaOperator = CERBOS_TO_PRISMA_OPERATOR[operator];
 
   if (!prismaOperator) {
@@ -787,6 +824,11 @@ function handleHasIntersectionOperator(
   if (operands.length !== 2) {
     throw new Error("hasIntersection requires exactly two operands");
   }
+
+  // Intersection is symmetric, and the planner preserves policy source order — e.g.
+  // `hasIntersection(["a"], R.attr.tags)` puts the constant list FIRST. Normalize to
+  // field/map-first (see #256).
+  ({ operands } = normalizeBinaryOperands("hasIntersection", operands));
 
   const leftOperand = assertDefined(
     operands[0],


### PR DESCRIPTION
Fixes #256.

## Problem

The query planner preserves policy source order, so a constant can be the **first** operand of a comparison: `1 < R.attr.aNumber` arrives as `lt(value, variable)`. `handleRelationalOperator` resolved operands by kind (never by position) and never mirrored the operator, so:

- `1 < R.attr.aNumber` → `{aNumber: {lt: 1}}` — **silently inverted filter, wrong rows returned**
- `0 < size(R.attr.ownedBy)` → threw `Unsupported size comparison: size(...) lt 0`
- `hasIntersection(["user1","userX"], R.attr.ownedBy)` (folded principal list first) → threw `First operand of hasIntersection must be a field reference or map expression`

## Fix

`normalizeBinaryOperands()` normalizes binary comparisons field-side-first — swapping when a value operand precedes a non-value operand and mirroring `lt↔gt` / `le↔ge` — applied at `handleRelationalOperator` entry (covers plain and `size()` comparisons). `handleHasIntersectionOperator` applies the symmetric swap. Same approach as the Spring Data adapter's `NormalizedBinary` (55b5c91).

## Tests (written red first)

Three new tests drive the `value-first-lt` / `value-first-size` / `value-first-intersect` conformance actions (from #220's `policies/resource.yaml`) through a real PDP via `cerbos run`, asserting both the produced filter shape and the actual row set from Prisma. All three reproduced the failures above before the fix; 149/149 pass after.

> Stacked on #220 (base `spring-data`) because the tests need the conformance actions added there. Retarget to `main` once #220 merges.