### PR TITLE
Expand the Spring Data example test app

### DIFF
--- a/spring-data/example/README.md
+++ b/spring-data/example/README.md
@@ -1,107 +1,226 @@
-# cerbos-spring-data — photo-sharing example
+# cerbos-spring-data — multi-resource enterprise example
 
-A minimal Spring Boot + JPA application that uses the [`cerbos-spring-data`](..) adapter
-to filter a `photos` table according to a Cerbos `PlanResources` decision served by a real
-PDP container.
+A Spring Boot + JPA application that exercises the `cerbos-spring-data` adapter through a
+real `JpaSpecificationExecutor`, H2 database, and Cerbos PDP. It authorizes three independent
+resource types—`photo`, `album`, and `workspace`—and doubles as an end-to-end edge-case harness.
+Every authorization-bearing request obtains a resource-specific `PlanResources` result,
+translates it to a typed JPA `Specification`, and executes the resulting SQL.
 
-## What it does
+Policy filtering is not reimplemented in Java. The one intentional application-owned predicate
+is the mandatory tenant boundary, composed outside the Cerbos specification so it still applies
+to `KIND_ALWAYS_ALLOWED`. Changing the resource policies under [`policies/`](policies/) changes
+the policy-controlled result sets without changing the app.
 
-1. Spring Boot exposes `GET /photos?user=<id>&role=<role>&action=<action>`.
-2. The controller calls the Cerbos PDP for a query plan over the `photo` resource.
-3. The adapter turns the plan into a JPA `Specification<Photo>`.
-4. `PhotoRepository.findAll(spec)` runs the SQL.
+> **Demo identity only:** the endpoints accept `user`, `role`, `tenant`, and `groups` query
+> parameters so the smoke harness can switch principals. Never copy that identity handling into
+> production. Derive all of them from authenticated, server-controlled state; otherwise a caller
+> could request `role=admin` or cross a tenant boundary.
 
-No filtering is hand-rolled in Java — the predicates come straight from the policy.
+## What it covers
+
+| Resource kind | Persistence/auth path | Representative rules |
+|---|---|---|
+| `photo` | `PhotoRepository` + `PhotoService` + `photo.yaml` | ownership, tags, labels, tenant-safe grants |
+| `album` | `AlbumRepository` + `AlbumService` + `album.yaml` | owner, shared flag, collaborator membership |
+| `workspace` | `WorkspaceRepository` + `WorkspaceService` + `workspace.yaml` | active state, owner, member collection |
+
+Every kind has its own entity, repository, attribute map, Cerbos resource policy, endpoint,
+fixtures, and PDP audit assertions. The sample does not emulate multiple kinds with a discriminator
+column or reuse a cast `Specification<?>`.
+
+| Scenario | Policy/operator | JPA shape |
+|---|---|---|
+| Public, archived, ownership rules | `and`, `or`, `eq`, bare booleans | Scalar columns |
+| Optional location | `!= null` | Nullable scalar / `IS NOT NULL` |
+| Discovery thresholds | `>=` | Integer scalar plus dotted `@Embedded` path |
+| Flat tags | `in`, `hasIntersection` | `@ElementCollection<String>` |
+| Principal interests | principal list attribute | Runtime value substituted into a relation predicate |
+| Tenant isolation | local `tenant AND plan AND filter` composition | Mandatory scalar fence around every plan kind |
+| Delegated access | nested `exists`, direct user or group | Structured `@OneToMany` grants |
+| Grant integrity | child tenant equals outer resource tenant | Field-to-field comparison inside a lambda |
+| Nullable grant subjects | positive, negated, and null-guarded `exists` | SQL/CEL three-valued logic |
+| Duplicate matching grants | two qualifying children for one photo | Correlated subquery without duplicate roots |
+| Optional rating filter | local `Specification.and(...)` | Application filter composed outside authorization |
+| Moderation labels | `exists` with nested `and` | Correlated subquery over `@OneToMany` entities |
+| Review state | `all`, `exists_one` | Collection macro semantics, including empty collections |
+| Missing labels | `size(...) == 0` | `NOT EXISTS` collection shortcut |
+| `%` and `_` in titles | `contains` | Escaped SQL `LIKE` literals |
+| Admin | unconditional allow | `KIND_ALWAYS_ALLOWED` |
+| Unknown `publish` action | no matching rule | `KIND_ALWAYS_DENIED` |
+| Relation-heavy pages | label and delegated-grant predicates | Separate content/count queries with stable totals |
+| Full request cycle | PDP audit-log assertion | Matched call IDs, resource kinds, actions, and filters |
+
+The seed set deliberately includes two tenants, nullable grant subjects, a cross-tenant malformed
+grant, duplicate qualifying grants, empty collections, nested dimensions, and SQL `LIKE`
+metacharacters.
+
+## Request flow
+
+1. `GET /photos`, `/albums`, or `/workspaces` supplies a demo principal, tenant, and action.
+2. The resource-specific service calls the live PDP with `Resource.newInstance("photo")`,
+   `"album"`, or `"workspace"`.
+3. `SpringDataQueryPlanAdapter` maps the plan using that entity's independent attribute map.
+4. The service composes `tenantBoundary AND authorizationPlan` plus any local filter.
+5. The matching typed `JpaSpecificationExecutor` executes the Criteria query against H2.
+6. The controller returns only the rows allowed by the composed specification.
 
 ## Layout
 
-```
+```text
 example/
-├── policies/photo.yaml          # resource policy (view/edit/delete/comment)
-├── cerbos-config.yaml           # PDP config (audit logs to stdout)
-├── docker-compose.yml           # spins up ghcr.io/cerbos/cerbos:latest
-├── settings.gradle.kts          # composite-build include of ../ (the adapter)
-├── build.gradle.kts             # Spring Boot 3.5 + JPA + H2 + adapter
-├── scripts/smoke.sh             # end-to-end script (compose up → bootRun → curl asserts)
+├── policies/photo.yaml
+├── policies/album.yaml
+├── policies/workspace.yaml
+├── cerbos-config.yaml
+├── docker-compose.yml
+├── settings.gradle.kts          # composite-build include of the adapter source
+├── build.gradle.kts             # Spring Boot 3.5, Spring Data JPA, H2
+├── scripts/smoke.sh             # live PDP + Boot + HTTP assertions
 └── src/main/
     ├── resources/application.yaml
     └── java/dev/cerbos/example/photos/
-        ├── PhotosApplication.java
-        ├── Photo.java                  @Entity (id, ownerId, isPublic, isArchived, tags…)
-        ├── PhotoRepository.java        JpaRepository + JpaSpecificationExecutor
-        ├── PhotoService.java           builds plan, calls adapter, runs the spec
-        ├── PhotoController.java        REST surface
-        ├── CerbosClientConfig.java     @Bean CerbosBlockingClient
-        └── SeedData.java               loads 6 photos at boot
+        ├── Photo.java            # tenant-scoped aggregate root and its relations
+        ├── PhotoDetails.java     # embedded dimensions
+        ├── PhotoLabel.java       # structured one-to-many relation
+        ├── PhotoGrant.java       # nullable direct/group delegated-access rows
+        ├── PhotoRepository.java  # JpaRepository + JpaSpecificationExecutor
+        ├── PhotoService.java     # plan, mapping, Specification execution
+        ├── PhotoController.java  # list and paginated REST endpoints
+        ├── Album.java            # independently authorized album entity
+        ├── AlbumRepository.java
+        ├── AlbumService.java     # Resource.newInstance("album")
+        ├── AlbumController.java  # GET /albums
+        ├── Workspace.java        # independently authorized workspace entity
+        ├── WorkspaceRepository.java
+        ├── WorkspaceService.java # Resource.newInstance("workspace")
+        ├── WorkspaceController.java # GET /workspaces
+        ├── AccessContext.java    # shared principal/tenant construction
+        ├── CerbosClientConfig.java
+        ├── SeedData.java         # nine adversarial photos across two tenants
+        └── PhotosApplication.java
 ```
-
-## Policy at a glance
-
-| Action  | Rule (role `user`)                                                          |
-|---------|-----------------------------------------------------------------------------|
-| view    | `(public && !archived) || ownerId == self`                                  |
-| edit    | `ownerId == self`                                                           |
-| delete  | `ownerId == self`                                                           |
-| comment | `(public && !archived) || "friends" in tags || ownerId == self`             |
-
-Role `admin` always allowed. See [`policies/photo.yaml`](policies/photo.yaml).
 
 ## Run it
 
+Prerequisites: Docker, curl, jq, Gradle 8.x, and JDK 17+.
+
 ```bash
-# 1. start the Cerbos PDP (mounts ./policies into the container)
+# terminal 1: live Cerbos PDP
 docker compose up -d
 
-# 2. start the Spring Boot app
+# terminal 2: Spring Boot app
 gradle bootRun --no-daemon
-# … or with the wrapper from ../, if you have one
 
-# 3. in another shell — hit the API
+# terminal 3: queries
 curl -s "http://localhost:8080/photos?user=alice&action=view" | jq '[.[].id]'
-# => ["p1","p2","p5","p6"]
+curl -s "http://localhost:8080/photos?user=alice&action=similar&interests=travel,food" | jq '[.[].id]'
+curl -s "http://localhost:8080/photos?user=alice&action=delegated-view&groups=finance,engineering" | jq '[.[].id]'
+curl -s "http://localhost:8080/photos?user=admin&role=admin&tenant=globex&action=view" | jq '[.[].id]'
+curl -s "http://localhost:8080/photos?user=alice&action=view&minRating=5" | jq '[.[].id]'
+curl -s "http://localhost:8080/photos?user=alice&action=needs-moderation" | jq '[.[].id]'
+curl -s "http://localhost:8080/photos/page?user=alice&action=needs-moderation&page=0&size=1" |
+  jq '{ids: [.content[].id], totalElements, totalPages}'
+curl -s "http://localhost:8080/albums?user=alice&action=view" | jq '[.[].id]'
+curl -s "http://localhost:8080/workspaces?user=alice&action=access" | jq '[.[].id]'
 ```
 
-Or one-shot via the smoke test:
+Or run the complete harness:
 
 ```bash
 ./scripts/smoke.sh
 ```
 
-## End-to-end smoke run
+The smoke script starts the PDP and app, checks the full scenario matrix, validates both
+pages and totals for a relation-based paginated query, and checks invalid page bounds return
+400. After each authorization-bearing HTTP assertion, it parses Cerbos's own JSON audit logs
+and requires exactly one `PlanResources` access and decision pair—with the same call ID, the
+expected action, and a query-plan filter in the PDP response. It also compares the full action
+and resource-kind multiset as a summary and proves controller-rejected requests do not reach
+the PDP. The run fails unless the observed kind set is exactly `album`, `photo`, and `workspace`.
 
-`scripts/smoke.sh` brings up the PDP, runs `gradle bootRun` in the background, and asserts
-the response IDs for eight `(user, role, action)` permutations. On success it prints the
-last 20 lines of the PDP audit log so you can see actual `PlanResources` calls flowing
-into the container — proving the result came from a live policy decision, not a stub.
+## Adapter mapping
 
-## Adapter wiring
+The mapping is intentionally not always one-to-one. It demonstrates dotted embedded paths
+and maps policy-facing label names to different Java property names:
 
 ```java
-private static final Map<String, AttributeMapping> PHOTO_ATTRS = Map.of(
-    "request.resource.attr.ownerId",  AttributeMapping.field("ownerId"),
-    "request.resource.attr.public",   AttributeMapping.field("isPublic"),
-    "request.resource.attr.archived", AttributeMapping.field("isArchived"),
-    "request.resource.attr.tags",     AttributeMapping.relation("tags")
-);
-
-PlanResourcesResult plan = cerbos.plan(
-    Principal.newInstance(userId).withRoles(role),
-    Resource.newInstance("photo"),
-    action);
-
-Result<Photo> result = SpringDataQueryPlanAdapter.toSpecification(plan, PHOTO_ATTRS);
-return repository.findAll(result.toSpecification());
+Map.entry("request.resource.attr.metadata.width",
+        AttributeMapping.field("details.pixelWidth")),
+Map.entry("request.resource.attr.tags",
+        AttributeMapping.relation("tags")),
+Map.entry("request.resource.attr.labels",
+        AttributeMapping.relation("labels", Map.of(
+                "name", AttributeMapping.field("labelName"),
+                "confidence", AttributeMapping.field("confidence"),
+                "reviewed", AttributeMapping.field("reviewed")))),
+Map.entry("request.resource.attr.grants",
+        AttributeMapping.relation("grants", Map.of(
+                "tenantId", AttributeMapping.field("tenantId"),
+                "permission", AttributeMapping.field("permission"),
+                "userId", AttributeMapping.field("userId"),
+                "groupId", AttributeMapping.field("groupId"))))
 ```
 
-`AttributeMapping.relation("tags")` is what makes `"friends" in tags` translate to a
-correlated `EXISTS` subquery against the `photo_tags` join table.
+Each request also sends `interests` as a Cerbos principal attribute. The `similar` action
+uses it in `hasIntersection(resource.tags, principal.interests)`, which the planner reduces
+to values the adapter can apply to the tag relation.
 
-## What this proves
+## Enterprise isolation and delegation
 
-- The adapter compiles against a real Spring Boot 3.5 application without dragging in
-  conflicting Spring/JPA versions (its Spring deps are `compileOnly`).
-- The PDP — not the app — decides which photos are visible. Changing
-  `policies/photo.yaml` and re-running the smoke script flips the result set without a
-  single line of Java change.
-- `KIND_ALWAYS_ALLOWED` (admin) and `KIND_CONDITIONAL` (user) both round-trip through
-  the adapter and land as a usable `Specification<Photo>`.
+Every repository query starts with an application-owned `tenantId` specification. It is ANDed
+outside the adapter result, so even an unconditional admin plan cannot escape the selected
+tenant. In production, the tenant must come from authenticated server context—not a query
+parameter. The optional `minRating` predicate demonstrates a second local specification without
+placing it outside the tenant fence by mistake.
+
+The `delegated-view` policy evaluates structured grant rows. A grant must match the photo's
+tenant, carry the `view` permission, and target either the principal ID or one of the principal's
+tenant-qualified groups. Fixtures include direct and group grants, two matching rows for one
+photo, the same group slug in another tenant, a wrong-permission grant, and a deliberately
+malformed grant whose tenant disagrees with its parent.
+
+The `group-grant`, `no-group-grant`, and `no-group-grant-safe` actions pin a subtle security
+property: a null child attribute evaluates UNKNOWN, not false. A null-only collection is excluded
+under both the positive and unguarded negated policy; explicitly checking `groupId != null`
+changes the negated result in a visible, documented way.
+
+## Album and workspace authorization
+
+Albums and workspaces are not thin routes over `Photo`. Each has a separate table, entity,
+`JpaSpecificationExecutor`, service, Cerbos attribute map, and resource policy:
+
+- `album` exercises scalar ownership/shared-state predicates and membership in an
+  `@ElementCollection` of collaborators.
+- `workspace` combines a mandatory active-state predicate with owner-or-member access and a
+  separate owner-only administration action.
+
+Both types retain the application-owned tenant fence around conditional, always-allowed, and
+always-denied plans. Their fixtures include Acme and Globex rows so the smoke matrix proves an
+unconditional admin plan remains tenant-limited for all three persistence models.
+
+## Why the paginated endpoint matters
+
+`JpaSpecificationExecutor.findAll(spec, pageable)` evaluates the specification for both the
+content query and a count query. `/photos/page` confirms that a conditional plan containing
+correlated label and grant subqueries can be rebuilt for both Criteria roots and produce stable
+IDs, `totalElements`, and `totalPages` without duplicate parent rows. Matching fixtures contain
+duplicate qualifying children specifically to catch accidental join-based duplication.
+
+## Full-cycle verification
+
+Matching response IDs alone could pass if application code accidentally replaced the PDP with
+local filtering. The smoke harness therefore verifies both ends of every successful scenario:
+
+1. The HTTP response contains the IDs produced by executing the translated Spring Data
+   specification against H2.
+2. A Cerbos access record confirms the `/PlanResources` RPC reached the PDP.
+3. A decision record with the same `callId` contains the expected
+   `planResources.input.resource.kind`, `planResources.input.actions`, and a non-null
+   `planResources.output.filter.kind`.
+
+Each HTTP assertion checks its own audit delta, so repeated actions cannot hide a missing or
+duplicate call. The final 42-entry resource/action multiset is a second summary check, and the
+observed resource-kind set must be exactly the three intended kinds. Readiness uses an
+unmapped route and creates no PDP traffic; after the rejected pagination/filter requests, a valid
+`audit-sentinel` request acts as an audit flush barrier and the complete delta must contain only
+that sentinel.

--- a/spring-data/example/policies/album.yaml
+++ b/spring-data/example/policies/album.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: album
+  version: default
+  rules:
+    - actions: ["view"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: request.resource.attr.tenantId == request.principal.attr.tenantId
+              - any:
+                  of:
+                    - expr: request.resource.attr.ownerId == request.principal.id
+                    - expr: request.resource.attr.shared == true
+                    - expr: request.principal.id in request.resource.attr.collaborators
+
+    - actions: ["manage"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: request.resource.attr.tenantId == request.principal.attr.tenantId
+              - expr: request.resource.attr.ownerId == request.principal.id
+
+    - actions: ["view", "manage"]
+      effect: EFFECT_ALLOW
+      roles: ["admin"]

--- a/spring-data/example/policies/photo.yaml
+++ b/spring-data/example/policies/photo.yaml
@@ -8,7 +8,15 @@
 #   edit    : ownerId == self
 #   delete  : ownerId == self
 #   comment : public + not archived, OR "friends" tag set, OR ownerId == self
-#   admin   : unconditional ALLOW on all actions
+#   discover         : numeric comparison on a scalar and an embedded field
+#   located          : nullable-field isSet/null semantics
+#   similar          : intersection with a principal list attribute
+#   needs-moderation : exists() over structured label entities
+#   fully-reviewed   : all() over labels, including the empty-set case
+#   unlabelled       : size() over a relation
+#   exactly-one-reviewed: exists_one() over a relation
+#   percent/underscore-title: literal SQL LIKE metacharacter escaping
+#   admin            : unconditional ALLOW on all actions
 apiVersion: api.cerbos.dev/v1
 resourcePolicy:
   resource: photo
@@ -48,6 +56,140 @@ resourcePolicy:
               - expr: '"friends" in request.resource.attr.tags'
               - expr: request.resource.attr.ownerId == request.principal.id
 
-    - actions: ["view", "edit", "delete", "comment"]
+    - actions: ["discover"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: request.resource.attr.rating >= 4
+              - expr: request.resource.attr.metadata.width >= 3000
+
+    - actions: ["located"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: request.resource.attr.location != null
+
+    - actions: ["similar"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: hasIntersection(request.resource.attr.tags, request.principal.attr.interests)
+
+    - actions: ["needs-moderation"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: >
+            request.resource.attr.labels.exists(label,
+              label.name == "safety" && label.confidence >= 0.8)
+
+    - actions: ["fully-reviewed"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: request.resource.attr.labels.all(label, label.reviewed == true)
+
+    - actions: ["unlabelled"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: size(request.resource.attr.labels) == 0
+
+    - actions: ["exactly-one-reviewed"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: request.resource.attr.labels.exists_one(label, label.reviewed == true)
+
+    - actions: ["percent-title"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: 'request.resource.attr.title.contains("%")'
+
+    - actions: ["underscore-title"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: 'request.resource.attr.title.contains("_")'
+
+    # Enterprise delegated access: the local JPA tenant Specification is the mandatory outer
+    # boundary; these policy checks add defense in depth and validate each grant against its
+    # owning photo so a malformed cross-tenant grant cannot authorize.
+    - actions: ["delegated-view"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: >
+            request.resource.attr.tenantId == request.principal.attr.tenantId &&
+            request.resource.attr.grants.exists(grant,
+              grant.tenantId == request.resource.attr.tenantId &&
+              grant.permission == "view" &&
+              (grant.userId == request.principal.id ||
+               grant.groupId in request.principal.attr.groups))
+
+    # These three actions deliberately distinguish CEL UNKNOWN from false for nullable child
+    # fields. A null-only grant is excluded under both the positive and unguarded negated forms.
+    - actions: ["group-grant"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: >
+            request.resource.attr.tenantId == request.principal.attr.tenantId &&
+            request.resource.attr.grants.exists(grant,
+              grant.groupId in request.principal.attr.groups)
+
+    - actions: ["no-group-grant"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: >
+            request.resource.attr.tenantId == request.principal.attr.tenantId &&
+            !request.resource.attr.grants.exists(grant,
+              grant.groupId in request.principal.attr.groups)
+
+    - actions: ["no-group-grant-safe"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: >
+            request.resource.attr.tenantId == request.principal.attr.tenantId &&
+            !request.resource.attr.grants.exists(grant,
+              grant.groupId != null &&
+              grant.groupId in request.principal.attr.groups)
+
+    - actions:
+        - "view"
+        - "edit"
+        - "delete"
+        - "comment"
+        - "discover"
+        - "located"
+        - "similar"
+        - "needs-moderation"
+        - "fully-reviewed"
+        - "unlabelled"
+        - "exactly-one-reviewed"
+        - "percent-title"
+        - "underscore-title"
+        - "delegated-view"
+        - "group-grant"
+        - "no-group-grant"
+        - "no-group-grant-safe"
       effect: EFFECT_ALLOW
       roles: ["admin"]

--- a/spring-data/example/policies/workspace.yaml
+++ b/spring-data/example/policies/workspace.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  resource: workspace
+  version: default
+  rules:
+    - actions: ["access"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: request.resource.attr.tenantId == request.principal.attr.tenantId
+              - expr: request.resource.attr.active == true
+              - any:
+                  of:
+                    - expr: request.resource.attr.ownerId == request.principal.id
+                    - expr: request.principal.id in request.resource.attr.members
+
+    - actions: ["administer"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: request.resource.attr.tenantId == request.principal.attr.tenantId
+              - expr: request.resource.attr.ownerId == request.principal.id
+
+    - actions: ["access", "administer"]
+      effect: EFFECT_ALLOW
+      roles: ["admin"]

--- a/spring-data/example/scripts/smoke.sh
+++ b/spring-data/example/scripts/smoke.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# End-to-end smoke test for the cerbos-spring-data photo-sharing example.
+# End-to-end smoke test for the cerbos-spring-data multi-resource example.
 #
 # Brings up the Cerbos PDP via docker compose, starts the Spring Boot app, and
-# hits the REST endpoint with a handful of (user, role, action) tuples. Each
+# hits three resource endpoints with a matrix of principal, tenant, role, and action tuples. Each
 # request triggers a real PlanResources call to the PDP container — the audit
 # log in `docker compose logs cerbos` then proves what plan the adapter saw.
 #
@@ -41,48 +41,365 @@ APP_PID=$!
 
 echo "==> waiting for Spring Boot on :8080"
 for i in {1..60}; do
-    if curl -fsS "http://localhost:8080/photos?user=alice" >/dev/null 2>&1; then break; fi
+    if curl -sS -o /dev/null "http://localhost:8080/" 2>/dev/null; then break; fi
     sleep 1
 done
-curl -fsS "http://localhost:8080/photos?user=alice" >/dev/null || \
+curl -sS -o /dev/null "http://localhost:8080/" || \
     { tail -40 build/smoke/app.log; fail "Spring Boot didn't come up"; }
+
+# Audit records are the independent proof that the HTTP request reached the PDP. The readiness
+# probe uses an unmapped route so it does not authorize; existing container logs are baselined.
+pdp_plan_records() {
+    docker compose logs --no-color --no-log-prefix cerbos 2>/dev/null |
+        jq -cR 'fromjson? | select(
+            .["log.logger"] == "cerbos.audit" and
+            .["log.kind"] == "decision" and
+            .planResources != null
+        )'
+}
+
+pdp_access_records() {
+    docker compose logs --no-color --no-log-prefix cerbos 2>/dev/null |
+        jq -cR 'fromjson? | select(
+            .["log.logger"] == "cerbos.audit" and
+            .["log.kind"] == "access" and
+            ((.method // "") | endswith("/PlanResources"))
+        )'
+}
+
+pdp_plan_count() {
+    pdp_plan_records | wc -l | tr -d ' '
+}
+
+pdp_access_count() {
+    pdp_access_records | wc -l | tr -d ' '
+}
+
+pdp_records_since() {
+    local baseline=$1
+    pdp_plan_records | tail -n "+$((baseline + 1))"
+}
+
+pdp_access_records_since() {
+    local baseline=$1
+    pdp_access_records | tail -n "+$((baseline + 1))"
+}
+
+PDP_BASELINE=$(pdp_plan_count)
+PDP_ACCESS_BASELINE=$(pdp_access_count)
+
+action_from_url() {
+    local url=$1 action
+    action=${url#*action=}
+    if [[ "$action" == "$url" ]]; then
+        fail "authorization assertion URL has no action: $url"
+    fi
+    printf '%s' "${action%%&*}"
+}
+
+resource_from_url() {
+    local url=$1 path
+    path=${url#*://}
+    path=${path#*/}
+    path=${path%%\?*}
+    path=${path%%/*}
+    case "$path" in
+        photos) printf 'photo' ;;
+        albums) printf 'album' ;;
+        workspaces) printf 'workspace' ;;
+        *) fail "authorization assertion URL has unknown resource path: $url" ;;
+    esac
+}
+
+verify_pdp_call() {
+    local label=$1 expected_action=$2 expected_resource=$3 access_before=$4 decision_before=$5
+    local access_target decision_target access_count decision_count
+    local access_record decision_record access_id decision_id observed_action observed_resource
+    local filter_kind
+    access_target=$((access_before + 1))
+    decision_target=$((decision_before + 1))
+
+    for _ in {1..50}; do
+        access_count=$(pdp_access_count)
+        decision_count=$(pdp_plan_count)
+        if (( access_count > access_target || decision_count > decision_target )); then
+            fail "$label made multiple PDP calls: accesses=$access_before->$access_count" \
+                "decisions=$decision_before->$decision_count"
+        fi
+        if (( access_count == access_target && decision_count == decision_target )); then
+            access_record=$(pdp_access_records | tail -1)
+            decision_record=$(pdp_plan_records | tail -1)
+            access_id=$(jq -r '.callId' <<<"$access_record")
+            decision_id=$(jq -r '.callId' <<<"$decision_record")
+            observed_action=$(jq -r '.planResources.input.actions | join(",")' \
+                <<<"$decision_record")
+            observed_resource=$(jq -r '.planResources.input.resource.kind' \
+                <<<"$decision_record")
+            filter_kind=$(jq -r '.planResources.output.filter.kind // empty' \
+                <<<"$decision_record")
+            if [[ "$access_id" != "$decision_id" ]]; then
+                fail "$label PDP access/decision call IDs differ: $access_id != $decision_id"
+            fi
+            if [[ "$observed_action" != "$expected_action" ]]; then
+                fail "$label PDP action mismatch: expected=$expected_action got=$observed_action"
+            fi
+            if [[ "$observed_resource" != "$expected_resource" ]]; then
+                fail "$label PDP resource mismatch: expected=$expected_resource got=$observed_resource"
+            fi
+            if [[ -z "$filter_kind" ]]; then
+                fail "$label PDP decision had no query-plan filter output"
+            fi
+            return
+        fi
+        sleep 0.1
+    done
+    fail "$label PDP audit timeout: accesses=$access_before->$access_count" \
+        "decisions=$decision_before->$decision_count"
+}
 
 assert_ids() {
     local label=$1 url=$2 expected=$3
-    local got
+    local got access_before decision_before action resource
+    access_before=$(pdp_access_count)
+    decision_before=$(pdp_plan_count)
+    action=$(action_from_url "$url")
+    resource=$(resource_from_url "$url")
     got=$(curl -fsS "$url" | jq -r '[.[].id] | sort | join(",")')
     if [[ "$got" == "$expected" ]]; then
         ok "$label  => $got"
     else
         fail "$label  expected=$expected  got=$got"
     fi
+    verify_pdp_call "$label" "$action" "$resource" "$access_before" "$decision_before"
+}
+
+assert_page() {
+    local label=$1 url=$2 expected_ids=$3 expected_total=$4 expected_pages=$5
+    local response got_ids got_total got_pages access_before decision_before action resource
+    access_before=$(pdp_access_count)
+    decision_before=$(pdp_plan_count)
+    action=$(action_from_url "$url")
+    resource=$(resource_from_url "$url")
+    response=$(curl -fsS "$url")
+    got_ids=$(jq -r '[.content[].id] | join(",")' <<<"$response")
+    got_total=$(jq -r '.totalElements' <<<"$response")
+    got_pages=$(jq -r '.totalPages' <<<"$response")
+    if [[ "$got_ids" == "$expected_ids" && "$got_total" == "$expected_total" && \
+          "$got_pages" == "$expected_pages" ]]; then
+        ok "$label  => ids=$got_ids total=$got_total pages=$got_pages"
+    else
+        fail "$label  expected=ids:$expected_ids,total:$expected_total,pages:$expected_pages" \
+            "got=ids:$got_ids,total:$got_total,pages:$got_pages"
+    fi
+    verify_pdp_call "$label" "$action" "$resource" "$access_before" "$decision_before"
+}
+
+assert_status() {
+    local label=$1 url=$2 expected=$3
+    local got
+    got=$(curl -sS -o /dev/null -w '%{http_code}' "$url")
+    if [[ "$got" == "$expected" ]]; then
+        ok "$label  => HTTP $got"
+    else
+        fail "$label  expected=HTTP:$expected got=HTTP:$got"
+    fi
 }
 
 # Seed data (from SeedData.java):
-#   p1 alice public  !arch tags=travel,sunset
-#   p2 alice private !arch tags=friends,food
-#   p3 bob   public   arch tags=wedding
-#   p4 bob   private !arch tags=portrait
-#   p5 charlie public !arch tags=travel,outdoors,friends
-#   p6 alice private  arch tags=legacy
+#   p1 alice   public  !arch location=Lisbon tags=travel,sunset labels=editorial
+#   p2 alice   private !arch location=NULL   tags=friends,food   labels=safety,faces
+#   p3 bob     public   arch location=Paris   tags=wedding        labels=safety
+#   p4 bob     private !arch location=Studio tags=portrait       labels=[]
+#   p5 charlie public  !arch location=Alps   tags=travel,...     labels=quality,safety
+#   p6 alice   private  arch location=Home   tags=legacy         labels=[]
+#   p7 dana    public  !arch location=NULL   tags=[] title contains literal "%"
+#   p8 erin    public  !arch location=Tokyo  tags=unicode,... title contains literal "_"
+#   p9 globex-user private arch tenant=globex (cross-tenant control row)
+#
+# Grants deliberately include null subjects, duplicate matches, wrong permissions, and one
+# grant whose tenant disagrees with its photo. Group IDs are tenant-qualified in the database.
 #
 # view (user)  : (public AND !archived) OR ownerId == self
 # edit (user)  : ownerId == self
 # comment(user): (public AND !archived) OR "friends" in tags OR ownerId == self
-# any (admin)  : ALWAYS_ALLOWED  =>  all 6
+# any (admin)  : ALWAYS_ALLOWED  =>  all 8
 
-assert_ids "alice/view"        "http://localhost:8080/photos?user=alice&action=view"          "p1,p2,p5,p6"
+assert_ids "alice/view"        "http://localhost:8080/photos?user=alice&action=view"          "p1,p2,p5,p6,p7,p8"
 assert_ids "alice/edit"        "http://localhost:8080/photos?user=alice&action=edit"          "p1,p2,p6"
-assert_ids "alice/comment"     "http://localhost:8080/photos?user=alice&action=comment"       "p1,p2,p5,p6"
-assert_ids "bob/view"          "http://localhost:8080/photos?user=bob&action=view"            "p1,p3,p4,p5"
+assert_ids "alice/comment"     "http://localhost:8080/photos?user=alice&action=comment"       "p1,p2,p5,p6,p7,p8"
+assert_ids "bob/view"          "http://localhost:8080/photos?user=bob&action=view"            "p1,p3,p4,p5,p7,p8"
 assert_ids "bob/edit"          "http://localhost:8080/photos?user=bob&action=edit"            "p3,p4"
-assert_ids "charlie/comment"   "http://localhost:8080/photos?user=charlie&action=comment"     "p1,p2,p5"
-assert_ids "admin/view"        "http://localhost:8080/photos?user=admin&role=admin&action=view"    "p1,p2,p3,p4,p5,p6"
-assert_ids "admin/delete"      "http://localhost:8080/photos?user=admin&role=admin&action=delete"  "p1,p2,p3,p4,p5,p6"
+assert_ids "charlie/comment"   "http://localhost:8080/photos?user=charlie&action=comment"     "p1,p2,p5,p7,p8"
+assert_ids "admin/view"        "http://localhost:8080/photos?user=admin&role=admin&action=view"    "p1,p2,p3,p4,p5,p6,p7,p8"
+assert_ids "admin/delete"      "http://localhost:8080/photos?user=admin&role=admin&action=delete"  "p1,p2,p3,p4,p5,p6,p7,p8"
+
+# The application-owned tenant Specification composes outside every Cerbos result kind.
+assert_ids "admin/globex"      "http://localhost:8080/photos?user=admin&role=admin&tenant=globex&action=view" "p9"
+assert_ids "alice/view/rating" "http://localhost:8080/photos?user=alice&action=view&minRating=5" "p1,p5"
+
+# Scalar/nested comparisons, NULL handling, principal list attributes, and empty collections.
+assert_ids "discover"          "http://localhost:8080/photos?user=alice&action=discover"                 "p1,p3,p5,p7,p8"
+assert_ids "located"           "http://localhost:8080/photos?user=alice&action=located"                  "p1,p3,p4,p5,p6,p8"
+assert_ids "similar/travel"    "http://localhost:8080/photos?user=alice&action=similar&interests=travel" "p1,p5"
+assert_ids "similar/multiple"  "http://localhost:8080/photos?user=alice&action=similar&interests=travel,food" "p1,p2,p5"
+assert_ids "similar/empty"     "http://localhost:8080/photos?user=alice&action=similar"                  ""
+
+# Enterprise grants combine direct users, tenant-qualified groups, nullable child fields,
+# child-to-parent tenant integrity, duplicate matching rows, and the mandatory tenant fence.
+assert_ids "delegated/direct" \
+    "http://localhost:8080/photos?user=alice&action=delegated-view" "p3"
+assert_ids "delegated/groups" \
+    "http://localhost:8080/photos?user=alice&action=delegated-view&groups=finance,engineering" \
+    "p2,p3,p5"
+assert_ids "delegated/finance" \
+    "http://localhost:8080/photos?user=dana&action=delegated-view&groups=finance" "p2"
+assert_ids "delegated/mismatched-tenant" \
+    "http://localhost:8080/photos?user=dana&action=delegated-view&groups=legal" ""
+assert_ids "delegated/globex" \
+    "http://localhost:8080/photos?user=alice&tenant=globex&action=delegated-view&groups=finance" \
+    "p9"
+
+# Null-only grant members are UNKNOWN, not false. Guarding null explicitly changes negation.
+assert_ids "grant/positive-unknown" \
+    "http://localhost:8080/photos?user=alice&action=group-grant&groups=finance" "p2,p7"
+assert_ids "grant/negated-unknown" \
+    "http://localhost:8080/photos?user=alice&action=no-group-grant&groups=finance" "p4,p5,p6"
+assert_ids "grant/guarded-negation" \
+    "http://localhost:8080/photos?user=alice&action=no-group-grant-safe&groups=finance" \
+    "p1,p3,p4,p5,p6,p8"
+
+# Structured @OneToMany label relation: exists, all, size, and exists_one.
+assert_ids "needs-moderation"  "http://localhost:8080/photos?user=alice&action=needs-moderation"   "p2,p3"
+assert_ids "fully-reviewed"    "http://localhost:8080/photos?user=alice&action=fully-reviewed"     "p1,p3,p4,p6,p7,p8"
+assert_ids "unlabelled"        "http://localhost:8080/photos?user=alice&action=unlabelled"          "p4,p6,p7,p8"
+assert_ids "exactly-one"       "http://localhost:8080/photos?user=alice&action=exactly-one-reviewed" "p1,p2,p3,p5"
+
+# LIKE wildcards must be escaped as literals by the adapter.
+assert_ids "literal-percent"   "http://localhost:8080/photos?user=alice&action=percent-title"      "p7"
+assert_ids "literal-underscore" "http://localhost:8080/photos?user=alice&action=underscore-title"  "p8"
+
+# An action with no matching rule becomes KIND_ALWAYS_DENIED.
+assert_ids "always-denied"     "http://localhost:8080/photos?user=alice&action=publish" ""
+
+# Relation predicates must also survive Spring Data's paginated content and count queries.
+assert_page "moderation/page-0" \
+    "http://localhost:8080/photos/page?user=alice&action=needs-moderation&page=0&size=1" \
+    "p2" "2" "2"
+assert_page "moderation/page-1" \
+    "http://localhost:8080/photos/page?user=alice&action=needs-moderation&page=1&size=1" \
+    "p3" "2" "2"
+assert_page "delegated/page-0" \
+    "http://localhost:8080/photos/page?user=alice&action=delegated-view&groups=finance,engineering&page=0&size=2" \
+    "p2,p3" "3" "2"
+assert_page "delegated/page-1" \
+    "http://localhost:8080/photos/page?user=alice&action=delegated-view&groups=finance,engineering&page=1&size=2" \
+    "p5" "3" "2"
+
+# Independent persistence and authorization paths for two additional Cerbos resource kinds.
+assert_ids "album/alice-view" \
+    "http://localhost:8080/albums?user=alice&action=view" "a1,a2"
+assert_ids "album/bob-manage" \
+    "http://localhost:8080/albums?user=bob&action=manage" "a2"
+assert_ids "album/admin-globex" \
+    "http://localhost:8080/albums?user=admin&role=admin&tenant=globex&action=view" "a3"
+assert_ids "album/always-denied" \
+    "http://localhost:8080/albums?user=alice&action=publish" ""
+
+assert_ids "workspace/alice-access" \
+    "http://localhost:8080/workspaces?user=alice&action=access" "w1"
+assert_ids "workspace/bob-administer" \
+    "http://localhost:8080/workspaces?user=bob&action=administer" "w1"
+assert_ids "workspace/admin-globex" \
+    "http://localhost:8080/workspaces?user=admin&role=admin&tenant=globex&action=access" "w3"
+assert_ids "workspace/always-denied" \
+    "http://localhost:8080/workspaces?user=alice&action=publish" ""
+
+# Prove every successful HTTP assertion above made exactly one PlanResources call with the
+# expected resource/action pair. The full multiset cannot confuse the same action across kinds.
+EXPECTED_PLAN_PAIRS=$(printf '%s\n' \
+    photo/view photo/view photo/view photo/view photo/view \
+    photo/edit photo/edit \
+    photo/comment photo/comment \
+    photo/delete \
+    photo/discover \
+    photo/located \
+    photo/similar photo/similar photo/similar \
+    photo/delegated-view photo/delegated-view photo/delegated-view photo/delegated-view \
+    photo/delegated-view photo/delegated-view photo/delegated-view \
+    photo/group-grant photo/no-group-grant photo/no-group-grant-safe \
+    photo/needs-moderation photo/needs-moderation photo/needs-moderation \
+    photo/fully-reviewed \
+    photo/unlabelled \
+    photo/exactly-one-reviewed \
+    photo/percent-title \
+    photo/underscore-title \
+    photo/publish \
+    album/view album/view album/manage album/publish \
+    workspace/access workspace/access workspace/administer workspace/publish | sort)
+EXPECTED_PLAN_CALLS=$(printf '%s\n' "$EXPECTED_PLAN_PAIRS" | wc -l | tr -d ' ')
+
+OBSERVED_ACCESS_CALLS=$(( $(pdp_access_count) - PDP_ACCESS_BASELINE ))
+if (( OBSERVED_ACCESS_CALLS != EXPECTED_PLAN_CALLS )); then
+    fail "PDP access-log count mismatch: expected=$EXPECTED_PLAN_CALLS got=$OBSERVED_ACCESS_CALLS"
+fi
+
+OBSERVED_PLAN_PAIRS=$(pdp_records_since "$PDP_BASELINE" |
+    jq -r '"\(.planResources.input.resource.kind)/\(.planResources.input.actions | join(","))"' |
+    sort)
+if [[ "$OBSERVED_PLAN_PAIRS" != "$EXPECTED_PLAN_PAIRS" ]]; then
+    diff -u <(printf '%s\n' "$EXPECTED_PLAN_PAIRS") \
+        <(printf '%s\n' "$OBSERVED_PLAN_PAIRS") >&2 || true
+    fail "PDP resource/action multiset did not match the HTTP scenarios"
+fi
+
+MISSING_FILTERS=$(pdp_records_since "$PDP_BASELINE" |
+    jq -s '[.[] | select(.planResources.output.filter.kind == null)] | length')
+if [[ "$MISSING_FILTERS" != "0" ]]; then
+    fail "$MISSING_FILTERS PDP decision records had no query-plan filter output"
+fi
+
+EXPECTED_RESOURCE_KINDS=$(printf '%s\n' album photo workspace)
+OBSERVED_RESOURCE_KINDS=$(pdp_records_since "$PDP_BASELINE" |
+    jq -r '.planResources.input.resource.kind' | sort -u)
+if [[ "$OBSERVED_RESOURCE_KINDS" != "$EXPECTED_RESOURCE_KINDS" ]]; then
+    diff -u <(printf '%s\n' "$EXPECTED_RESOURCE_KINDS") \
+        <(printf '%s\n' "$OBSERVED_RESOURCE_KINDS") >&2 || true
+    fail "PDP resource-kind set did not include exactly album, photo, and workspace"
+fi
+
+ACCESS_CALL_IDS=$(pdp_access_records_since "$PDP_ACCESS_BASELINE" | jq -r '.callId' | sort)
+DECISION_CALL_IDS=$(pdp_records_since "$PDP_BASELINE" | jq -r '.callId' | sort)
+if [[ "$ACCESS_CALL_IDS" != "$DECISION_CALL_IDS" ]]; then
+    diff -u <(printf '%s\n' "$ACCESS_CALL_IDS") \
+        <(printf '%s\n' "$DECISION_CALL_IDS") >&2 || true
+    fail "PDP PlanResources access and decision records did not share the same call IDs"
+fi
+ok "HTTP -> service -> PDP  => $EXPECTED_PLAN_CALLS calls across 3 resource kinds"
+
+# Rejected pagination requests stop in the controller and must not call the PDP. A subsequent
+# valid sentinel is the audit flush barrier: the complete delta must contain only that sentinel.
+PDP_BEFORE_REJECTED=$(pdp_plan_count)
+PDP_ACCESS_BEFORE_REJECTED=$(pdp_access_count)
+assert_status "pagination/negative-page" \
+    "http://localhost:8080/photos/page?user=alice&page=-1&size=1" "400"
+assert_status "pagination/oversized" \
+    "http://localhost:8080/photos/page?user=alice&page=0&size=101" "400"
+assert_status "filter/invalid-rating" \
+    "http://localhost:8080/photos?user=alice&minRating=6" "400"
+SENTINEL_RESPONSE=$(curl -fsS \
+    "http://localhost:8080/photos?user=smoke&action=audit-sentinel" |
+    jq -r 'length')
+if [[ "$SENTINEL_RESPONSE" != "0" ]]; then
+    fail "audit sentinel unexpectedly returned $SENTINEL_RESPONSE photos"
+fi
+verify_pdp_call "audit-sentinel" "audit-sentinel" "photo" \
+    "$PDP_ACCESS_BEFORE_REJECTED" "$PDP_BEFORE_REJECTED"
+ok "controller rejection -> no PDP call"
 
 echo
-echo "==> PDP decision-log tail (proves PlanResources was hit, not stubbed):"
-docker compose logs --tail=20 cerbos | grep -E '"planResources"|callId' || true
+echo "==> Sample verified PDP PlanResources decisions:"
+pdp_records_since "$PDP_BASELINE" | tail -3 |
+    jq -c '{callId, resource: .planResources.input.resource.kind, action: .planResources.input.actions, filter: .planResources.output.filter.kind}'
 
 echo
-ok "all assertions passed"
+ok "all HTTP, database result, and PDP audit assertions passed"

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/AccessContext.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/AccessContext.java
@@ -1,0 +1,32 @@
+package dev.cerbos.example.photos;
+
+import dev.cerbos.sdk.builders.AttributeValue;
+import dev.cerbos.sdk.builders.Principal;
+
+import java.util.Set;
+
+public record AccessContext(String userId, String role, String tenantId,
+                            Set<String> groups, Set<String> interests) {
+
+    public AccessContext {
+        groups = Set.copyOf(groups);
+        interests = Set.copyOf(interests);
+    }
+
+    Principal toPrincipal() {
+        AttributeValue[] groupValues = groups.stream()
+                .map(group -> tenantId + ":" + group)
+                .sorted()
+                .map(AttributeValue::stringValue)
+                .toArray(AttributeValue[]::new);
+        AttributeValue[] interestValues = interests.stream()
+                .sorted()
+                .map(AttributeValue::stringValue)
+                .toArray(AttributeValue[]::new);
+        return Principal.newInstance(userId)
+                .withRoles(role)
+                .withAttribute("tenantId", AttributeValue.stringValue(tenantId))
+                .withAttribute("groups", AttributeValue.listValue(groupValues))
+                .withAttribute("interests", AttributeValue.listValue(interestValues));
+    }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/Album.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/Album.java
@@ -1,0 +1,57 @@
+package dev.cerbos.example.photos;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "albums")
+public class Album {
+
+    @Id
+    private String id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private String tenantId;
+
+    @Column(name = "owner_id", nullable = false)
+    private String ownerId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "is_shared", nullable = false)
+    private boolean shared;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "album_collaborators", joinColumns = @JoinColumn(name = "album_id"))
+    @Column(name = "principal_id")
+    private Set<String> collaborators = new LinkedHashSet<>();
+
+    protected Album() {}
+
+    public Album(String id, String tenantId, String ownerId, String title, boolean shared,
+                 Set<String> collaborators) {
+        this.id = id;
+        this.tenantId = tenantId;
+        this.ownerId = ownerId;
+        this.title = title;
+        this.shared = shared;
+        this.collaborators = new LinkedHashSet<>(collaborators);
+    }
+
+    public String getId() { return id; }
+    public String getTenantId() { return tenantId; }
+    public String getOwnerId() { return ownerId; }
+    public String getTitle() { return title; }
+    public boolean isShared() { return shared; }
+    public Set<String> getCollaborators() { return collaborators; }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/AlbumController.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/AlbumController.java
@@ -1,0 +1,37 @@
+package dev.cerbos.example.photos;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/albums")
+public class AlbumController {
+
+    public record AlbumView(String id, String tenantId, String ownerId, String title,
+                            boolean shared, Set<String> collaborators) {
+        static AlbumView from(Album album) {
+            return new AlbumView(album.getId(), album.getTenantId(), album.getOwnerId(),
+                    album.getTitle(), album.isShared(), album.getCollaborators());
+        }
+    }
+
+    private final AlbumService service;
+
+    public AlbumController(AlbumService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<AlbumView> list(@RequestParam String user,
+                                @RequestParam(defaultValue = "user") String role,
+                                @RequestParam(defaultValue = "acme") String tenant,
+                                @RequestParam(defaultValue = "view") String action) {
+        AccessContext context = new AccessContext(user, role, tenant, Set.of(), Set.of());
+        return service.listAllowed(context, action).stream().map(AlbumView::from).toList();
+    }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/AlbumRepository.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/AlbumRepository.java
@@ -1,0 +1,8 @@
+package dev.cerbos.example.photos;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface AlbumRepository
+        extends JpaRepository<Album, String>, JpaSpecificationExecutor<Album> {
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/AlbumService.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/AlbumService.java
@@ -1,0 +1,41 @@
+package dev.cerbos.example.photos;
+
+import dev.cerbos.queryplan.springdata.AttributeMapping;
+import dev.cerbos.queryplan.springdata.Result;
+import dev.cerbos.queryplan.springdata.SpringDataQueryPlanAdapter;
+import dev.cerbos.sdk.CerbosBlockingClient;
+import dev.cerbos.sdk.PlanResourcesResult;
+import dev.cerbos.sdk.builders.Resource;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class AlbumService {
+
+    private static final Map<String, AttributeMapping> ALBUM_ATTRS = Map.of(
+            "request.resource.attr.tenantId", AttributeMapping.field("tenantId"),
+            "request.resource.attr.ownerId", AttributeMapping.field("ownerId"),
+            "request.resource.attr.shared", AttributeMapping.field("shared"),
+            "request.resource.attr.collaborators", AttributeMapping.relation("collaborators")
+    );
+
+    private final CerbosBlockingClient cerbos;
+    private final AlbumRepository repository;
+
+    public AlbumService(CerbosBlockingClient cerbos, AlbumRepository repository) {
+        this.cerbos = cerbos;
+        this.repository = repository;
+    }
+
+    public List<Album> listAllowed(AccessContext context, String action) {
+        PlanResourcesResult plan = cerbos.plan(
+                context.toPrincipal(), Resource.newInstance("album"), action);
+        Result<Album> result = SpringDataQueryPlanAdapter.toSpecification(plan, ALBUM_ATTRS);
+        Specification<Album> tenantBoundary = (root, query, cb) ->
+                cb.equal(root.get("tenantId"), context.tenantId());
+        return repository.findAll(tenantBoundary.and(result.toSpecification()));
+    }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/Photo.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/Photo.java
@@ -1,15 +1,20 @@
 package dev.cerbos.example.photos;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -23,6 +28,9 @@ public class Photo {
     @Column(name = "owner_id", nullable = false)
     private String ownerId;
 
+    @Column(name = "tenant_id", nullable = false)
+    private String tenantId;
+
     @Column(name = "title", nullable = false)
     private String title;
 
@@ -35,31 +43,62 @@ public class Photo {
     @Column(name = "location")
     private String location;
 
-    // EAGER so the controller can serialize tags after the @Transactional repository call —
-    // the example uses spring.jpa.open-in-view=false to avoid the lazy-init footgun.
+    @Column(name = "rating", nullable = false)
+    private int rating;
+
+    @Embedded
+    private PhotoDetails details;
+
+    // EAGER so the controller can build DTOs after the repository transaction has closed —
+    // the example uses spring.jpa.open-in-view=false to avoid hidden persistence work in the web layer.
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "photo_tags", joinColumns = @JoinColumn(name = "photo_id"))
     @Column(name = "tag")
-    private Set<String> tags = new HashSet<>();
+    private Set<String> tags = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "photo", cascade = CascadeType.ALL, orphanRemoval = true,
+            fetch = FetchType.EAGER)
+    private Set<PhotoLabel> labels = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "photo", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PhotoGrant> grants = new ArrayList<>();
 
     public Photo() {}
 
-    public Photo(String id, String ownerId, String title, boolean isPublic, boolean isArchived,
-                 String location, Set<String> tags) {
+    public Photo(String id, String tenantId, String ownerId, String title, boolean isPublic,
+                 boolean isArchived, String location, int rating, PhotoDetails details,
+                 Set<String> tags) {
         this.id = id;
+        this.tenantId = tenantId;
         this.ownerId = ownerId;
         this.title = title;
         this.isPublic = isPublic;
         this.isArchived = isArchived;
         this.location = location;
+        this.rating = rating;
+        this.details = details;
         this.tags = tags;
     }
 
+    public Photo addLabel(String name, double confidence, boolean reviewed) {
+        labels.add(new PhotoLabel(this, name, confidence, reviewed));
+        return this;
+    }
+
+    public Photo addGrant(String tenantId, String permission, String userId, String groupId) {
+        grants.add(new PhotoGrant(this, tenantId, permission, userId, groupId));
+        return this;
+    }
+
     public String getId() { return id; }
+    public String getTenantId() { return tenantId; }
     public String getOwnerId() { return ownerId; }
     public String getTitle() { return title; }
     public boolean isPublic() { return isPublic; }
     public boolean isArchived() { return isArchived; }
     public String getLocation() { return location; }
+    public int getRating() { return rating; }
+    public PhotoDetails getDetails() { return details; }
     public Set<String> getTags() { return tags; }
+    public Set<PhotoLabel> getLabels() { return labels; }
 }

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoController.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoController.java
@@ -1,22 +1,40 @@
 package dev.cerbos.example.photos;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/photos")
 public class PhotoController {
 
-    public record PhotoView(String id, String ownerId, String title, boolean isPublic,
-                            boolean isArchived, String location, Set<String> tags) {
+    public record LabelView(String name, double confidence, boolean reviewed) {
+        static LabelView from(PhotoLabel label) {
+            return new LabelView(label.getLabelName(), label.getConfidence(), label.isReviewed());
+        }
+    }
+
+    public record PhotoView(String id, String tenantId, String ownerId, String title, boolean isPublic,
+                            boolean isArchived, String location, int rating, int width, int height,
+                            Set<String> tags, Set<LabelView> labels) {
         static PhotoView from(Photo p) {
-            return new PhotoView(p.getId(), p.getOwnerId(), p.getTitle(), p.isPublic(),
-                    p.isArchived(), p.getLocation(), p.getTags());
+            return new PhotoView(p.getId(), p.getTenantId(), p.getOwnerId(), p.getTitle(), p.isPublic(),
+                    p.isArchived(), p.getLocation(), p.getRating(), p.getDetails().getPixelWidth(),
+                    p.getDetails().getPixelHeight(), p.getTags(), p.getLabels().stream()
+                    .map(LabelView::from)
+                    .collect(Collectors.toCollection(LinkedHashSet::new)));
         }
     }
 
@@ -26,11 +44,74 @@ public class PhotoController {
         this.service = service;
     }
 
-    /** GET /photos?user=alice&role=user&action=view */
+    /**
+     * GET /photos?user=alice&role=user&action=view
+     *
+     * <p>Identity, tenant, and groups are request parameters only to make authorization cases
+     * reproducible in this local harness. Production code must derive them from authenticated,
+     * server-side state.
+     */
     @GetMapping
     public List<PhotoView> list(@RequestParam String user,
                                 @RequestParam(defaultValue = "user") String role,
-                                @RequestParam(defaultValue = "view") String action) {
-        return service.listAllowed(user, role, action).stream().map(PhotoView::from).toList();
+                                @RequestParam(defaultValue = "view") String action,
+                                @RequestParam(defaultValue = "acme") String tenant,
+                                @RequestParam(defaultValue = "") String groups,
+                                @RequestParam(defaultValue = "") String interests,
+                                @RequestParam(required = false) Integer minRating) {
+        validateMinRating(minRating);
+        return service.listAllowed(context(user, role, tenant, groups, interests), action, minRating)
+                .stream()
+                .map(PhotoView::from)
+                .toList();
+    }
+
+    /** GET /photos/page?user=alice&action=needs-moderation&page=0&size=1 */
+    @GetMapping("/page")
+    public Page<PhotoView> page(@RequestParam String user,
+                                @RequestParam(defaultValue = "user") String role,
+                                @RequestParam(defaultValue = "view") String action,
+                                @RequestParam(defaultValue = "acme") String tenant,
+                                @RequestParam(defaultValue = "") String groups,
+                                @RequestParam(defaultValue = "") String interests,
+                                @RequestParam(required = false) Integer minRating,
+                                @RequestParam(defaultValue = "0") int page,
+                                @RequestParam(defaultValue = "2") int size) {
+        validateMinRating(minRating);
+        PageRequest pageRequest = pageRequest(page, size);
+        return service.listAllowed(
+                        context(user, role, tenant, groups, interests), action, minRating, pageRequest)
+                .map(PhotoView::from);
+    }
+
+    private static AccessContext context(String user, String role, String tenant,
+                                         String groups, String interests) {
+        return new AccessContext(
+                user, role, tenant, parseCsv(groups), parseCsv(interests));
+    }
+
+    private static void validateMinRating(Integer minRating) {
+        if (minRating != null && (minRating < 0 || minRating > 5)) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "minRating must be between 0 and 5");
+        }
+    }
+
+    private static PageRequest pageRequest(int page, int size) {
+        if (page < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "page must be at least 0");
+        }
+        if (size < 1 || size > 100) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "size must be between 1 and 100");
+        }
+        return PageRequest.of(page, size, Sort.by("id").ascending());
+    }
+
+    private static Set<String> parseCsv(String csv) {
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoDetails.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoDetails.java
@@ -1,0 +1,24 @@
+package dev.cerbos.example.photos;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class PhotoDetails {
+
+    @Column(name = "pixel_width", nullable = false)
+    private int pixelWidth;
+
+    @Column(name = "pixel_height", nullable = false)
+    private int pixelHeight;
+
+    protected PhotoDetails() {}
+
+    public PhotoDetails(int pixelWidth, int pixelHeight) {
+        this.pixelWidth = pixelWidth;
+        this.pixelHeight = pixelHeight;
+    }
+
+    public int getPixelWidth() { return pixelWidth; }
+    public int getPixelHeight() { return pixelHeight; }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoGrant.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoGrant.java
@@ -1,0 +1,46 @@
+package dev.cerbos.example.photos;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "photo_grants")
+public class PhotoGrant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private String tenantId;
+
+    @Column(name = "permission", nullable = false)
+    private String permission;
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(name = "group_id")
+    private String groupId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "photo_id", nullable = false)
+    private Photo photo;
+
+    protected PhotoGrant() {}
+
+    PhotoGrant(Photo photo, String tenantId, String permission, String userId, String groupId) {
+        this.photo = photo;
+        this.tenantId = tenantId;
+        this.permission = permission;
+        this.userId = userId;
+        this.groupId = groupId;
+    }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoLabel.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoLabel.java
@@ -1,0 +1,46 @@
+package dev.cerbos.example.photos;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "photo_labels")
+public class PhotoLabel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "label_name", nullable = false)
+    private String labelName;
+
+    @Column(name = "confidence", nullable = false)
+    private double confidence;
+
+    @Column(name = "reviewed", nullable = false)
+    private boolean reviewed;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "photo_id", nullable = false)
+    private Photo photo;
+
+    protected PhotoLabel() {}
+
+    PhotoLabel(Photo photo, String labelName, double confidence, boolean reviewed) {
+        this.photo = photo;
+        this.labelName = labelName;
+        this.confidence = confidence;
+        this.reviewed = reviewed;
+    }
+
+    public String getLabelName() { return labelName; }
+    public double getConfidence() { return confidence; }
+    public boolean isReviewed() { return reviewed; }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoService.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoService.java
@@ -5,8 +5,10 @@ import dev.cerbos.queryplan.springdata.Result;
 import dev.cerbos.queryplan.springdata.SpringDataQueryPlanAdapter;
 import dev.cerbos.sdk.CerbosBlockingClient;
 import dev.cerbos.sdk.PlanResourcesResult;
-import dev.cerbos.sdk.builders.Principal;
 import dev.cerbos.sdk.builders.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,15 +20,31 @@ public class PhotoService {
     /**
      * Maps Cerbos resource-attribute paths used in the policy to JPA paths on {@link Photo}.
      * The Spring Data adapter translates each plan operand to {@code root.get(...)} via this
-     * mapping. {@code tags} is an {@code @ElementCollection<String>} — declaring it as a
-     * relation makes the adapter emit a correlated {@code EXISTS} subquery for the CEL
-     * {@code "x" in tags} predicate.
+     * mapping. Declaring {@code tags} and {@code labels} as relations makes collection operators
+     * emit correlated subqueries; the nested labels map also decouples policy field names from
+     * Java property names.
      */
-    private static final Map<String, AttributeMapping> PHOTO_ATTRS = Map.of(
-            "request.resource.attr.ownerId", AttributeMapping.field("ownerId"),
-            "request.resource.attr.public", AttributeMapping.field("isPublic"),
-            "request.resource.attr.archived", AttributeMapping.field("isArchived"),
-            "request.resource.attr.tags", AttributeMapping.relation("tags")
+    private static final Map<String, AttributeMapping> PHOTO_ATTRS = Map.ofEntries(
+            Map.entry("request.resource.attr.ownerId", AttributeMapping.field("ownerId")),
+            Map.entry("request.resource.attr.tenantId", AttributeMapping.field("tenantId")),
+            Map.entry("request.resource.attr.public", AttributeMapping.field("isPublic")),
+            Map.entry("request.resource.attr.archived", AttributeMapping.field("isArchived")),
+            Map.entry("request.resource.attr.title", AttributeMapping.field("title")),
+            Map.entry("request.resource.attr.location", AttributeMapping.field("location")),
+            Map.entry("request.resource.attr.rating", AttributeMapping.field("rating")),
+            Map.entry("request.resource.attr.metadata.width", AttributeMapping.field("details.pixelWidth")),
+            Map.entry("request.resource.attr.tags", AttributeMapping.relation("tags")),
+            Map.entry("request.resource.attr.labels", AttributeMapping.relation("labels", Map.of(
+                    "name", AttributeMapping.field("labelName"),
+                    "confidence", AttributeMapping.field("confidence"),
+                    "reviewed", AttributeMapping.field("reviewed")
+            ))),
+            Map.entry("request.resource.attr.grants", AttributeMapping.relation("grants", Map.of(
+                    "tenantId", AttributeMapping.field("tenantId"),
+                    "permission", AttributeMapping.field("permission"),
+                    "userId", AttributeMapping.field("userId"),
+                    "groupId", AttributeMapping.field("groupId")
+            )))
     );
 
     private final CerbosBlockingClient cerbos;
@@ -37,13 +55,30 @@ public class PhotoService {
         this.repository = repository;
     }
 
-    public List<Photo> listAllowed(String userId, String role, String action) {
+    public List<Photo> listAllowed(AccessContext context, String action, Integer minRating) {
+        return repository.findAll(specification(context, action, minRating));
+    }
+
+    public Page<Photo> listAllowed(AccessContext context, String action, Integer minRating,
+                                   Pageable pageable) {
+        return repository.findAll(specification(context, action, minRating), pageable);
+    }
+
+    private Specification<Photo> specification(AccessContext context, String action,
+                                                Integer minRating) {
         PlanResourcesResult plan = cerbos.plan(
-                Principal.newInstance(userId).withRoles(role),
+                context.toPrincipal(),
                 Resource.newInstance("photo"),
                 action);
 
         Result<Photo> result = SpringDataQueryPlanAdapter.toSpecification(plan, PHOTO_ATTRS);
-        return repository.findAll(result.toSpecification());
+        Specification<Photo> tenantBoundary = (root, query, cb) ->
+                cb.equal(root.get("tenantId"), context.tenantId());
+        Specification<Photo> specification = tenantBoundary.and(result.toSpecification());
+        if (minRating != null) {
+            specification = specification.and((root, query, cb) ->
+                    cb.greaterThanOrEqualTo(root.get("rating"), minRating));
+        }
+        return specification;
     }
 }

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/SeedData.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/SeedData.java
@@ -3,32 +3,78 @@ package dev.cerbos.example.photos;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Set;
 
 @Component
 public class SeedData implements CommandLineRunner {
 
-    private final PhotoRepository repository;
+    private final PhotoRepository photoRepository;
+    private final AlbumRepository albumRepository;
+    private final WorkspaceRepository workspaceRepository;
 
-    public SeedData(PhotoRepository repository) {
-        this.repository = repository;
+    public SeedData(PhotoRepository photoRepository, AlbumRepository albumRepository,
+                    WorkspaceRepository workspaceRepository) {
+        this.photoRepository = photoRepository;
+        this.albumRepository = albumRepository;
+        this.workspaceRepository = workspaceRepository;
     }
 
     @Override
     public void run(String... args) {
-        repository.saveAll(java.util.List.of(
-                new Photo("p1", "alice",   "Beach sunset",   true,  false, "Lisbon",
-                        Set.of("travel", "sunset")),
-                new Photo("p2", "alice",   "Family lunch",   false, false, "Home",
-                        Set.of("friends", "food")),
-                new Photo("p3", "bob",     "Wedding",        true,  true,  "Paris",
-                        Set.of("wedding")),
-                new Photo("p4", "bob",     "Selfie",         false, false, "Studio",
-                        Set.of("portrait")),
-                new Photo("p5", "charlie", "Mountain hike",  true,  false, "Alps",
-                        Set.of("travel", "outdoors", "friends")),
-                new Photo("p6", "alice",   "Old archive",    false, true,  "Home",
-                        Set.of("legacy"))
+        photoRepository.saveAll(List.of(
+                new Photo("p1", "acme", "alice",   "Beach sunset",   true,  false, "Lisbon",
+                        5, new PhotoDetails(4000, 3000), Set.of("travel", "sunset"))
+                        .addLabel("editorial", 0.95, true)
+                        .addGrant("acme", "view", null, null),
+                new Photo("p2", "acme", "alice",   "Family lunch",   false, false, null,
+                        3, new PhotoDetails(1600, 1200), Set.of("friends", "food"))
+                        .addLabel("safety", 0.90, false)
+                        .addLabel("safety", 0.85, false)
+                        .addLabel("faces", 0.60, true)
+                        .addGrant("acme", "view", null, null)
+                        .addGrant("acme", "view", null, "acme:finance"),
+                new Photo("p3", "acme", "bob",     "Wedding",        true,  true,  "Paris",
+                        4, new PhotoDetails(6000, 4000), Set.of("wedding"))
+                        .addLabel("safety", 0.95, true)
+                        .addGrant("acme", "view", null, null)
+                        .addGrant("acme", "view", null, "acme:sales")
+                        .addGrant("acme", "view", "alice", null),
+                new Photo("p4", "acme", "bob",     "Selfie",         false, false, "Studio",
+                        2, new PhotoDetails(800, 600), Set.of("portrait"))
+                        .addGrant("globex", "view", null, "acme:legal"),
+                new Photo("p5", "acme", "charlie", "Mountain hike",  true,  false, "Alps",
+                        5, new PhotoDetails(5000, 3500), Set.of("travel", "outdoors", "friends"))
+                        .addLabel("quality", 0.90, true)
+                        .addLabel("safety", 0.40, false)
+                        .addGrant("acme", "view", null, "acme:engineering")
+                        .addGrant("acme", "view", null, "acme:engineering"),
+                new Photo("p6", "acme", "alice",   "Old archive",    false, true,  "Home",
+                        1, new PhotoDetails(1024, 768), Set.of("legacy")),
+                new Photo("p7", "acme", "dana",    "100% coverage",  true,  false, null,
+                        4, new PhotoDetails(3200, 1800), Set.of())
+                        .addGrant("acme", "edit", null, "acme:finance"),
+                new Photo("p8", "acme", "erin",    "Under_score",    true,  false, "Tokyo",
+                        4, new PhotoDetails(3200, 2400), Set.of("unicode", "旅行"))
+                        .addGrant("acme", "view", "bob", null),
+                new Photo("p9", "globex", "globex-user", "Confidential acquisition",
+                        false, true, null, 2, new PhotoDetails(800, 600), Set.of("globex"))
+                        .addGrant("globex", "view", null, "globex:finance")
+        ));
+
+        albumRepository.saveAll(List.of(
+                new Album("a1", "acme", "alice", "Launch campaign", false, Set.of("bob")),
+                new Album("a2", "acme", "bob", "Company offsite", true, Set.of("alice")),
+                new Album("a3", "globex", "globex-user", "Acquisition room", true, Set.of()),
+                new Album("a4", "acme", "charlie", "Board drafts", false, Set.of())
+        ));
+
+        workspaceRepository.saveAll(List.of(
+                new Workspace("w1", "acme", "bob", "Production", true, Set.of("alice")),
+                new Workspace("w2", "acme", "alice", "Suspended migration", false,
+                        Set.of("charlie")),
+                new Workspace("w3", "globex", "globex-user", "M&A", true, Set.of("alice")),
+                new Workspace("w4", "acme", "charlie", "Finance", true, Set.of())
         ));
     }
 }

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/Workspace.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/Workspace.java
@@ -1,0 +1,57 @@
+package dev.cerbos.example.photos;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "workspaces")
+public class Workspace {
+
+    @Id
+    private String id;
+
+    @Column(name = "tenant_id", nullable = false)
+    private String tenantId;
+
+    @Column(name = "owner_id", nullable = false)
+    private String ownerId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "workspace_members", joinColumns = @JoinColumn(name = "workspace_id"))
+    @Column(name = "principal_id")
+    private Set<String> members = new LinkedHashSet<>();
+
+    protected Workspace() {}
+
+    public Workspace(String id, String tenantId, String ownerId, String name, boolean active,
+                     Set<String> members) {
+        this.id = id;
+        this.tenantId = tenantId;
+        this.ownerId = ownerId;
+        this.name = name;
+        this.active = active;
+        this.members = new LinkedHashSet<>(members);
+    }
+
+    public String getId() { return id; }
+    public String getTenantId() { return tenantId; }
+    public String getOwnerId() { return ownerId; }
+    public String getName() { return name; }
+    public boolean isActive() { return active; }
+    public Set<String> getMembers() { return members; }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/WorkspaceController.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/WorkspaceController.java
@@ -1,0 +1,38 @@
+package dev.cerbos.example.photos;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/workspaces")
+public class WorkspaceController {
+
+    public record WorkspaceView(String id, String tenantId, String ownerId, String name,
+                                boolean active, Set<String> members) {
+        static WorkspaceView from(Workspace workspace) {
+            return new WorkspaceView(workspace.getId(), workspace.getTenantId(),
+                    workspace.getOwnerId(), workspace.getName(), workspace.isActive(),
+                    workspace.getMembers());
+        }
+    }
+
+    private final WorkspaceService service;
+
+    public WorkspaceController(WorkspaceService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<WorkspaceView> list(@RequestParam String user,
+                                    @RequestParam(defaultValue = "user") String role,
+                                    @RequestParam(defaultValue = "acme") String tenant,
+                                    @RequestParam(defaultValue = "access") String action) {
+        AccessContext context = new AccessContext(user, role, tenant, Set.of(), Set.of());
+        return service.listAllowed(context, action).stream().map(WorkspaceView::from).toList();
+    }
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/WorkspaceRepository.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/WorkspaceRepository.java
@@ -1,0 +1,8 @@
+package dev.cerbos.example.photos;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface WorkspaceRepository
+        extends JpaRepository<Workspace, String>, JpaSpecificationExecutor<Workspace> {
+}

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/WorkspaceService.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/WorkspaceService.java
@@ -1,0 +1,42 @@
+package dev.cerbos.example.photos;
+
+import dev.cerbos.queryplan.springdata.AttributeMapping;
+import dev.cerbos.queryplan.springdata.Result;
+import dev.cerbos.queryplan.springdata.SpringDataQueryPlanAdapter;
+import dev.cerbos.sdk.CerbosBlockingClient;
+import dev.cerbos.sdk.PlanResourcesResult;
+import dev.cerbos.sdk.builders.Resource;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class WorkspaceService {
+
+    private static final Map<String, AttributeMapping> WORKSPACE_ATTRS = Map.of(
+            "request.resource.attr.tenantId", AttributeMapping.field("tenantId"),
+            "request.resource.attr.ownerId", AttributeMapping.field("ownerId"),
+            "request.resource.attr.active", AttributeMapping.field("active"),
+            "request.resource.attr.members", AttributeMapping.relation("members")
+    );
+
+    private final CerbosBlockingClient cerbos;
+    private final WorkspaceRepository repository;
+
+    public WorkspaceService(CerbosBlockingClient cerbos, WorkspaceRepository repository) {
+        this.cerbos = cerbos;
+        this.repository = repository;
+    }
+
+    public List<Workspace> listAllowed(AccessContext context, String action) {
+        PlanResourcesResult plan = cerbos.plan(
+                context.toPrincipal(), Resource.newInstance("workspace"), action);
+        Result<Workspace> result =
+                SpringDataQueryPlanAdapter.toSpecification(plan, WORKSPACE_ATTRS);
+        Specification<Workspace> tenantBoundary = (root, query, cb) ->
+                cb.equal(root.get("tenantId"), context.tenantId());
+        return repository.findAll(tenantBoundary.and(result.toSpecification()));
+    }
+}


### PR DESCRIPTION
## Summary
- Expand the Spring Data example with album, photo, and workspace models and services
- Add Cerbos policies, access context handling, seed data, and smoke-test coverage
- Update the example README with the expanded workflow

## Testing
Not run (not requested)