### PR TITLE
fix(sqlalchemy): mirror value-first comparisons instead of silently inverting them

### DIFF
--- a/.github/workflows/sqlalchemy_pr.yaml
+++ b/.github/workflows/sqlalchemy_pr.yaml
@@ -1,5 +1,7 @@
 name: SQLAlchemy Pull Request
 
+# No branch filter: like the other adapter workflows, tests must also run on PRs
+# targeting non-main bases (e.g. stacked PRs).
 on:
   pull_request:
     paths:
@@ -7,8 +9,6 @@ on:
       - "policies/**"
       - ".github/workflows/sqlalchemy_pr.yaml"
       - ".github/workflows/sqlalchemy_release.yaml"
-    branches:
-      - main
 
 defaults:
   run:

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -6,7 +6,20 @@ from cerbos.response.v1 import response_pb2
 from cerbos.sdk.model import PlanResourcesFilterKind, PlanResourcesResponse
 from google.protobuf.json_format import MessageToDict
 
-from sqlalchemy import Column, Float, Integer, String, Table, and_, case, cast, func, not_, or_, select
+from sqlalchemy import (
+    Column,
+    Float,
+    Integer,
+    String,
+    Table,
+    and_,
+    case,
+    cast,
+    func,
+    not_,
+    or_,
+    select,
+)
 from sqlalchemy.orm import DeclarativeMeta, InstrumentedAttribute
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.expression import BinaryExpression, ColumnOperators
@@ -46,6 +59,18 @@ __operator_fns: OperatorFnMap = {
     "size": lambda c, _: func.length(c),
 }
 OPERATOR_FNS = MappingProxyType(__operator_fns)
+
+# Directional operators mirror when their operands swap sides; symmetric operators are
+# unchanged. The planner preserves policy source order, so `1 < R.attr.x` arrives as
+# lt(value(1), variable(x)) and must translate as `x > 1`, not `x < 1` (#257).
+_MIRRORED_OPERATORS = MappingProxyType(
+    {
+        "lt": "gt",
+        "gt": "lt",
+        "le": "ge",
+        "ge": "le",
+    }
+)
 
 # Unary value-returning operators take a single non-value input.
 _UNARY_VALUE_OPERATORS = frozenset({"string", "double", "int", "size"})
@@ -198,9 +223,11 @@ def get_query(
         if (
             operator_override_fns
             and operator in operator_override_fns
-            and (has_nested_expression or len(child_operands) != 2 or not all(
-                "variable" in o or "value" in o for o in child_operands
-            ))
+            and (
+                has_nested_expression
+                or len(child_operands) != 2
+                or not all("variable" in o or "value" in o for o in child_operands)
+            )
         ):
             resolved = [resolve_operand(o) for o in child_operands]
             if len(resolved) == 1:
@@ -217,10 +244,14 @@ def get_query(
             return get_operator_fn(operator, left, right)
 
         # otherwise, they are a list[dict] (len==2), in the form: `[{'variable': 'foo'}, {'value': 'bar'}]`
-        # The order of the keys `variable` and `value` is not guaranteed.
+        # The order of the operands is NOT guaranteed to be variable-first: the planner
+        # preserves policy source order, so mirror directional operators when the value
+        # precedes the variable (`1 < R.attr.x` means `x > 1`).
         d = {k: v for o in child_operands for k, v in o.items()}
         variable = d["variable"]
         value = d["value"]
+        if "value" in child_operands[0]:
+            operator = _MIRRORED_OPERATORS.get(operator, operator)
 
         column = resolve_variable(variable)
 

--- a/sqlalchemy/tests/test_query.py
+++ b/sqlalchemy/tests/test_query.py
@@ -146,6 +146,21 @@ class TestGetQuery:
         assert len(res) == 2
         assert all(map(lambda x: x.name in {"resource2", "resource3"}, res))
 
+    def test_value_first_lt(
+        self, cerbos_client, principal, resource_desc, resource_table, conn
+    ):
+        # The planner preserves policy source order: `1 < R.attr.aNumber` arrives as
+        # lt(value(1), variable(aNumber)) — the constant is the FIRST operand. The operator
+        # must be mirrored (aNumber > 1) or the filter is silently inverted (#257).
+        plan = cerbos_client.plan_resources("value-first-lt", principal, resource_desc)
+        attr = {
+            "request.resource.attr.aNumber": resource_table.aNumber,
+        }
+        query = get_query(plan, resource_table, attr)
+        res = conn.execute(query).fetchall()
+        assert len(res) == 2
+        assert all(map(lambda x: x.name in {"resource2", "resource3"}, res))
+
     def test_lte(self, cerbos_client, principal, resource_desc, resource_table, conn):
         plan = cerbos_client.plan_resources("lte", principal, resource_desc)
         attr = {


### PR DESCRIPTION
Fixes #257.

## Problem

The query planner preserves policy source order, so a constant can be the **first** operand of a comparison: `1 < R.attr.aNumber` arrives as `lt(value, variable)`. The leaf path merges the two operands into a dict keyed by `variable`/`value` — discarding position — and always builds `column < value`: a **silently inverted filter** returning the wrong rows.

## Fix

Mirror directional operators (`lt↔gt`, `le↔ge`) when the value operand precedes the variable operand. The nested-expression path already resolves left/right positionally and is unchanged. Same approach as the Spring Data adapter's `NormalizedBinary` (55b5c91) and the Prisma fix for #256.

## Tests (written red first)

`test_value_first_lt` drives the `value-first-lt` conformance action (from #220's `policies/resource.yaml`) through a real PDP container: red before the fix (0 rows instead of 2), green after. 97/97 pass; black/isort applied.

> Stacked on #220 (base `spring-data`) because the test needs the conformance action added there. Retarget to `main` once #220 merges.