### PR TITLE
fix(spring-data): guard delete(Specification) against collection-row corruption

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -87,6 +87,25 @@ Page<Contact> results = contactRepository.findAll(
     own.and(result.toSpecification()), pageable);
 ```
 
+> [!WARNING]
+> **The Specification is SELECT-only.** Never pass it to
+> `repository.delete(Specification)` or any other criteria bulk operation. Relation
+> mappings translate to correlated subqueries over collection/join tables, and
+> Hibernate's multi-table bulk delete first clears those `@ElementCollection`/join
+> tables using the same predicate — the pre-clear removes exactly the rows the
+> correlated subquery references, so the delete removes **0 entity rows while
+> silently destroying their collection rows** (e.g. all ownership entries). Under a
+> blocklist policy like `!(P.id in R.attr.ownedBy)`, the now-ownerless survivors
+> become visible to every principal. The adapter detects the bulk-delete invocation
+> context and throws `UnsupportedOperationException` before anything is deleted.
+> To delete policy-permitted rows, select ids first, then delete by id:
+>
+> ```java
+> List<Long> ids = contactRepository.findAll(result.toSpecification())
+>         .stream().map(Contact::getId).toList();
+> contactRepository.deleteAllById(ids);
+> ```
+
 ## Field mapping
 
 Map each `request.resource.attr.<name>` to a JPA path or a relation:

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/Result.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/Result.java
@@ -18,6 +18,24 @@ public sealed interface Result<T> permits Result.AlwaysAllowed, Result.AlwaysDen
      *       {@code findAll(spec, Pageable)}), so callers must not cache the produced
      *       {@code Predicate} across query executions.</li>
      * </ul>
+     *
+     * <p><strong>The Specification is SELECT-only.</strong> Never pass it to
+     * {@code JpaSpecificationExecutor.delete(Specification)} or any other criteria bulk
+     * operation. When the attribute mapping contains {@link AttributeMapping.Relation}
+     * entries, the translation builds correlated subqueries over collection/join tables, and
+     * Hibernate's multi-table bulk delete first clears those {@code @ElementCollection}/join
+     * tables using the same predicate — self-invalidating the correlated subquery so that
+     * 0 entity rows are deleted while their collection rows are silently destroyed (which can
+     * in turn flip the outcome of ownership/blocklist policies for the surviving rows). The
+     * adapter detects the bulk-delete invocation context and throws
+     * {@link UnsupportedOperationException} before anything is deleted. To delete
+     * policy-permitted rows, select first and delete by id:
+     *
+     * <pre>{@code
+     * List<Long> ids = repository.findAll(result.toSpecification())
+     *         .stream().map(MyEntity::getId).toList();
+     * repository.deleteAllById(ids);
+     * }</pre>
      */
     Specification<T> toSpecification();
 
@@ -50,6 +68,13 @@ public sealed interface Result<T> permits Result.AlwaysAllowed, Result.AlwaysDen
      * never cache or re-use the {@code Predicate} returned by
      * {@link Specification#toPredicate}; pass the Specification itself to repository methods
      * and let Spring Data invoke it once per query.
+     *
+     * <p>The Specification is SELECT-only: passing it to
+     * {@code JpaSpecificationExecutor.delete(Specification)} (or any criteria bulk operation)
+     * throws {@link UnsupportedOperationException} whenever the plan touches a
+     * {@link AttributeMapping.Relation} — see {@link Result#toSpecification()} for the
+     * corruption mechanism this prevents and the select-ids-then-{@code deleteAllById}
+     * alternative.</p>
      */
     record Conditional<T>(Specification<T> specification) implements Result<T> {
         @Override

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -6,6 +6,7 @@ import dev.cerbos.api.v1.response.Response.PlanResourcesResponse;
 import dev.cerbos.sdk.PlanResourcesResult;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Path;
@@ -50,7 +51,8 @@ public final class SpringDataQueryPlanAdapter {
         Operand condition = planResult.getCondition()
                 .orElseThrow(() -> new IllegalArgumentException("Conditional plan has no condition"));
         return new Result.Conditional<>((root, query, cb) ->
-                new Translator(cb, overrides).traverse(condition, Scope.root(root, query, mapper)));
+                new Translator(cb, overrides, isSelectInvocation(root, query))
+                        .traverse(condition, Scope.root(root, query, mapper)));
     }
 
     // -- PlanResourcesResponse overloads --
@@ -74,7 +76,8 @@ public final class SpringDataQueryPlanAdapter {
                     throw new IllegalArgumentException("Conditional plan has no condition");
                 }
                 yield new Result.Conditional<T>((root, query, cb) ->
-                        new Translator(cb, overrides).traverse(cond, Scope.root(root, query, mapper)));
+                        new Translator(cb, overrides, isSelectInvocation(root, query))
+                                .traverse(cond, Scope.root(root, query, mapper)));
             }
             default -> throw new IllegalArgumentException("Unknown filter kind: " + filter.getKind());
         };
@@ -82,18 +85,34 @@ public final class SpringDataQueryPlanAdapter {
 
     // -- Internal translator --
 
+    /**
+     * Detects whether the Specification is being evaluated for the {@code SELECT} query it was
+     * handed: in every Spring Data SELECT path ({@code findAll}/{@code findOne}/{@code count}/
+     * {@code exists}/pagination) the {@code Root} is created via {@code query.from(...)}, so it is
+     * a member of {@code query.getRoots()}. In {@code SimpleJpaRepository.delete(Specification)}
+     * the {@code Root} comes from a {@code CriteriaDelete} while the {@code CriteriaQuery}
+     * argument is a fresh throwaway {@code createQuery(cls)} whose root set does not contain it
+     * (and newer Spring Data versions pass {@code null} for the query). Correlated subqueries are
+     * only sound in the first case — see {@code chainSubquery}.
+     */
+    private static boolean isSelectInvocation(Root<?> root, CriteriaQuery<?> query) {
+        return query != null && query.getRoots().contains(root);
+    }
+
     private static final class Translator {
         private final CriteriaBuilder cb;
         private final TriPredicate tri;
         private final Map<String, OperatorFunction> overrides;
         private final HierarchyTranslator hierarchy;
         private final ComparisonTranslator comparisons = new ComparisonTranslator();
+        private final boolean selectInvocation;
 
-        Translator(CriteriaBuilder cb, Map<String, OperatorFunction> overrides) {
+        Translator(CriteriaBuilder cb, Map<String, OperatorFunction> overrides, boolean selectInvocation) {
             this.cb = cb;
             this.tri = new TriPredicate(cb);
             this.overrides = overrides;
             this.hierarchy = new HierarchyTranslator(cb);
+            this.selectInvocation = selectInvocation;
         }
 
         Predicate traverse(Operand operand, Scope scope) {
@@ -1688,6 +1707,20 @@ public final class SpringDataQueryPlanAdapter {
          */
         private <T> ChainSubquery<T> chainSubquery(Class<T> resultType, Scope scope,
                                                    Scope.ResolvedRelation ref) {
+            if (!selectInvocation) {
+                String chain = ref.chain().stream()
+                        .map(AttributeMapping.Relation::joinAttribute)
+                        .collect(java.util.stream.Collectors.joining("."));
+                throw new UnsupportedOperationException(
+                        "Relation '" + chain + "' requires a correlated subquery, but this Specification "
+                        + "is being evaluated outside its own SELECT query — e.g. via "
+                        + "repository.delete(Specification) or a criteria bulk delete/update. "
+                        + "Hibernate's multi-table bulk delete first clears @ElementCollection/join "
+                        + "tables using this same predicate, which self-invalidates the correlated "
+                        + "subquery: 0 entity rows are deleted while their collection rows are "
+                        + "silently destroyed. The Cerbos Specification is SELECT-only; fetch the "
+                        + "matching ids with findAll(spec) and delete them with deleteAllById(ids).");
+            }
             Subquery<T> sub = scope.parentQuery().subquery(resultType);
             From<?, ?> correlated = correlate(sub, ref.owner().from());
             Join<?, ?> join = correlated.join(ref.chain().get(0).joinAttribute());

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -15,6 +15,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -24,10 +25,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -2496,6 +2499,159 @@ class SpringDataQueryPlanAdapterTest {
                             exprOp("add", var("request.resource.attr.aString"), sval("x")),
                             sval("z")),
                     "numeric");
+        }
+    }
+
+    /**
+     * {@code repository.delete(Specification)} guard. Relation-mapped operators translate to
+     * correlated subqueries over collection tables; Hibernate's multi-table bulk delete first
+     * clears {@code @ElementCollection}/join tables with the same predicate, which
+     * self-invalidates the correlated subquery — empirically (Hibernate 6.6.18/H2, plan
+     * {@code in(value "user1", variable ownedBy)}): SELECT returns the row, {@code delete()}
+     * returns 0, the entity survives, and ALL its {@code resource_owned_by} collection rows are
+     * destroyed. The adapter now detects the bulk-delete invocation context (the {@code Root}
+     * comes from a {@code CriteriaDelete} and is not a member of the throwaway
+     * {@code CriteriaQuery}'s root set) and throws {@link UnsupportedOperationException} from
+     * {@code toPredicate} — i.e. BEFORE any statement executes.
+     */
+    @Nested
+    class BulkDeleteGuard {
+
+        /**
+         * Exact wire shape the PDP emits for policy {@code P.id in request.resource.attr.ownedBy}
+         * (operand order is source order, so the constant-folded principal id comes first).
+         */
+        private final Operand ownedByUser1 =
+                exprOp("in", sval("user1"), var("request.resource.attr.ownedBy"));
+
+        private Specification<ResourceEntity> spec(Operand condition) {
+            PlanResourcesResponse resp =
+                    buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+            Result<ResourceEntity> result =
+                    SpringDataQueryPlanAdapter.toSpecification(resp, MAPPER, Map.of());
+            return ((Result.Conditional<ResourceEntity>) result).specification();
+        }
+
+        @Test
+        void deleteWithRelationSpecThrowsBeforeAnyDeletion() {
+            ResourceEntity r = new ResourceEntity("bulk-del-1");
+            r.setOwnedBy(new ArrayList<>(List.of("user1", "user2")));
+            withResource(r, () -> {
+                Specification<ResourceEntity> spec = spec(ownedByUser1);
+                EntityManager em = emf.createEntityManager();
+                try {
+                    SimpleJpaRepository<ResourceEntity, String> repository =
+                            new SimpleJpaRepository<>(ResourceEntity.class, em);
+
+                    // SELECT paths through the real Spring Data repository are unaffected.
+                    assertEquals(1, repository.findAll(spec).size());
+                    assertEquals(1, repository.count(spec));
+
+                    em.getTransaction().begin();
+                    try {
+                        UnsupportedOperationException ex = assertThrows(
+                                UnsupportedOperationException.class,
+                                () -> repository.delete(spec));
+                        assertTrue(ex.getMessage().contains("ownedBy"),
+                                "message should name the relation, was: " + ex.getMessage());
+                        assertTrue(ex.getMessage().contains("SELECT"),
+                                "message should state the SELECT-only contract, was: " + ex.getMessage());
+                        assertTrue(ex.getMessage().contains("deleteAllById"),
+                                "message should point at the safe alternative, was: " + ex.getMessage());
+                    } finally {
+                        em.getTransaction().rollback();
+                    }
+                } finally {
+                    em.close();
+                }
+
+                // The guard fired inside toPredicate, before Hibernate built or ran any DELETE:
+                // the entity row AND every one of its collection rows survive. (Without the
+                // guard: entity survives but resource_owned_by is emptied — data corruption.)
+                EntityManager check = emf.createEntityManager();
+                try {
+                    ResourceEntity reloaded = check.find(ResourceEntity.class, "bulk-del-1");
+                    assertNotNull(reloaded, "entity row must survive");
+                    assertEquals(Set.of("user1", "user2"), Set.copyOf(reloaded.getOwnedBy()),
+                            "collection rows must survive untouched");
+                } finally {
+                    check.close();
+                }
+            });
+        }
+
+        @Test
+        void deleteWithFieldOnlySpecStillDeletes() {
+            // Field-only predicates involve no correlated subquery and no collection-table
+            // pre-clear hazard — the guard must not block them.
+            ResourceEntity r = new ResourceEntity("bulk-del-2");
+            r.setCreatedBy("alice");
+            withResource(r, () -> {
+                Specification<ResourceEntity> spec =
+                        spec(exprOp("eq", var("request.resource.attr.createdBy"), sval("alice")));
+                EntityManager em = emf.createEntityManager();
+                try {
+                    SimpleJpaRepository<ResourceEntity, String> repository =
+                            new SimpleJpaRepository<>(ResourceEntity.class, em);
+                    em.getTransaction().begin();
+                    long deleted = repository.delete(spec);
+                    em.getTransaction().commit();
+                    assertEquals(1, deleted);
+                } finally {
+                    em.close();
+                }
+                EntityManager check = emf.createEntityManager();
+                try {
+                    assertNull(check.find(ResourceEntity.class, "bulk-del-2"),
+                            "field-only delete(Specification) must still work");
+                } finally {
+                    check.close();
+                }
+            });
+        }
+
+        @Test
+        void criteriaDeleteInvocationContextIsDetected() {
+            // Pins the detection mechanism itself, independent of the Spring Data version:
+            // SimpleJpaRepository.delete(Specification) calls
+            // spec.toPredicate(delete.from(cls), builder.createQuery(cls), builder) — a Root
+            // created on a CriteriaDelete plus a throwaway CriteriaQuery whose root set does
+            // not contain it. Every Spring Data SELECT path creates the Root via
+            // query.from(...), so membership in query.getRoots() distinguishes the two.
+            Specification<ResourceEntity> spec = spec(ownedByUser1);
+            EntityManager em = emf.createEntityManager();
+            try {
+                CriteriaBuilder cb = em.getCriteriaBuilder();
+                CriteriaDelete<ResourceEntity> delete = cb.createCriteriaDelete(ResourceEntity.class);
+                Root<ResourceEntity> deleteRoot = delete.from(ResourceEntity.class);
+                assertThrows(UnsupportedOperationException.class,
+                        () -> spec.toPredicate(deleteRoot, cb.createQuery(ResourceEntity.class), cb));
+            } finally {
+                em.close();
+            }
+        }
+
+        @Test
+        void hasIntersectionAndSizeAreGuardedToo() {
+            // All correlated-subquery construction funnels through the same choke point
+            // (chainSubquery) — spot-check two more Relation-mapped operator families.
+            Operand hasIntersection = exprOp("hasIntersection",
+                    var("request.resource.attr.ownedBy"), listOp("user1", "user2"));
+            Operand sizeGt = exprOp("gt",
+                    exprOp("size", var("request.resource.attr.ownedBy")), nval(1));
+            EntityManager em = emf.createEntityManager();
+            try {
+                CriteriaBuilder cb = em.getCriteriaBuilder();
+                for (Operand cond : List.of(hasIntersection, sizeGt)) {
+                    Specification<ResourceEntity> spec = spec(cond);
+                    CriteriaDelete<ResourceEntity> delete = cb.createCriteriaDelete(ResourceEntity.class);
+                    Root<ResourceEntity> deleteRoot = delete.from(ResourceEntity.class);
+                    assertThrows(UnsupportedOperationException.class,
+                            () -> spec.toPredicate(deleteRoot, cb.createQuery(ResourceEntity.class), cb));
+                }
+            } finally {
+                em.close();
+            }
         }
     }
 }


### PR DESCRIPTION
Finding 2/27 from an internal adversarial review of the spring-data adapter (severity HIGH — data corruption).

## Mechanism

Every Relation-mapped operator (`in` / `hasIntersection` / `exists` / `size`) translates to a correlated EXISTS/COUNT subquery against the collection table. Spring Data's `JpaSpecificationExecutor.delete(Specification)` (Spring Data JPA 3.5.1, `SimpleJpaRepository:493-508`) invokes

```java
spec.toPredicate(delete.from(cls), builder.createQuery(cls), builder)
```

— the `Root` comes from a `CriteriaDelete` and the `CriteriaQuery` argument is a fresh throwaway — and then triggers Hibernate's **multi-table bulk delete**, which FIRST clears `@ElementCollection`/join tables using the same predicate. That pre-clear removes exactly the rows the correlated EXISTS references, so the main DELETE's predicate self-invalidates and matches nothing.

**Reproduced empirically** (Hibernate 6.6.18 / H2) with the PDP-emitted plan `in(value "user1", variable ownedBy)` for policy `P.id in request.resource.attr.ownedBy`:

- `findAll(spec)` returns the row (SELECT is correct)
- `repository.delete(spec)` returns **0** — looks like a no-op
- the entity row survives
- **ALL of its `resource_owned_by` collection rows are silently destroyed**

Second-order authorization exposure: under a blocklist policy `!(P.id in R.attr.ownedBy)`, the now-ownerless rows become visible to **every** principal.

## Guard feasibility — investigated, feasible

The bulk-delete invocation context IS reliably distinguishable inside `toPredicate`: in every Spring Data SELECT path (`findAll` / `findOne` / `count` / `exists` / pagination / fluent `findBy`) the `Root` is created via `query.from(...)` and is therefore a member of `query.getRoots()`. In the delete path the `Root` belongs to a `CriteriaDelete` while the passed `CriteriaQuery` is a throwaway whose root set does not contain it (newer Spring Data versions pass `null` for the query — also handled). Verified at runtime through a real `SimpleJpaRepository` (see tests): `findAll`/`count` are classified as SELECT invocations; `delete` is not.

## What shipped

- **Guard (fail loudly instead of corrupting):** `chainSubquery` — the single choke point through which every correlated subquery (`existsSubquery` / `countSubquery`) is built — now throws `UnsupportedOperationException` when the Specification is evaluated outside its own SELECT query, naming the relation, explaining the corruption mechanism, and pointing at the safe alternative. The throw happens inside `toPredicate`, i.e. **before any statement executes** — nothing is deleted, nothing is corrupted. Field-only predicates (no correlated subquery, no pre-clear hazard) still work with `delete(Specification)` unchanged.
- **Documentation:** prominent SELECT-only warning in the README (with the select-ids-then-`deleteAllById` pattern) and in the `Result` Javadoc (`toSpecification()` + `Conditional`).
- **Tests** (`BulkDeleteGuard` nested class, running through a real `SimpleJpaRepository`):
  - `deleteWithRelationSpecThrowsBeforeAnyDeletion` — seeds an entity with two `ownedBy` rows, confirms `findAll`/`count` still see it, asserts `delete(spec)` throws, then asserts the entity **and both collection rows survive untouched**
  - `deleteWithFieldOnlySpecStillDeletes` — the guard does not block relation-free bulk deletes (returns 1, row gone)
  - `criteriaDeleteInvocationContextIsDetected` — pins the detection mechanism against the raw criteria-delete calling convention, independent of the Spring Data version
  - `hasIntersectionAndSizeAreGuardedToo` — spot-checks the other Relation operator families through the same choke point

## Test results

Full build via `gradle build` (Docker `gradle:8.12-jdk17`, Testcontainers PDP):

```
BUILD SUCCESSFUL — 360 tests, 0 failures, 0 errors, 0 skipped
```

(includes the live-PDP `AdversarialConformanceTest` differential oracle, 80 tests, and the Testcontainers integration suites)

New tests verified to fail on the pre-guard code (guard reverted, tests kept):

```
BulkDeleteGuard > deleteWithRelationSpecThrowsBeforeAnyDeletion FAILED
BulkDeleteGuard > criteriaDeleteInvocationContextIsDetected     FAILED
BulkDeleteGuard > hasIntersectionAndSizeAreGuardedToo           FAILED
BulkDeleteGuard > deleteWithFieldOnlySpecStillDeletes           PASSED
```

SELECT-path translation semantics are unchanged.
