### PR TITLE
Support ternary expression rewriting in Prisma adapters

### DIFF
--- a/prisma/prisma/schema.prisma
+++ b/prisma/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Resource {
   nestedResourceId String
   tags             Tag[] // Add many-to-many relationship
   aOptionalString  String?
+  aOptionalBool    Boolean?
   categories       Category[] // Add categories relation
 }
 

--- a/prisma/prisma/schema.v6.prisma
+++ b/prisma/prisma/schema.v6.prisma
@@ -23,6 +23,7 @@ model Resource {
   nestedResourceId String
   tags             Tag[] // Add many-to-many relationship
   aOptionalString  String?
+  aOptionalBool    Boolean?
   categories       Category[] // Add categories relation
 }
 

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -176,6 +176,7 @@ const fixtureResources: Prisma.ResourceCreateInput[] = [
     aNumber: 1,
     aString: "string",
     aOptionalString: "optionalString",
+    aOptionalBool: true,
     createdBy: {
       connect: {
         id: "user1",
@@ -207,6 +208,7 @@ const fixtureResources: Prisma.ResourceCreateInput[] = [
     aBool: false,
     aNumber: 2,
     aString: "string2",
+    aOptionalBool: false,
     createdBy: {
       connect: {
         id: "user2",
@@ -6890,7 +6892,28 @@ describe("Type Conversion Operators", () => {
 });
 
 describe("Ternary Operator", () => {
-  test("ternary (if) is unsupported", async () => {
+  const mapper = {
+    "request.resource.attr.aBool": { field: "aBool" },
+    "request.resource.attr.aNumber": { field: "aNumber" },
+    "request.resource.attr.aString": { field: "aString" },
+    "request.resource.attr.aOptionalString": { field: "aOptionalString" },
+    "request.resource.attr.aOptionalBool": { field: "aOptionalBool" },
+  };
+
+  async function matchingResourceIds(
+    queryPlan: PlanResourcesResponse
+  ): Promise<string[]> {
+    const result = queryPlanToPrisma({ queryPlan, mapper });
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+    const resources = await prisma.resource.findMany({
+      where: { ...result.filters },
+    });
+    return resources.map((resource) => resource.id).sort();
+  }
+
+  test("rewrites a comparison-wrapped ternary from the PDP", async () => {
     const queryPlan = await cerbos.planResources({
       principal: { id: "user1", roles: ["USER"] },
       resource: { kind: "resource" },
@@ -6913,15 +6936,303 @@ describe("Ternary Operator", () => {
       ],
     });
 
-    expect(() =>
+    expect(queryPlanToPrisma({ queryPlan, mapper })).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        OR: [
+          {
+            AND: [
+              { aBool: { equals: true } },
+              { aNumber: { gt: 0 } },
+            ],
+          },
+          {
+            AND: [
+              { aBool: { equals: true } },
+              { aBool: { equals: false } },
+            ],
+          },
+        ],
+      },
+    });
+    expect(await matchingResourceIds(queryPlan)).toEqual(["resource1"]);
+  });
+
+  test("rewrites a ternary used directly as a boolean predicate", async () => {
+    const queryPlan = createConditionalPlan({
+      operator: "if",
+      operands: [
+        { name: "request.resource.attr.aBool" },
+        {
+          operator: "gt",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 0 },
+          ],
+        },
+        {
+          operator: "eq",
+          operands: [
+            { name: "request.resource.attr.aString" },
+            { value: "string3" },
+          ],
+        },
+      ],
+    });
+
+    expect(await matchingResourceIds(queryPlan)).toEqual([
+      "resource1",
+      "resource3",
+    ]);
+  });
+
+  test("recursively rewrites nested ternary branches", async () => {
+    const queryPlan = createConditionalPlan({
+      operator: "gt",
+      operands: [
+        {
+          operator: "if",
+          operands: [
+            { name: "request.resource.attr.aBool" },
+            {
+              operator: "if",
+              operands: [
+                {
+                  operator: "eq",
+                  operands: [
+                    { name: "request.resource.attr.aString" },
+                    { value: "string" },
+                  ],
+                },
+                { name: "request.resource.attr.aNumber" },
+                { value: 0 },
+              ],
+            },
+            { value: 0 },
+          ],
+        },
+        { value: 0 },
+      ],
+    });
+
+    expect(await matchingResourceIds(queryPlan)).toEqual(["resource1"]);
+  });
+
+  test("mirrors a value-first comparison around a ternary", async () => {
+    const queryPlan = createConditionalPlan({
+      operator: "lt",
+      operands: [
+        { value: 0 },
+        {
+          operator: "if",
+          operands: [
+            { name: "request.resource.attr.aBool" },
+            { name: "request.resource.attr.aNumber" },
+            { value: -1 },
+          ],
+        },
+      ],
+    });
+
+    const result = queryPlanToPrisma({ queryPlan, mapper });
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        OR: [
+          {
+            AND: [
+              { aBool: { equals: true } },
+              { aNumber: { gt: 0 } },
+            ],
+          },
+          {
+            AND: [
+              { aBool: { equals: true } },
+              { aBool: { equals: false } },
+            ],
+          },
+        ],
+      },
+    });
+    expect(await matchingResourceIds(queryPlan)).toEqual(["resource1"]);
+  });
+
+  test("keeps a nullable condition unknown under outer negation", async () => {
+    const queryPlan = createConditionalPlan({
+      operator: "not",
+      operands: [
+        {
+          operator: "if",
+          operands: [
+            { name: "request.resource.attr.aOptionalBool" },
+            { value: false },
+            { value: false },
+          ],
+        },
+      ],
+    });
+
+    expect(await matchingResourceIds(queryPlan)).toEqual([
+      "resource1",
+      "resource2",
+    ]);
+  });
+
+  test("negates a relation-backed boolean condition as a whole", () => {
+    const queryPlan = createConditionalPlan({
+      operator: "if",
+      operands: [
+        { name: "request.resource.attr.ownedBy.aBool" },
+        { value: false },
+        { value: true },
+      ],
+    });
+
+    expect(
       queryPlanToPrisma({
         queryPlan,
         mapper: {
-          "request.resource.attr.aBool": { field: "aBool" },
-          "request.resource.attr.aNumber": { field: "aNumber" },
+          "request.resource.attr.ownedBy": {
+            relation: {
+              name: "ownedBy",
+              type: "many",
+              fields: { aBool: { field: "aBool" } },
+            },
+          },
         },
       })
-    ).toThrow("Unsupported operator: if");
+    ).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        OR: [
+          {
+            NOT: {
+              ownedBy: {
+                some: { aBool: { equals: true } },
+              },
+            },
+          },
+          {
+            AND: [
+              {
+                ownedBy: {
+                  some: { aBool: { equals: true } },
+                },
+              },
+              {
+                NOT: {
+                  ownedBy: {
+                    some: { aBool: { equals: true } },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  test("rejects malformed and non-boolean ternary conditions", () => {
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan: createConditionalPlan({
+          operator: "if",
+          operands: [
+            { name: "request.resource.attr.aBool" },
+            { value: true },
+          ],
+        }),
+        mapper,
+      })
+    ).toThrow(
+      "if (ternary) requires exactly 3 operands (condition, then, else), got 2"
+    );
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan: createConditionalPlan({
+          operator: "if",
+          operands: [{ value: null }, { value: true }, { value: false }],
+        }),
+        mapper,
+      })
+    ).toThrow("if (ternary) condition must be a boolean expression");
+
+    expect(() =>
+      queryPlanToPrisma({
+        queryPlan: createConditionalPlan({
+          operator: "eq",
+          operands: [
+            {
+              operator: "if",
+              operands: [
+                { name: "request.resource.attr.aBool" },
+                { value: true },
+                { value: false },
+              ],
+            },
+            { value: true },
+            { value: false },
+          ],
+        }),
+        mapper,
+      })
+    ).toThrow("eq with a ternary requires exactly 2 operands, got 3");
+  });
+
+  test("handles planner-normalized constant conditions", async () => {
+    const bareTrue = createConditionalPlan({
+      operator: "if",
+      operands: [{ value: true }, { value: true }, { value: false }],
+    });
+    const bareFalse = createConditionalPlan({
+      operator: "if",
+      operands: [{ value: true }, { value: false }, { value: true }],
+    });
+    const comparisonFalse = createConditionalPlan({
+      operator: "gt",
+      operands: [
+        {
+          operator: "if",
+          operands: [{ value: true }, { value: 0 }, { value: 1 }],
+        },
+        { value: 0 },
+      ],
+    });
+
+    expect(await matchingResourceIds(bareTrue)).toEqual([
+      "resource1",
+      "resource2",
+      "resource3",
+    ]);
+    expect(() => queryPlanToPrisma({ queryPlan: bareFalse, mapper })).toThrow(
+      "A constant-false conditional predicate must be folded by the Cerbos planner"
+    );
+    expect(() =>
+      queryPlanToPrisma({ queryPlan: comparisonFalse, mapper })
+    ).toThrow(
+      "A constant-false conditional predicate must be folded by the Cerbos planner"
+    );
+  });
+
+  test("orders folded strings by Unicode code point", async () => {
+    const queryPlan = createConditionalPlan({
+      operator: "lt",
+      operands: [
+        {
+          operator: "if",
+          operands: [
+            { name: "request.resource.attr.aBool" },
+            { value: "\u{10000}" },
+            { value: "\u{10000}" },
+          ],
+        },
+        { value: "\uE000" },
+      ],
+    });
+
+    expect(await matchingResourceIds(queryPlan)).toEqual([]);
   });
 });
 

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -1,7 +1,7 @@
-import {
+import { PlanKind } from "@cerbos/core";
+import type {
   PlanResourcesResponse,
   PlanExpressionOperand,
-  PlanKind,
   Value,
 } from "@cerbos/core";
 
@@ -14,6 +14,22 @@ const CERBOS_TO_PRISMA_OPERATOR: Record<string, string> = {
   le: "lte",
   gt: "gt",
   ge: "gte",
+};
+
+const TERNARY_COMPARISON_OPERATORS = new Set([
+  "eq",
+  "ne",
+  "lt",
+  "le",
+  "gt",
+  "ge",
+]);
+
+const MIRRORED_TERNARY_COMPARISON_OPERATOR: Record<string, string> = {
+  lt: "gt",
+  le: "ge",
+  gt: "lt",
+  ge: "le",
 };
 
 // Type Definitions
@@ -207,6 +223,14 @@ function buildFieldDirectOrInFilter(
       : { [fieldName]: { in: values } };
   return wrapRelations(fieldRef.relations, baseFilter);
 }
+
+function buildAlwaysTrueFilter(): PrismaFilter {
+  return {};
+}
+
+type TernaryBranchPredicate =
+  | { kind: "constant"; value: boolean }
+  | { kind: "filter"; filter: PrismaFilter };
 
 /**
  * Converts a Cerbos query plan to a Prisma filter.
@@ -530,6 +554,10 @@ function buildPrismaFilterFromCerbosExpression(
       };
     }
 
+    case "if": {
+      return handleBooleanTernaryOperator(operands, mapper);
+    }
+
     case "eq":
     case "ne":
     case "lt":
@@ -588,6 +616,396 @@ function buildPrismaFilterFromCerbosExpression(
     default:
       throw new Error(`Unsupported operator: ${operator}`);
   }
+}
+
+function getTernaryOperands(operands: PlanExpressionOperand[]): {
+  condition: PlanExpressionOperand;
+  thenBranch: PlanExpressionOperand;
+  elseBranch: PlanExpressionOperand;
+} {
+  if (operands.length !== 3) {
+    throw new Error(
+      `if (ternary) requires exactly 3 operands (condition, then, else), got ${operands.length}`
+    );
+  }
+
+  return {
+    condition: assertDefined(
+      operands[0],
+      "if (ternary) requires a condition operand"
+    ),
+    thenBranch: assertDefined(
+      operands[1],
+      "if (ternary) requires a then operand"
+    ),
+    elseBranch: assertDefined(
+      operands[2],
+      "if (ternary) requires an else operand"
+    ),
+  };
+}
+
+function getConstantBooleanCondition(
+  condition: PlanExpressionOperand
+): boolean | undefined {
+  if (!isValueOperand(condition)) {
+    return undefined;
+  }
+  if (typeof condition.value !== "boolean") {
+    throw new Error("if (ternary) condition must be a boolean expression");
+  }
+  return condition.value;
+}
+
+function buildBooleanBranchFilter(
+  branch: PlanExpressionOperand,
+  mapper: Mapper
+): TernaryBranchPredicate {
+  if (!isValueOperand(branch)) {
+    return {
+      kind: "filter",
+      filter: buildPrismaFilterFromCerbosExpression(branch, mapper),
+    };
+  }
+  if (typeof branch.value !== "boolean") {
+    throw new Error(
+      "if (ternary) branch in boolean position must be a boolean"
+    );
+  }
+  return { kind: "constant", value: branch.value };
+}
+
+function buildFalseConditionFilter(
+  condition: PlanExpressionOperand,
+  mapper: Mapper
+): PrismaFilter {
+  if (isValueOperand(condition)) {
+    throw new Error("Constant ternary conditions must be folded before use");
+  }
+
+  if (isNamedOperand(condition)) {
+    const fieldRef = resolveFieldReference(condition.name, mapper);
+    if (!fieldRef.relations || fieldRef.relations.length === 0) {
+      return buildFieldEqualsFilter(fieldRef, false);
+    }
+    return {
+      NOT: buildFieldEqualsFilter(fieldRef, true),
+    };
+  }
+
+  if (isOperatorOperand(condition) && condition.operator === "not") {
+    return buildPrismaFilterFromCerbosExpression(
+      assertDefined(condition.operands[0], "not operator requires an operand"),
+      mapper
+    );
+  }
+
+  return {
+    NOT: buildPrismaFilterFromCerbosExpression(condition, mapper),
+  };
+}
+
+function buildGuardedTernaryFilter({
+  condition,
+  thenFilter,
+  elseFilter,
+  mapper,
+}: {
+  condition: PlanExpressionOperand;
+  thenFilter: TernaryBranchPredicate;
+  elseFilter: TernaryBranchPredicate;
+  mapper: Mapper;
+}): PrismaFilter {
+  const conditionTrue = buildPrismaFilterFromCerbosExpression(
+    condition,
+    mapper
+  );
+  const conditionFalse = buildFalseConditionFilter(condition, mapper);
+  const guardedBranches: PrismaFilter[] = [];
+
+  if (thenFilter.kind === "filter") {
+    guardedBranches.push({ AND: [conditionTrue, thenFilter.filter] });
+  } else if (thenFilter.value) {
+    guardedBranches.push(conditionTrue);
+  }
+
+  if (elseFilter.kind === "filter") {
+    guardedBranches.push({ AND: [conditionFalse, elseFilter.filter] });
+  } else if (elseFilter.value) {
+    guardedBranches.push(conditionFalse);
+  }
+
+  // For a known condition this contradiction is false. If the condition is
+  // NULL/error-derived, both sides are SQL UNKNOWN, which keeps the whole
+  // ternary UNKNOWN under an outer NOT instead of authorizing the row.
+  guardedBranches.push({ AND: [conditionTrue, conditionFalse] });
+
+  return {
+    OR: guardedBranches,
+  };
+}
+
+function finalizeTernaryBranchPredicate(
+  predicate: TernaryBranchPredicate
+): PrismaFilter {
+  if (predicate.kind === "filter") {
+    return predicate.filter;
+  }
+  if (predicate.value) {
+    return buildAlwaysTrueFilter();
+  }
+  // Prisma has no model-agnostic always-false `where` shape: empty logical
+  // arrays are ignored. Real PDP plans fold this case to ALWAYS_DENIED.
+  throw new Error(
+    "A constant-false conditional predicate must be folded by the Cerbos planner"
+  );
+}
+
+function handleBooleanTernaryOperator(
+  operands: PlanExpressionOperand[],
+  mapper: Mapper
+): PrismaFilter {
+  const { condition, thenBranch, elseBranch } = getTernaryOperands(operands);
+  const constantCondition = getConstantBooleanCondition(condition);
+  if (constantCondition !== undefined) {
+    return finalizeTernaryBranchPredicate(
+      buildBooleanBranchFilter(
+        constantCondition ? thenBranch : elseBranch,
+        mapper
+      )
+    );
+  }
+
+  return buildGuardedTernaryFilter({
+    condition,
+    thenFilter: buildBooleanBranchFilter(thenBranch, mapper),
+    elseFilter: buildBooleanBranchFilter(elseBranch, mapper),
+    mapper,
+  });
+}
+
+function buildTernaryComparisonBranch({
+  operator,
+  operands,
+  ternaryIndex,
+  branch,
+  mapper,
+}: {
+  operator: string;
+  operands: PlanExpressionOperand[];
+  ternaryIndex: number;
+  branch: PlanExpressionOperand;
+  mapper: Mapper;
+}): TernaryBranchPredicate {
+  const substitutedOperands = operands.map((operand, index) =>
+    index === ternaryIndex ? branch : operand
+  );
+  const first = assertDefined(
+    substitutedOperands[0],
+    `${operator} requires a left operand`
+  );
+  const second = assertDefined(
+    substitutedOperands[1],
+    `${operator} requires a right operand`
+  );
+
+  // Keep value-first normalization scoped to the comparison produced by this
+  // ternary rewrite; generic comparison normalization is separate work.
+  const normalized =
+    isValueOperand(first) && !isValueOperand(second)
+      ? {
+          operator: MIRRORED_TERNARY_COMPARISON_OPERATOR[operator] ?? operator,
+          operands: [second, first],
+        }
+      : { operator, operands: substitutedOperands };
+
+  const normalizedFirst = normalized.operands[0];
+  const normalizedSecond = normalized.operands[1];
+  if (
+    normalized.operands.length === 2 &&
+    normalizedFirst !== undefined &&
+    normalizedSecond !== undefined &&
+    isValueOperand(normalizedFirst) &&
+    isValueOperand(normalizedSecond)
+  ) {
+    return {
+      kind: "constant",
+      value: evaluateConstantComparison(
+        normalized.operator,
+        normalizedFirst.value,
+        normalizedSecond.value
+      ),
+    };
+  }
+
+  return {
+    kind: "filter",
+    filter: buildPrismaFilterFromCerbosExpression(normalized, mapper),
+  };
+}
+
+function tryHandleTernaryComparison(
+  operator: string,
+  operands: PlanExpressionOperand[],
+  mapper: Mapper
+): PrismaFilter | null {
+  if (!TERNARY_COMPARISON_OPERATORS.has(operator)) {
+    return null;
+  }
+
+  const ternaryIndex = operands.findIndex(
+    (operand) => isOperatorOperand(operand) && operand.operator === "if"
+  );
+  if (ternaryIndex === -1) {
+    return null;
+  }
+  if (operands.length !== 2) {
+    throw new Error(
+      `${operator} with a ternary requires exactly 2 operands, got ${operands.length}`
+    );
+  }
+
+  const ternary = assertDefined(
+    operands[ternaryIndex],
+    "Ternary comparison operand is missing"
+  );
+  if (!isOperatorOperand(ternary)) {
+    throw new Error("Ternary comparison operand must be an expression");
+  }
+
+  const { condition, thenBranch, elseBranch } = getTernaryOperands(
+    ternary.operands
+  );
+  const constantCondition = getConstantBooleanCondition(condition);
+  if (constantCondition !== undefined) {
+    return finalizeTernaryBranchPredicate(
+      buildTernaryComparisonBranch({
+        operator,
+        operands,
+        ternaryIndex,
+        branch: constantCondition ? thenBranch : elseBranch,
+        mapper,
+      })
+    );
+  }
+
+  return buildGuardedTernaryFilter({
+    condition,
+    thenFilter: buildTernaryComparisonBranch({
+      operator,
+      operands,
+      ternaryIndex,
+      branch: thenBranch,
+      mapper,
+    }),
+    elseFilter: buildTernaryComparisonBranch({
+      operator,
+      operands,
+      ternaryIndex,
+      branch: elseBranch,
+      mapper,
+    }),
+    mapper,
+  });
+}
+
+function evaluateConstantComparison(
+  operator: string,
+  left: Value,
+  right: Value
+): boolean {
+  switch (operator) {
+    case "eq":
+      return areValuesEqual(left, right);
+    case "ne":
+      return !areValuesEqual(left, right);
+    case "lt":
+    case "le":
+    case "gt":
+    case "ge": {
+      if (
+        !(
+          (typeof left === "number" && typeof right === "number") ||
+          (typeof left === "string" && typeof right === "string")
+        )
+      ) {
+        throw new Error(
+          `${operator} constant comparison requires two numbers or two strings`
+        );
+      }
+      switch (operator) {
+        case "lt":
+          return compareConstantValues(left, right) < 0;
+        case "le":
+          return compareConstantValues(left, right) <= 0;
+        case "gt":
+          return compareConstantValues(left, right) > 0;
+        case "ge":
+          return compareConstantValues(left, right) >= 0;
+      }
+    }
+  }
+
+  throw new Error(`Unsupported constant comparison operator: ${operator}`);
+}
+
+function compareConstantValues(left: number | string, right: number | string) {
+  if (typeof left === "number" && typeof right === "number") {
+    return left === right ? 0 : left < right ? -1 : 1;
+  }
+  if (typeof left !== "string" || typeof right !== "string") {
+    throw new Error("Cannot order constant values of different types");
+  }
+
+  const leftCodePoints = Array.from(left, (character) =>
+    character.codePointAt(0)
+  );
+  const rightCodePoints = Array.from(right, (character) =>
+    character.codePointAt(0)
+  );
+  const sharedLength = Math.min(leftCodePoints.length, rightCodePoints.length);
+  for (let index = 0; index < sharedLength; index++) {
+    const leftCodePoint = leftCodePoints[index]!;
+    const rightCodePoint = rightCodePoints[index]!;
+    if (leftCodePoint !== rightCodePoint) {
+      return leftCodePoint < rightCodePoint ? -1 : 1;
+    }
+  }
+  return leftCodePoints.length === rightCodePoints.length
+    ? 0
+    : leftCodePoints.length < rightCodePoints.length
+      ? -1
+      : 1;
+}
+
+function areValuesEqual(left: Value, right: Value): boolean {
+  if (Array.isArray(left)) {
+    return (
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => areValuesEqual(value, right[index]!))
+    );
+  }
+
+  if (Array.isArray(right)) {
+    return false;
+  }
+
+  if (typeof left === "object" && left !== null) {
+    if (typeof right !== "object" || right === null) {
+      return false;
+    }
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        (key) => key in right && areValuesEqual(left[key]!, right[key]!)
+      )
+    );
+  }
+
+  return left === right;
 }
 
 function handleSizeComparison(
@@ -652,6 +1070,15 @@ function handleRelationalOperator(
   operands: PlanExpressionOperand[],
   mapper: Mapper
 ): PrismaFilter {
+  const ternaryFilter = tryHandleTernaryComparison(
+    operator,
+    operands,
+    mapper
+  );
+  if (ternaryFilter) {
+    return ternaryFilter;
+  }
+
   const prismaOperator = CERBOS_TO_PRISMA_OPERATOR[operator];
 
   if (!prismaOperator) {


### PR DESCRIPTION
## Summary

- Add Prisma filter rewriting for boolean and comparison-wrapped Cerbos ternary expressions
- Handle nested branches, nullable and relation-backed conditions, constant folding, mirrored comparisons, and Unicode string ordering
- Expand Prisma fixtures with an optional boolean field
- Add comprehensive ternary operator integration coverage

## Testing

- Added and updated Prisma Jest unit and integration tests covering ternary rewriting and validation