### PR TITLE
Add expression mappings and Prisma 5 support

### DIFF
--- a/prisma/README.md
+++ b/prisma/README.md
@@ -37,17 +37,18 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 - Collection mapping and filtering
 - Complex condition combinations
 - Type-safe field mappings
+- Application-defined expression mappings for provider- or schema-specific filters
 
 ## Requirements
 
 - Cerbos > v0.40
 - `@cerbos/http` or `@cerbos/grpc` client
-- Prisma >= v6.0 (v7 supported)
+- Prisma >= v5.0 (v6 and v7 supported)
 
 ## System Requirements
 
 - Node.js >= 20.0.
-- Prisma CLI & Client >= 6.0 (v7 supported)
+- Prisma CLI & Client >= 5.0 (v6 and v7 supported)
 - A database supported by Prisma (SQLite/PostgreSQL/MySQL/etc.) so the Prisma client can communicate with stored data
 
 ## Installation
@@ -293,6 +294,60 @@ When using relations, fields are automatically inferred from the path unless exp
 - Arrays remain `{ field: { in: [...] } }`.
 - Relation-backed fields retain their relation structure while still applying the appropriate equality or `in` operator at the leaf.
 
+### Mapping Provider- or Schema-Specific Expressions
+
+Prisma 5, 6, and 7 do not expose a portable `where` representation for
+computed arithmetic, regular expressions, casts, positional indexing, or
+scalar string length. `queryPlanToPrisma` continues to throw for expressions
+that it cannot translate faithfully.
+
+Use `expressionMapper` to provide an application-specific Prisma filter when
+your schema or database gives you an exact equivalent. The mapper receives the
+complete predicate before the built-in translator. Return `undefined` to use
+the built-in behavior. It is called for supported expressions too, allowing a
+complete comparison containing an unsupported value expression to be replaced:
+
+```ts
+const result = queryPlanToPrisma({
+  queryPlan,
+  mapper,
+  expressionMapper: ({ expression }) => {
+    if (!("operator" in expression) || expression.operator !== "matches") {
+      return undefined;
+    }
+
+    // This application guarantees that the CEL pattern and database collation
+    // make this startsWith filter semantically equivalent.
+    return { slug: { startsWith: "docs-" } };
+  },
+});
+```
+
+Mappings compose inside `and`, `or`, `not`, and relation-lambda predicates.
+They must return an ordinary Prisma filter object, so they work across the
+supported Prisma versions and remain composable with `findMany({ where })`.
+The `mapper` argument is scoped to the current expression; inside a relation
+lambda it resolves the lambda variable's fields rather than root resource
+fields.
+
+The application is responsible for proving that a mapped filter has the same
+semantics as the Cerbos expression. In particular:
+
+- `matches` uses CEL/RE2 semantics, which may differ from database collation or
+  provider-specific regular expressions.
+- Arithmetic and casts depend on the source field's numeric type, overflow,
+  rounding, and conversion behavior.
+- A to-many relation has no positional `index` unless the data model stores an
+  explicit position.
+- General scalar string `size` comparisons need a materialized length or a
+  provider-specific query; comparing with an empty string is not portable
+  across all supported databases.
+
+Do not return a broader approximation from `expressionMapper`: doing so can
+admit resources that the Cerbos condition denies. Prisma raw SQL fragments
+cannot be embedded in a normal `where` object; use a separate provider-specific
+query path if an exact ordinary Prisma filter does not exist.
+
 ### Complex Example with Multiple Relations and Direct Fields
 
 ```ts
@@ -443,6 +498,15 @@ type MapperConfig = {
 };
 
 type Mapper = { [key: string]: MapperConfig } | ((key: string) => MapperConfig);
+```
+
+`expressionMapper` has the following type:
+
+```ts
+type ExpressionMapper = (args: {
+  expression: PlanExpressionOperand;
+  mapper: Mapper;
+}) => PrismaFilter | undefined;
 ```
 
 ## Full Example

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -1,4 +1,10 @@
-import { queryPlanToPrisma, PlanKind, QueryPlanToPrismaResult } from ".";
+import {
+  type ExpressionMapperArgs,
+  type Mapper,
+  queryPlanToPrisma,
+  PlanKind,
+  QueryPlanToPrismaResult,
+} from ".";
 import {
   beforeAll,
   beforeEach,
@@ -6309,6 +6315,343 @@ describe("Return Types", () => {
   });
 });
 
+describe("Expression Mapper", () => {
+  const unsupportedPredicates: [string, PlanExpressionOperand][] = [
+    [
+      "arithmetic",
+      {
+        operator: "gt",
+        operands: [
+          {
+            operator: "add",
+            operands: [
+              { name: "request.resource.attr.aNumber" },
+              { value: 1 },
+            ],
+          },
+          { value: 2 },
+        ],
+      },
+    ],
+    [
+      "regex",
+      {
+        operator: "matches",
+        operands: [
+          { name: "request.resource.attr.aString" },
+          { value: "^str.*" },
+        ],
+      },
+    ],
+    [
+      "string cast",
+      {
+        operator: "eq",
+        operands: [
+          {
+            operator: "string",
+            operands: [{ name: "request.resource.attr.aNumber" }],
+          },
+          { value: "1" },
+        ],
+      },
+    ],
+    [
+      "double cast",
+      {
+        operator: "gt",
+        operands: [
+          {
+            operator: "double",
+            operands: [{ name: "request.resource.attr.aNumber" }],
+          },
+          { value: 1.5 },
+        ],
+      },
+    ],
+    [
+      "int cast",
+      {
+        operator: "gt",
+        operands: [
+          {
+            operator: "int",
+            operands: [{ name: "request.resource.attr.aString" }],
+          },
+          { value: 0 },
+        ],
+      },
+    ],
+    [
+      "list index",
+      {
+        operator: "eq",
+        operands: [
+          {
+            operator: "index",
+            operands: [
+              { name: "request.resource.attr.ownedBy" },
+              { value: 0 },
+            ],
+          },
+          { value: "user1" },
+        ],
+      },
+    ],
+    [
+      "scalar string size",
+      {
+        operator: "gt",
+        operands: [
+          {
+            operator: "size",
+            operands: [{ name: "request.resource.attr.aString" }],
+          },
+          { value: 0 },
+        ],
+      },
+    ],
+  ];
+
+  test.each(unsupportedPredicates)(
+    "maps an unsupported %s predicate as a complete expression",
+    (_name, expression) => {
+      const mapper: Mapper = {
+        "request.resource.attr.aNumber": { field: "aNumber" },
+        "request.resource.attr.aString": { field: "aString" },
+        "request.resource.attr.ownedBy": {
+          relation: { name: "ownedBy", type: "many", field: "id" },
+        },
+      };
+      const calls: ExpressionMapperArgs[] = [];
+
+      const result = queryPlanToPrisma({
+        queryPlan: createConditionalPlan(expression),
+        mapper,
+        expressionMapper: (args) => {
+          calls.push(args);
+          return { id: { equals: "resource1" } };
+        },
+      });
+
+      expect(result).toStrictEqual({
+        kind: PlanKind.CONDITIONAL,
+        filters: { id: { equals: "resource1" } },
+      });
+      expect(calls).toStrictEqual([{ expression, mapper }]);
+    }
+  );
+
+  test("falls back to the built-in translator when the mapper declines", () => {
+    const plan = createConditionalPlan({
+      operator: "eq",
+      operands: [
+        { name: "request.resource.attr.aNumber" },
+        { value: 1 },
+      ],
+    });
+
+    const result = queryPlanToPrisma({
+      queryPlan: plan,
+      mapper: {
+        "request.resource.attr.aNumber": { field: "aNumber" },
+      },
+      expressionMapper: () => undefined,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: { aNumber: { equals: 1 } },
+    });
+  });
+
+  test("composes a mapped predicate with built-in predicates", async () => {
+    const matchesExpression: PlanExpressionOperand = {
+      operator: "matches",
+      operands: [
+        { name: "request.resource.attr.aString" },
+        { value: "^str.*" },
+      ],
+    };
+    const plan = createConditionalPlan({
+      operator: "and",
+      operands: [
+        matchesExpression,
+        {
+          operator: "eq",
+          operands: [
+            { name: "request.resource.attr.aNumber" },
+            { value: 1 },
+          ],
+        },
+      ],
+    });
+
+    const result = queryPlanToPrisma({
+      queryPlan: plan,
+      mapper: {
+        "request.resource.attr.aString": { field: "aString" },
+        "request.resource.attr.aNumber": { field: "aNumber" },
+      },
+      expressionMapper: ({ expression }) =>
+        expression === matchesExpression
+          ? { aString: { startsWith: "str" } }
+          : undefined,
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        AND: [
+          { aString: { startsWith: "str" } },
+          { aNumber: { equals: 1 } },
+        ],
+      },
+    });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+
+    const query = await prisma.resource.findMany({ where: result.filters });
+    expect(query.map(({ id }) => id)).toEqual(["resource1"]);
+  });
+
+  test.each([
+    [
+      "or",
+      {
+        operator: "or",
+        operands: [
+          {
+            operator: "eq",
+            operands: [
+              { name: "request.resource.attr.aNumber" },
+              { value: 999 },
+            ],
+          },
+          {
+            operator: "matches",
+            operands: [
+              { name: "request.resource.attr.aString" },
+              { value: "^str.*" },
+            ],
+          },
+        ],
+      },
+      {
+        OR: [
+          { aNumber: { equals: 999 } },
+          { aString: { startsWith: "str" } },
+        ],
+      },
+    ],
+    [
+      "not",
+      {
+        operator: "not",
+        operands: [
+          {
+            operator: "matches",
+            operands: [
+              { name: "request.resource.attr.aString" },
+              { value: "^str.*" },
+            ],
+          },
+        ],
+      },
+      { NOT: { aString: { startsWith: "str" } } },
+    ],
+  ] satisfies [string, PlanExpressionOperand, Record<string, unknown>][]) (
+    "composes a mapped predicate inside %s",
+    (_name, expression, expectedFilter) => {
+      const result = queryPlanToPrisma({
+        queryPlan: createConditionalPlan(expression),
+        mapper: {
+          "request.resource.attr.aString": { field: "aString" },
+          "request.resource.attr.aNumber": { field: "aNumber" },
+        },
+        expressionMapper: ({ expression: currentExpression }) =>
+          "operator" in currentExpression &&
+          currentExpression.operator === "matches"
+            ? { aString: { startsWith: "str" } }
+            : undefined,
+      });
+
+      expect(result).toStrictEqual({
+        kind: PlanKind.CONDITIONAL,
+        filters: expectedFilter,
+      });
+    }
+  );
+
+  test("maps unsupported predicates inside relation lambdas", async () => {
+    const matchesExpression: PlanExpressionOperand = {
+      operator: "matches",
+      operands: [{ name: "tag.name" }, { value: "^pub.*" }],
+    };
+    const plan = createConditionalPlan({
+      operator: "exists",
+      operands: [
+        { name: "request.resource.attr.tags" },
+        {
+          operator: "lambda",
+          operands: [matchesExpression, { name: "tag" }],
+        },
+      ],
+    });
+
+    let scopedMapper: Mapper | undefined;
+    const result = queryPlanToPrisma({
+      queryPlan: plan,
+      mapper: {
+        "request.resource.attr.tags": {
+          relation: {
+            name: "tags",
+            type: "many",
+            fields: { name: { field: "name" } },
+          },
+        },
+      },
+      expressionMapper: ({ expression, mapper }) => {
+        if (expression !== matchesExpression) {
+          return undefined;
+        }
+
+        scopedMapper = mapper;
+        return {
+          name: { startsWith: "pub" },
+          id: { equals: "tag2" },
+        };
+      },
+    });
+
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: {
+        tags: {
+          some: {
+            name: { startsWith: "pub" },
+            id: { equals: "tag2" },
+          },
+        },
+      },
+    });
+
+    if (typeof scopedMapper !== "function") {
+      throw new Error("Expected a relation-scoped mapper");
+    }
+    expect(scopedMapper("tag.name")).toStrictEqual({ field: "name" });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+
+    const query = await prisma.resource.findMany({ where: result.filters });
+    expect(query).toEqual([]);
+  });
+});
+
 // Issue #156: add operator (string concatenation)
 describe("Add Operator", () => {
   test("add with two values (constant folding)", () => {
@@ -6578,7 +6921,11 @@ describe("Arithmetic Operators", () => {
     });
 
     expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
-    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+    if (queryPlan.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL query plan");
+    }
+    const condition = queryPlan.condition;
+    expect(condition).toEqual({
       operator: "gt",
       operands: [
         {
@@ -6602,6 +6949,28 @@ describe("Arithmetic Operators", () => {
     ).toThrow(
       "Operator gt is not supported with add and field references"
     );
+
+    const result = queryPlanToPrisma({
+      queryPlan,
+      mapper: {
+        "request.resource.attr.aNumber": { field: "aNumber" },
+      },
+      expressionMapper: ({ expression }) =>
+        expression === condition ? { aNumber: { gt: 1 } } : undefined,
+    });
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: { aNumber: { gt: 1 } },
+    });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+    const query = await prisma.resource.findMany({ where: result.filters });
+    expect(query.map(({ id }) => id).sort()).toEqual([
+      "resource2",
+      "resource3",
+    ]);
   });
 
   test("arith-sub is unsupported", async () => {
@@ -6612,7 +6981,11 @@ describe("Arithmetic Operators", () => {
     });
 
     expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
-    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+    if (queryPlan.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL query plan");
+    }
+    const condition = queryPlan.condition;
+    expect(condition).toEqual({
       operator: "lt",
       operands: [
         {
@@ -6644,7 +7017,11 @@ describe("Arithmetic Operators", () => {
     });
 
     expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
-    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+    if (queryPlan.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL query plan");
+    }
+    const condition = queryPlan.condition;
+    expect(condition).toEqual({
       operator: "gt",
       operands: [
         {
@@ -6745,7 +7122,11 @@ describe("Regex Operator", () => {
     });
 
     expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
-    expect((queryPlan as PlanResourcesConditionalResponse).condition).toEqual({
+    if (queryPlan.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL query plan");
+    }
+    const condition = queryPlan.condition;
+    expect(condition).toEqual({
       operator: "matches",
       operands: [
         { name: "request.resource.attr.aString" },
@@ -6761,6 +7142,31 @@ describe("Regex Operator", () => {
         },
       })
     ).toThrow("Unsupported operator: matches");
+
+    const result = queryPlanToPrisma({
+      queryPlan,
+      mapper: {
+        "request.resource.attr.aString": { field: "aString" },
+      },
+      expressionMapper: ({ expression }) =>
+        expression === condition
+          ? { aString: { startsWith: "str" } }
+          : undefined,
+    });
+    expect(result).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: { aString: { startsWith: "str" } },
+    });
+
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error("Expected CONDITIONAL result");
+    }
+    const query = await prisma.resource.findMany({ where: result.filters });
+    expect(query.map(({ id }) => id).sort()).toEqual([
+      "resource1",
+      "resource2",
+      "resource3",
+    ]);
   });
 });
 

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -33,9 +33,19 @@ export type Mapper =
   | Record<string, MapperConfig>
   | ((key: string) => MapperConfig);
 
+export type ExpressionMapperArgs = {
+  expression: PlanExpressionOperand;
+  mapper: Mapper;
+};
+
+export type ExpressionMapper = (
+  args: ExpressionMapperArgs
+) => PrismaFilter | undefined;
+
 export interface QueryPlanToPrismaArgs {
   queryPlan: PlanResourcesResponse;
   mapper?: Mapper;
+  expressionMapper?: ExpressionMapper;
 }
 
 export type QueryPlanToPrismaResult =
@@ -126,6 +136,15 @@ type ResolvedValue = {
 
 type ResolvedOperand = ResolvedFieldReference | ResolvedValue;
 
+type TranslationContext = {
+  mapper: Mapper;
+  expressionMapper?: ExpressionMapper;
+};
+
+type ExpressionMapping =
+  | { kind: "mapped"; filter: PrismaFilter }
+  | { kind: "unmapped" };
+
 function isResolvedFieldReference(
   operand: ResolvedOperand
 ): operand is ResolvedFieldReference {
@@ -214,6 +233,7 @@ function buildFieldDirectOrInFilter(
 export function queryPlanToPrisma({
   queryPlan,
   mapper = {},
+  expressionMapper,
 }: QueryPlanToPrismaArgs): QueryPlanToPrismaResult {
   switch (queryPlan.kind) {
     case PlanKind.ALWAYS_ALLOWED:
@@ -225,7 +245,7 @@ export function queryPlanToPrisma({
         kind: PlanKind.CONDITIONAL,
         filters: buildPrismaFilterFromCerbosExpression(
           queryPlan.condition,
-          mapper
+          { mapper, expressionMapper }
         ),
       };
     default:
@@ -385,7 +405,9 @@ function resolveOperand(
   } else if (isOperatorOperand(operand)) {
     const folded = tryFoldValueExpression(operand, mapper);
     if (folded !== null) return { value: folded };
-    const nestedResult = buildPrismaFilterFromCerbosExpression(operand, mapper);
+    const nestedResult = buildPrismaFilterFromCerbosExpression(operand, {
+      mapper,
+    });
     return { value: nestedResult };
   }
   throw new Error("Operand must have name, value, or be an expression");
@@ -481,8 +503,32 @@ function createScopedMapper(
  */
 function buildPrismaFilterFromCerbosExpression(
   expression: PlanExpressionOperand,
-  mapper: Mapper
+  context: TranslationContext
 ): PrismaFilter {
+  const mapping = mapExpression(expression, context);
+  if (mapping.kind === "mapped") {
+    return mapping.filter;
+  }
+
+  return buildPrismaFilterFromCerbosExpressionBuiltIn(expression, context);
+}
+
+function mapExpression(
+  expression: PlanExpressionOperand,
+  context: TranslationContext
+): ExpressionMapping {
+  const { mapper, expressionMapper } = context;
+  const filter = expressionMapper?.({ expression, mapper });
+  return filter === undefined
+    ? { kind: "unmapped" }
+    : { kind: "mapped", filter };
+}
+
+function buildPrismaFilterFromCerbosExpressionBuiltIn(
+  expression: PlanExpressionOperand,
+  context: TranslationContext
+): PrismaFilter {
+  const { mapper } = context;
   // A bare named operand represents a boolean field reference (e.g. `R.attr.booleanAttr`)
   if (isNamedOperand(expression)) {
     const fieldRef = resolveFieldReference(expression.name, mapper);
@@ -500,14 +546,20 @@ function buildPrismaFilterFromCerbosExpression(
     case "and":
       return {
         AND: operands.map((operand) =>
-          buildPrismaFilterFromCerbosExpression(operand, mapper)
+          buildPrismaFilterFromCerbosExpression(
+            operand,
+            context
+          )
         ),
       };
 
     case "or":
       return {
         OR: operands.map((operand) =>
-          buildPrismaFilterFromCerbosExpression(operand, mapper)
+          buildPrismaFilterFromCerbosExpression(
+            operand,
+            context
+          )
         ),
       };
 
@@ -526,7 +578,10 @@ function buildPrismaFilterFromCerbosExpression(
         }
       }
       return {
-        NOT: buildPrismaFilterFromCerbosExpression(operand, mapper),
+        NOT: buildPrismaFilterFromCerbosExpression(
+          operand,
+          context
+        ),
       };
     }
 
@@ -558,7 +613,7 @@ function buildPrismaFilterFromCerbosExpression(
     }
 
     case "lambda": {
-      return handleLambdaOperator(operands);
+      return handleLambdaOperator(operands, context);
     }
 
     case "exists":
@@ -566,7 +621,11 @@ function buildPrismaFilterFromCerbosExpression(
     case "all":
     case "except":
     case "filter": {
-      return handleCollectionOperator(operator, operands, mapper);
+      return handleCollectionOperator(
+        operator,
+        operands,
+        context
+      );
     }
 
     case "map": {
@@ -890,7 +949,10 @@ function handleHasIntersectionOperator(
 /**
  * Helper function to handle "lambda" operator
  */
-function handleLambdaOperator(operands: PlanExpressionOperand[]): PrismaFilter {
+function handleLambdaOperator(
+  operands: PlanExpressionOperand[],
+  context: TranslationContext
+): PrismaFilter {
   const condition = assertDefined(
     operands[0],
     "Lambda requires a condition operand"
@@ -904,9 +966,15 @@ function handleLambdaOperator(operands: PlanExpressionOperand[]): PrismaFilter {
     throw new Error("Lambda variable must have a name");
   }
 
-  return buildPrismaFilterFromCerbosExpression(condition, (key: string) => ({
-    field: key.replace(`${variable.name}.`, ""),
-  }));
+  return buildPrismaFilterFromCerbosExpression(
+    condition,
+    {
+      ...context,
+      mapper: (key: string) => ({
+        field: key.replace(`${variable.name}.`, ""),
+      }),
+    }
+  );
 }
 
 /**
@@ -915,8 +983,9 @@ function handleLambdaOperator(operands: PlanExpressionOperand[]): PrismaFilter {
 function handleCollectionOperator(
   operator: string,
   operands: PlanExpressionOperand[],
-  mapper: Mapper
+  context: TranslationContext
 ): PrismaFilter {
+  const { mapper, expressionMapper } = context;
   if (operands.length !== 2) {
     throw new Error(`${operator} requires exactly two operands`);
   }
@@ -967,10 +1036,18 @@ function handleCollectionOperator(
     lambda.operands[0],
     "Lambda expression must provide a condition"
   );
-  const lambdaCondition = buildPrismaFilterFromCerbosExpression(
-    lambdaConditionOperand, // Use the condition part of the lambda
-    scopedMapper
-  );
+  const scopedContext = {
+    mapper: scopedMapper,
+    expressionMapper,
+  } satisfies TranslationContext;
+  const lambdaMapping = mapExpression(lambdaConditionOperand, scopedContext);
+  const lambdaCondition =
+    lambdaMapping.kind === "mapped"
+      ? lambdaMapping.filter
+      : buildPrismaFilterFromCerbosExpressionBuiltIn(
+          lambdaConditionOperand,
+          scopedContext
+        );
 
   const relation = assertDefined(
     relations[0],
@@ -979,7 +1056,13 @@ function handleCollectionOperator(
   let filterValue = lambdaCondition;
 
   // If the lambda condition already has a relation structure, merge it
-  if (lambdaCondition["AND"] || lambdaCondition["OR"]) {
+  if (lambdaMapping.kind === "mapped") {
+    filterValue = lambdaMapping.filter;
+  } else if (
+    lambdaCondition["AND"] ||
+    lambdaCondition["OR"] ||
+    lambdaCondition["NOT"]
+  ) {
     filterValue = lambdaCondition;
   } else {
     const lambdaKeys = Object.keys(lambdaCondition);


### PR DESCRIPTION
## Summary

- Add application-defined expression mappings for unsupported or provider-specific Prisma filters.
- Preserve built-in translation when mappings decline expressions.
- Support mapped predicates within boolean operators and relation lambdas.
- Document expression mapping behavior and lower the minimum Prisma version to 5.0.
- Expand coverage for arithmetic, regex, casts, indexing, string size, and relation scopes.

## Testing

- Added unit and integration coverage for expression mapping, composition, fallback behavior, and relation lambdas.
- Existing Prisma test suite validation not run (not requested).