### PR TITLE
Fix Prisma query plans for value-first directional comparisons

### DIFF
--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -1242,6 +1242,96 @@ describe("Field Operations", () => {
           .map((r) => r.id)
       );
     });
+
+    const valueFirstDirectionalCases = [
+      {
+        operator: "lt",
+        prismaOperator: "gt",
+        matches: (value: number, field: number) => value < field,
+      },
+      {
+        operator: "le",
+        prismaOperator: "gte",
+        matches: (value: number, field: number) => value <= field,
+      },
+      {
+        operator: "gt",
+        prismaOperator: "lt",
+        matches: (value: number, field: number) => value > field,
+      },
+      {
+        operator: "ge",
+        prismaOperator: "lte",
+        matches: (value: number, field: number) => value >= field,
+      },
+    ] satisfies {
+      operator: string;
+      prismaOperator: string;
+      matches: (value: number, field: number) => boolean;
+    }[];
+
+    test.each(valueFirstDirectionalCases)(
+      "conditional - value-first $operator mirrors to $prismaOperator",
+      async ({ operator, prismaOperator, matches }) => {
+        const value = 2;
+        const result = queryPlanToPrisma({
+          queryPlan: createConditionalPlan({
+            operator,
+            operands: [
+              { value },
+              { name: "request.resource.attr.aNumber" },
+            ],
+          }),
+          mapper: {
+            "request.resource.attr.aNumber": { field: "aNumber" },
+          },
+        });
+
+        expect(result).toStrictEqual({
+          kind: PlanKind.CONDITIONAL,
+          filters: { aNumber: { [prismaOperator]: value } },
+        });
+
+        if (result.kind !== PlanKind.CONDITIONAL) {
+          throw new Error("Expected CONDITIONAL result");
+        }
+
+        const query = await prisma.resource.findMany({
+          where: { ...result.filters },
+        });
+        expect(query.map((resource) => resource.id)).toEqual(
+          fixtureResources
+            .filter((resource) => matches(value, resource.aNumber))
+            .map((resource) => resource.id)
+        );
+      }
+    );
+
+    test.each([
+      { operator: "eq", prismaOperator: "equals" },
+      { operator: "ne", prismaOperator: "not" },
+    ])(
+      "conditional - value-first symmetric $operator remains $prismaOperator",
+      ({ operator, prismaOperator }) => {
+        const result = queryPlanToPrisma({
+          queryPlan: createConditionalPlan({
+            operator,
+            operands: [
+              { value: 2 },
+              { name: "request.resource.attr.aNumber" },
+            ],
+          }),
+          mapper: {
+            "request.resource.attr.aNumber": { field: "aNumber" },
+          },
+        });
+
+        expect(result).toStrictEqual({
+          kind: PlanKind.CONDITIONAL,
+          filters: { aNumber: { [prismaOperator]: 2 } },
+        });
+      }
+    );
   });
 
   describe("String Tests", () => {
@@ -3354,6 +3444,39 @@ describe("Relations", () => {
           filters: { ownedBy: { some: {} } },
         });
       });
+
+      test.each([
+        { operator: "lt", value: 0, prismaOperator: "some" },
+        { operator: "le", value: 1, prismaOperator: "some" },
+        { operator: "gt", value: 1, prismaOperator: "none" },
+        { operator: "ge", value: 0, prismaOperator: "none" },
+      ])(
+        "conditional - value-first $operator size(field) produces $prismaOperator",
+        ({ operator, value, prismaOperator }) => {
+          const result = queryPlanToPrisma({
+            queryPlan: createConditionalPlan({
+              operator,
+              operands: [
+                { value },
+                {
+                  operator: "size",
+                  operands: [{ name: "request.resource.attr.ownedBy" }],
+                },
+              ],
+            }),
+            mapper: {
+              "request.resource.attr.ownedBy": {
+                relation: { name: "ownedBy", type: "many", field: "id" },
+              },
+            },
+          });
+
+          expect(result).toStrictEqual({
+            kind: PlanKind.CONDITIONAL,
+            filters: { ownedBy: { [prismaOperator]: {} } },
+          });
+        }
+      );
 
       test("conditional - size on nested relation walks full chain", () => {
         const result = queryPlanToPrisma({

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -16,6 +16,13 @@ const CERBOS_TO_PRISMA_OPERATOR: Record<string, string> = {
   ge: "gte",
 };
 
+const MIRRORED_RELATIONAL_OPERATOR: Record<string, string> = {
+  lt: "gt",
+  le: "ge",
+  gt: "lt",
+  ge: "le",
+};
+
 // Type Definitions
 export type PrismaFilter = Record<string, any>;
 
@@ -652,35 +659,60 @@ function handleRelationalOperator(
   operands: PlanExpressionOperand[],
   mapper: Mapper
 ): PrismaFilter {
-  const prismaOperator = CERBOS_TO_PRISMA_OPERATOR[operator];
+  const fieldOperandIndex = operands.findIndex(
+    (operand) => isNamedOperand(operand) || isOperatorOperand(operand)
+  );
+  if (fieldOperandIndex === -1) {
+    throw new Error("No valid left operand found");
+  }
+
+  const fieldOperand = operands[fieldOperandIndex];
+  if (!fieldOperand) {
+    throw new Error("No valid left operand found");
+  }
+
+  const valueOperand = operands.find(
+    (_, operandIndex) => operandIndex !== fieldOperandIndex
+  );
+  if (!valueOperand) {
+    throw new Error("No valid right operand found");
+  }
+
+  const normalizedOperator =
+    fieldOperandIndex === 0
+      ? operator
+      : (MIRRORED_RELATIONAL_OPERATOR[operator] ?? operator);
+  const prismaOperator = CERBOS_TO_PRISMA_OPERATOR[normalizedOperator];
 
   if (!prismaOperator) {
-    throw new Error(`Unsupported operator: ${operator}`);
+    throw new Error(`Unsupported operator: ${normalizedOperator}`);
   }
 
-  const leftOperand = operands.find(
-    (o) => isNamedOperand(o) || isOperatorOperand(o)
-  );
-  if (!leftOperand) throw new Error("No valid left operand found");
-
-  const rightOperand = operands.find((o) => o !== leftOperand);
-  if (!rightOperand) throw new Error("No valid right operand found");
-
-  if (isOperatorOperand(leftOperand) && leftOperand.operator === "size") {
-    return handleSizeComparison(operator, leftOperand, rightOperand, mapper);
+  if (isOperatorOperand(fieldOperand) && fieldOperand.operator === "size") {
+    return handleSizeComparison(
+      normalizedOperator,
+      fieldOperand,
+      valueOperand,
+      mapper
+    );
   }
 
-  const addOperand = [leftOperand, rightOperand].find(
+  const addOperand = [fieldOperand, valueOperand].find(
     (o): o is OperatorOperand =>
       isOperatorOperand(o) && o.operator === "add"
   );
   if (addOperand) {
     const otherOperand =
-      addOperand === leftOperand ? rightOperand : leftOperand;
-    return handleAddComparison(operator, addOperand, otherOperand, mapper);
+      addOperand === fieldOperand ? valueOperand : fieldOperand;
+    return handleAddComparison(
+      normalizedOperator,
+      addOperand,
+      otherOperand,
+      mapper
+    );
   }
 
-  const mapOperand = [leftOperand, rightOperand].find(
+  const mapOperand = [fieldOperand, valueOperand].find(
     (o): o is OperatorOperand =>
       isOperatorOperand(o) && o.operator === "map"
   );
@@ -691,9 +723,9 @@ function handleRelationalOperator(
     );
   }
 
-  const left = resolveOperand(leftOperand, mapper);
+  const left = resolveOperand(fieldOperand, mapper);
   const right = requireResolvedValue(
-    resolveOperand(rightOperand, mapper),
+    resolveOperand(valueOperand, mapper),
     "Right operand must be a value"
   );
 


### PR DESCRIPTION
## Summary
- Correctly mirror relational operators when the value appears before the field.
- Preserve equality and inequality behavior for symmetric comparisons.
- Add coverage for scalar fields and relation-size comparisons.

## Testing
- Added Jest coverage for directional, symmetric, and relation-size comparisons.