### PR TITLE
fix(spring-data): document collation requirements and add real-database oracle CI legs

### DIFF
--- a/.github/workflows/spring-data.yaml
+++ b/.github/workflows/spring-data.yaml
@@ -34,3 +34,31 @@ jobs:
 
       - name: Build and test
         run: gradle build --no-daemon
+
+  # Runs the full suite with AdversarialConformanceTest (the differential check()-oracle)
+  # backed by a real database via Testcontainers instead of in-memory H2. Guards against
+  # dialect divergences H2 cannot surface — most importantly the collation over-grant
+  # documented in spring-data/README.md "Database collation requirements": the MySQL leg
+  # creates its schema with utf8mb4_0900_as_cs; the suite's mixed-case seeds fail the
+  # oracle comparison on MySQL's default case-insensitive collation.
+  test-database:
+    strategy:
+      matrix:
+        database: ["postgres", "mysql"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup JDK
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Build and test (${{ matrix.database }})
+        run: gradle build --no-daemon
+        env:
+          ADAPTER_TEST_DB: ${{ matrix.database }}

--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -87,6 +87,62 @@ Page<Contact> results = contactRepository.findAll(
     own.and(result.toSpecification()), pageable);
 ```
 
+## Database collation requirements
+
+> **⚠️ Hard requirement: every string column referenced by an `AttributeMapping` MUST use a
+> binary or case-sensitive collation.** On MySQL use `utf8mb4_bin` or `utf8mb4_0900_as_cs`;
+> on SQL Server use a `*_CS_AS` collation (e.g. `Latin1_General_100_CS_AS`). PostgreSQL,
+> H2, and Oracle are case-sensitive by default and are safe unless you opt into
+> case-insensitive behavior (PostgreSQL nondeterministic `ICU` collations, `citext`).
+
+**Why.** CEL string comparison at the PDP is exact and case-sensitive: with
+`R.attr.department == "finance"`, a `check()` call for a resource holding
+`department = "Finance"` returns **DENY**. But the adapter builds every string predicate
+with no collation control, so the database's column collation decides what matches. MySQL
+8's default collation, `utf8mb4_0900_ai_ci`, is case- **and** accent-insensitive, and SQL
+Server defaults to CI collations — on those defaults `WHERE department = 'finance'`
+matches the `'Finance'` row the PDP just denied. The plan-based filter silently returns
+rows the policy denies: **an authorization over-grant**, with no error or log line to
+notice. The same divergence applies to accent folding (`'résumé'` vs `'resume'`).
+
+**Every string predicate the adapter emits is affected:**
+
+- `eq` / `ne` (`cb.equal` / `cb.notEqual`)
+- string ordering: `lt` / `gt` / `le` / `ge`
+- the LIKE family: `contains` / `startsWith` / `endsWith`, including the constant-receiver
+  forms and the field-to-field variants built from `REPLACE`-escaped column patterns
+- `in` list membership (`path.in(...)`)
+- `hasIntersection` (both the direct-collection and `map(...)`-projection translations)
+- `hierarchy(...)` ancestor/descendant checks (prefix `LIKE` and ancestor-prefix `IN` lists)
+
+**`OperatorFunction` overrides are not a workaround for all of these.** In particular, the
+`hasIntersection` translation over a plain field (`path.in(values)`) is built before any
+override consultation, so a user-supplied `OperatorFunction` cannot intercept it. Fix the
+collation in the schema — that is the only route that covers every predicate site.
+
+Role and tenancy checks are the highest-risk shapes: `'admin'` vs `'Admin'` under
+`eq`/`in`/`hasIntersection`, and hierarchy descendant checks where `LIKE 'a:b:%'` matches
+`'A:B:x'`.
+
+**How this is enforced in CI.** The differential oracle suite
+(`AdversarialConformanceTest`) runs against real PostgreSQL and MySQL databases via
+Testcontainers, with mixed-case seed rows whose `check()` decisions differ from what a
+case-insensitive collation would match. The MySQL leg creates its schema with
+`utf8mb4_0900_as_cs`; running it against MySQL's default collation makes the suite fail,
+demonstrating the over-grant. Run the legs locally:
+
+```bash
+# PostgreSQL (case-sensitive by default — passes)
+ADAPTER_TEST_DB=postgres gradle test --tests AdversarialConformanceTest
+
+# MySQL with the required case-sensitive collation — passes
+ADAPTER_TEST_DB=mysql gradle test --tests AdversarialConformanceTest
+
+# MySQL with its DEFAULT collation — FAILS, reproducing the over-grant
+ADAPTER_TEST_DB=mysql ADAPTER_TEST_MYSQL_COLLATION=utf8mb4_0900_ai_ci \
+  gradle test --tests AdversarialConformanceTest
+```
+
 ## Field mapping
 
 Map each `request.resource.attr.<name>` to a JPA path or a relation:

--- a/spring-data/build.gradle.kts
+++ b/spring-data/build.gradle.kts
@@ -33,6 +33,12 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.testcontainers:testcontainers:1.21.3")
     testImplementation("org.testcontainers:junit-jupiter:1.21.3")
+    // Real-database legs for AdversarialConformanceTest (selected via ADAPTER_TEST_DB /
+    // -Dadapter.test.db): PostgreSQL and MySQL containers + their JDBC drivers.
+    testImplementation("org.testcontainers:postgresql:1.21.3")
+    testImplementation("org.testcontainers:mysql:1.21.3")
+    testRuntimeOnly("org.postgresql:postgresql:42.7.7")
+    testRuntimeOnly("com.mysql:mysql-connector-j:9.3.0")
     testImplementation("org.hibernate.orm:hibernate-core:6.6.18.Final")
     testImplementation("com.h2database:h2:2.3.232")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -55,5 +61,19 @@ tasks.test {
     }
     if (cerbosPort != null) {
         environment("CERBOS_PORT", cerbosPort)
+    }
+    // Select the database backing AdversarialConformanceTest: h2 (default), postgres, or
+    // mysql. The MySQL leg creates its schema with a case-sensitive collation by default
+    // (utf8mb4_0900_as_cs); override adapter.test.mysql.collation to reproduce the
+    // over-grant on MySQL's default utf8mb4_0900_ai_ci — see the README
+    // "Database collation requirements" section.
+    val adapterTestDb = System.getProperty("adapter.test.db") ?: System.getenv("ADAPTER_TEST_DB")
+    if (adapterTestDb != null) {
+        systemProperty("adapter.test.db", adapterTestDb)
+    }
+    val mysqlCollation = System.getProperty("adapter.test.mysql.collation")
+        ?: System.getenv("ADAPTER_TEST_MYSQL_COLLATION")
+    if (mysqlCollation != null) {
+        systemProperty("adapter.test.mysql.collation", mysqlCollation)
     }
 }

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.jpa.domain.Specification;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.Transferable;
@@ -56,6 +59,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * negative numbers — and the policies use planner shapes the conformance policies don't
  * (value-first comparisons, empty {@code in} lists, fractional thresholds against integer
  * columns, outer attribute references two lambda levels deep).
+ *
+ * <p><strong>Database selection.</strong> By default the suite runs on in-memory H2. Set the
+ * {@code adapter.test.db} system property (forwarded from the {@code ADAPTER_TEST_DB} env var
+ * by the Gradle build) to {@code postgres} or {@code mysql} to run the same differential oracle
+ * against a real database started via Testcontainers — the same pattern used for the Cerbos PDP
+ * container above. The MySQL leg creates its schema with the case-sensitive
+ * {@code utf8mb4_0900_as_cs} collation the README requires; running it with MySQL's default
+ * case/accent-insensitive collation ({@code -Dadapter.test.mysql.collation=utf8mb4_0900_ai_ci})
+ * makes the mixed-case seeds (c1/c2) fail the oracle comparison, reproducing the silent
+ * authorization over-grant documented in the README's "Database collation requirements" section.
  */
 class AdversarialConformanceTest {
 
@@ -138,7 +151,19 @@ class AdversarialConformanceTest {
             new Seed("b5", true, "nulltag", 9, "nt",
                     List.of(new Tag("t10a", null)), List.of()),
             new Seed("b6", false, "mixed", 10, "mx",
-                    List.of(new Tag("t11a", null), new Tag("t11b", "public")), List.of())
+                    List.of(new Tag("t11a", null), new Tag("t11b", "public")), List.of()),
+            // Mixed-case collation witnesses: CEL string comparison at the PDP is exact and
+            // case-sensitive, so check() DENIES these rows for the lowercase constants the
+            // policies use ("one", "public", "finance", "a_b") — but a case-insensitive
+            // database collation (MySQL default utf8mb4_0900_ai_ci, SQL Server *_CI_*)
+            // matches them anyway, and the differential oracle catches the over-grant.
+            // c1 discriminates eq/in ("One" vs "one"), relation membership and
+            // hasIntersection ("Public" vs the principal's "public"), and nested-relation
+            // equality ("Finance" vs "finance"); c2 discriminates the LIKE family
+            // ("xA_by" wrongly matches contains("a_b") under a CI collation).
+            new Seed("c1", true, "One", 11, "Set",
+                    List.of(new Tag("tc1", "Public")), List.of("Finance")),
+            new Seed("c2", false, "xA_by", 12, null, List.of(), List.of())
     );
 
     /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
@@ -149,6 +174,8 @@ class AdversarialConformanceTest {
     private static GenericContainer<?> cerbos;
     private static CerbosBlockingClient client;
     private static EntityManagerFactory emf;
+    /** Non-null only when {@code adapter.test.db} selects a real database. */
+    private static JdbcDatabaseContainer<?> database;
 
     @BeforeAll
     static void setUp() throws Exception {
@@ -169,13 +196,72 @@ class AdversarialConformanceTest {
         client = new CerbosClientBuilder(cerbos.getHost() + ":" + cerbos.getMappedPort(3593))
                 .withPlaintext().buildBlockingClient();
 
-        emf = Persistence.createEntityManagerFactory("adversarial-pu");
+        emf = createEntityManagerFactory();
         seed();
+    }
+
+    /**
+     * Builds the EntityManagerFactory for the database selected by {@code adapter.test.db}:
+     * the H2-backed persistence unit as-is (default), or the same unit with its JDBC
+     * connection properties overridden to point at a Testcontainers-managed PostgreSQL or
+     * MySQL instance.
+     */
+    private static EntityManagerFactory createEntityManagerFactory() {
+        String db = System.getProperty("adapter.test.db", "h2");
+        switch (db) {
+            case "h2":
+                return Persistence.createEntityManagerFactory("adversarial-pu");
+            case "postgres": {
+                PostgreSQLContainer<?> pg = new PostgreSQLContainer<>("postgres:16");
+                pg.start();
+                database = pg;
+                return Persistence.createEntityManagerFactory(
+                        "adversarial-pu", jdbcOverrides(pg, "org.hibernate.dialect.PostgreSQLDialect"));
+            }
+            case "mysql": {
+                // Case-sensitive server collation by default, per the README's
+                // "Database collation requirements" section. Overriding this with MySQL's
+                // default utf8mb4_0900_ai_ci reproduces the collation over-grant: the
+                // mixed-case seeds (c1/c2) then diverge from the check() oracle.
+                String collation = System.getProperty(
+                        "adapter.test.mysql.collation", "utf8mb4_0900_as_cs");
+                MySQLContainer<?> my = new MySQLContainer<>("mysql:8.4")
+                        .withCommand("--character-set-server=utf8mb4",
+                                "--collation-server=" + collation)
+                        // Server-side prepared statements so JDBC double binds keep their
+                        // type. Connector/J's default client-side prepared statements
+                        // interpolate double parameters as DECIMAL literals, and Hibernate's
+                        // MySQLDialect renders the adapter's to-double casts as
+                        // decimal(53,20) — together that evaluates the adapter's double-space
+                        // arithmetic in exact decimal (3 * 0.1 == 0.3 becomes TRUE, diverging
+                        // from CEL IEEE semantics; p-double-frac is the witness). With typed
+                        // double binds the decimal*double product promotes to double and the
+                        // oracle agrees. Verified empirically on MySQL 8.4.
+                        .withUrlParam("useServerPrepStmts", "true");
+                my.start();
+                database = my;
+                return Persistence.createEntityManagerFactory(
+                        "adversarial-pu", jdbcOverrides(my, "org.hibernate.dialect.MySQLDialect"));
+            }
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown adapter.test.db '" + db + "' (expected h2, postgres, or mysql)");
+        }
+    }
+
+    private static Map<String, Object> jdbcOverrides(JdbcDatabaseContainer<?> c, String dialect) {
+        return Map.of(
+                "jakarta.persistence.jdbc.url", c.getJdbcUrl(),
+                "jakarta.persistence.jdbc.driver", c.getDriverClassName(),
+                "jakarta.persistence.jdbc.user", c.getUsername(),
+                "jakarta.persistence.jdbc.password", c.getPassword(),
+                "hibernate.dialect", dialect);
     }
 
     @AfterAll
     static void tearDown() {
         if (emf != null) emf.close();
+        if (database != null) database.stop();
         if (cerbos != null) cerbos.stop();
     }
 
@@ -312,6 +398,10 @@ class AdversarialConformanceTest {
             "in-single", "in-empty",
             "like-percent", "like-underscore", "like-backslash",
             "unicode-eq", "empty-string-eq",
+            // explicit case-sensitivity witness (c1/c2 seeds also discriminate in-single,
+            // like-underscore, lambda-in-principal, and p-hasintersection-map on
+            // case-insensitive database collations — see the README collation section)
+            "cs-eq",
             "neg-number", "double-threshold",
             "all-on-empty", "exists-on-empty", "exists-one-multi", "not-exists",
             "outer-attr-depth2", "lambda-in-principal",

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -68,6 +68,18 @@ resourcePolicy:
         match:
           expr: R.attr.aString.endsWith("\\")
 
+    # -- case sensitivity: CEL string equality is exact and case-sensitive, so the c1 seed
+    # (aString "One") is DENIED here. A case-insensitive database collation (MySQL default
+    # utf8mb4_0900_ai_ci, SQL Server *_CI_*) matches it anyway — the differential oracle
+    # turns that into a test failure, proving the over-grant. See the README's
+    # "Database collation requirements" section.
+    - actions: ["cs-eq"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: R.attr.aString == "one"
+
     # -- string edge values --
     - actions: ["unicode-eq"]
       effect: EFFECT_ALLOW


### PR DESCRIPTION
## Problem

CEL string comparison at the PDP is **exact and case-sensitive**, but every string predicate the Spring Data adapter builds (`cb.equal`/`notEqual`, string ordering, the `LIKE` family, `path.in`, `hasIntersection`, hierarchy prefix checks) binds with no collation control — the database's column collation decides what matches. On MySQL 8's default `utf8mb4_0900_ai_ci` (case- **and** accent-insensitive) and SQL Server's default CI collations, the generated `WHERE` clause matches rows the PDP's `check()` API denies: a **silent authorization over-grant**, with no error or log line to notice.

Example: policy `R.attr.department == "finance"`, row `department = 'Finance'` → `check()` returns DENY, but `WHERE department = 'finance'` on `utf8mb4_0900_ai_ci` returns the row.

Until now nothing could catch this: both test persistence units run on in-memory H2 (case-sensitive), and CI had no database dimension.

## Empirical evidence

Running the differential check()-oracle suite (`AdversarialConformanceTest`) against MySQL 8.4 with its **default** collation, 24 of 81 oracle comparisons fail — the extra rows are exactly the mixed-case fixtures the PDP denies:

```
cs-eq                 expected: <[a1]> but was: <[a1, c1]>            # eq
in-single             expected: <[a1]> but was: <[a1, c1]>            # in
like-underscore       expected: <[a4]> but was: <[a4, c2]>            # LIKE family
lambda-in-principal   expected: <[..., b6]> but was: <[..., b6, c1]>  # relation IN
p-hasintersection-map expected: <[..., a8]> but was: <[..., a8, c1]>  # hasIntersection
```

(24 failing actions in total, spanning eq/ne, in, LIKE, relation membership, hasIntersection, and nested-relation equality.)

With the schema created under `utf8mb4_0900_as_cs`, all 81 comparisons agree with the PDP.

## What this PR adds

**Documentation** — a prominent "Database collation requirements" section in `spring-data/README.md`: binary/case-sensitive collations are a hard requirement on every mapped string column (MySQL `utf8mb4_bin` / `utf8mb4_0900_as_cs`, SQL Server `*_CS_AS`), why (CEL exact-match vs CI collations = over-grant), the full list of affected predicate shapes, and an explicit note that the `hasIntersection` plain-field translation (`path.in`) is built before the `OperatorFunction` override hook, so overrides cannot intercept it — the schema collation is the only complete fix.

**Real-database CI legs** — `AdversarialConformanceTest` can now run its differential oracle against real PostgreSQL 16 and MySQL 8.4 via Testcontainers (same pattern as the existing PDP container), selected with `ADAPTER_TEST_DB=postgres|mysql` / `-Dadapter.test.db`. New mixed-case seed rows (`c1`, `c2`) plus an explicit `cs-eq` action make the oracle discriminate collation behavior. The MySQL leg creates its schema with the documented `utf8mb4_0900_as_cs` collation (so the suite passes while exercising real MySQL semantics); `ADAPTER_TEST_MYSQL_COLLATION=utf8mb4_0900_ai_ci` reproduces the over-grant on demand. `.github/workflows/spring-data.yaml` gains a `test-database` job with a `postgres`/`mysql` matrix.

**Follow-up observed while building the MySQL leg** (not fixed here, noted in a test comment): Hibernate's MySQLDialect renders the adapter's to-double casts as `decimal(53,20)`, and Connector/J's default *client-side* prepared statements interpolate double binds as DECIMAL literals — together the adapter's IEEE double-space arithmetic evaluates in exact decimal on MySQL (`3 * 0.1 == 0.3` becomes TRUE, diverging from CEL; verified on MySQL 8.4). The MySQL leg sets `useServerPrepStmts=true` so binds keep their JDBC types, which restores IEEE semantics and keeps `p-double-frac` honest. This deserves its own README caveat/issue.

## Test results

All runs via the Docker Gradle toolchain (`gradle:8.12-jdk17`, Testcontainers on the host socket), full `gradle build` on the final code state:

| Leg | Result |
|---|---|
| H2 (default) | `357 tests` — **BUILD SUCCESSFUL** |
| PostgreSQL 16 (`ADAPTER_TEST_DB=postgres`) | `357 tests` — **BUILD SUCCESSFUL** |
| MySQL 8.4 `utf8mb4_0900_as_cs` (`ADAPTER_TEST_DB=mysql`) | `357 tests` — **BUILD SUCCESSFUL** |
| MySQL 8.4 `utf8mb4_0900_ai_ci` (negative control) | `81 tests completed, 24 failed` — **BUILD FAILED** (expected: proves the over-grant) |

No adapter translation semantics change in this PR — a collation-forcing translation mode can be a follow-up.

---

This is finding 1/27 from an internal adversarial production-readiness review of the spring-data adapter.
