### PR TITLE
fix(spring-data): make eq/ne add-solve IEEE-faithful instead of algebraic

### DIFF
--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/PlanValues.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/PlanValues.java
@@ -73,10 +73,60 @@ final class PlanValues {
     }
 
     /**
+     * Largest magnitude at which every long is exactly representable as an IEEE double
+     * (2<sup>53</sup>). CEL attribute arithmetic is always double-typed at check time, so
+     * beyond this bound the check-time arithmetic has gaps between representable integers
+     * and an algebraic long-space solve could disagree with what the PDP evaluates.
+     */
+    private static final long MAX_EXACT_DOUBLE_LONG = 1L << 53;
+
+    /**
+     * Whether {@code field + addConstant eq/ne comparisonValue} must be lowered to SQL-side
+     * double arithmetic instead of solved algebraically in Java.
+     *
+     * <p>IEEE subtraction does not invert IEEE addition: {@code fl(fl(t - c) + c) != t} for
+     * many double pairs — e.g. {@code t = 0.1, c = 0.7}: the algebraic solve yields exactly
+     * {@code -0.6}, yet {@code -0.6 + 0.7 == 0.09999999999999998 != 0.1}, so a pre-solved
+     * {@code field = -0.6} filter returns rows the PDP's {@code check()} denies (and the
+     * {@code ne} mirror hides rows it allows). Only long/long pairs where every value —
+     * including the solution — stays within ±2<sup>53</sup> remain on the solve path: there
+     * both the Java solve and the check-time double arithmetic are exact. Non-numeric
+     * pairings return {@code false} so {@link #solveAdd} keeps owning their translation
+     * (string concatenation) and their type-mismatch error messages.
+     */
+    static boolean requiresSqlLowering(Object comparisonValue, Object addConstant) {
+        if (!(comparisonValue instanceof Number) || !(addConstant instanceof Number)) {
+            return false;
+        }
+        return !(comparisonValue instanceof Long t && addConstant instanceof Long c
+                && isExactLongSolve(t, c));
+    }
+
+    /**
+     * True when {@code t - c} is exact in both long and double space: {@code t}, {@code c},
+     * and the solution all within ±2<sup>53</sup>. The bounds on {@code t} and {@code c} are
+     * checked first, capping {@code |t - c|} at 2<sup>54</sup> — so the subtraction cannot
+     * overflow before its own range check runs.
+     */
+    private static boolean isExactLongSolve(long t, long c) {
+        return withinExactDoubleRange(t) && withinExactDoubleRange(c)
+                && withinExactDoubleRange(t - c);
+    }
+
+    /** {@code Math.abs}-free range check: safe for {@code Long.MIN_VALUE}. */
+    private static boolean withinExactDoubleRange(long v) {
+        return -MAX_EXACT_DOUBLE_LONG <= v && v <= MAX_EXACT_DOUBLE_LONG;
+    }
+
+    /**
      * Solve {@code field + addConstant == comparisonValue} (or with operands swapped if
-     * {@code !fieldIsLeft}). For strings: strip the prefix/suffix and return what the field must
-     * equal; return {@code null} if the comparison value doesn't match the constant's
-     * shape (which means no field value can satisfy the equation). For numbers: subtract.
+     * {@code !fieldIsLeft}) — for the ALGEBRAICALLY EXACT shapes only. For strings: strip the
+     * prefix/suffix and return what the field must equal; return {@code null} if the
+     * comparison value doesn't match the constant's shape (which means no field value can
+     * satisfy the equation). For numbers: subtract, but only in-range long/long pairs —
+     * fractional or oversized numbers are not invertible in IEEE double space and must be
+     * lowered to SQL-side double arithmetic by the caller (see {@link #requiresSqlLowering});
+     * reaching that case here is an adapter routing bug.
      */
     static Object solveAdd(Object comparisonValue, Object addConstant, boolean fieldIsLeft) {
         if (comparisonValue instanceof String compStr && addConstant instanceof String constStr) {
@@ -89,12 +139,15 @@ final class PlanValues {
             if (!compStr.startsWith(constStr)) return null;
             return compStr.substring(constStr.length());
         }
-        if (comparisonValue instanceof Number compNum && addConstant instanceof Number constNum) {
+        if (comparisonValue instanceof Number && addConstant instanceof Number) {
             // Both orderings of numeric addition produce the same equation: field = comp - const
-            if (comparisonValue instanceof Long && addConstant instanceof Long) {
-                return compNum.longValue() - constNum.longValue();
+            if (comparisonValue instanceof Long t && addConstant instanceof Long c
+                    && isExactLongSolve(t, c)) {
+                return t - c;
             }
-            return compNum.doubleValue() - constNum.doubleValue();
+            throw new IllegalArgumentException(
+                    "Numeric add-solve is only exact for integer constants within ±2^53; "
+                            + "this shape must be lowered to SQL double arithmetic instead");
         }
         throw new IllegalArgumentException(
                 "add comparison type mismatch: " + comparisonValue.getClass() + " vs " + addConstant.getClass());

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -506,8 +506,10 @@ public final class SpringDataQueryPlanAdapter {
 
                 /**
                  * {@code add(field, value)} / {@code add(value, field)} — solvable for the field
-                 * under eq/ne against a constant ({@link PlanValues#solveAdd}); every other
-                 * pairing lowers to SQL arithmetic.
+                 * under eq/ne against a constant ({@link PlanValues#solveAdd}) when the solve is
+                 * algebraically exact (string concatenation, in-range long/long integers); every
+                 * other pairing — including fractional doubles, which IEEE subtraction cannot
+                 * invert — lowers to SQL arithmetic.
                  */
                 record FieldPlusConstant(String fieldVariable, Operand constant, boolean fieldIsLeft)
                         implements Resolved {}
@@ -633,11 +635,19 @@ public final class SpringDataQueryPlanAdapter {
                     if (left instanceof Resolved.Field f && right instanceof Resolved.ConstantAdd ca) {
                         return applyLeaf(op, scope.resolvePath(f.variable()), ca.fold());
                     }
-                    // Solve: `add(field, const) eq/ne constant` — string concat/numeric solve for
-                    // the field side (same algorithm as the Prisma adapter).
+                    // Solve: `add(field, const) eq/ne constant` — for the ALGEBRAICALLY EXACT
+                    // shapes only (string concatenation, in-range long/long integers).
+                    // Fractional/oversized numeric pairs fall through to numericComparison:
+                    // IEEE subtraction does not invert IEEE addition (fl(fl(t-c)+c) != t), so
+                    // a Java-side solve would return rows the PDP's check() denies — the SQL
+                    // side must compute fl(field + const) and compare it to the target in
+                    // double space, sharing IEEE semantics with the ordering operators.
                     if (("eq".equals(op) || "ne".equals(op))
                             && left instanceof Resolved.FieldPlusConstant fpc
-                            && right instanceof Resolved.Constant other) {
+                            && right instanceof Resolved.Constant other
+                            && !PlanValues.requiresSqlLowering(
+                                    other.value(),
+                                    PlanValues.protoValueToJava(fpc.constant().getValue()))) {
                         return solveAddComparison(op, fpc, other, scope);
                     }
                     // Everything else arithmetic-rooted lowers to SQL-side double-space arithmetic.
@@ -689,10 +699,13 @@ public final class SpringDataQueryPlanAdapter {
             }
 
             /**
-             * Solve {@code add(field, const) eq/ne constant} for the field. When no solution
-             * exists (e.g. {@code "projects:123" == "users:" + R.id} can never be true), eq is
-             * always-false; ne is NOT always-true — a missing attribute makes the concatenation a
-             * CEL evaluation error ({@code "users:" + null}) → deny, so NULL rows must stay
+             * Solve {@code add(field, const) eq/ne constant} for the field — only reached for
+             * algebraically exact solves (string concatenation, in-range long/long integers;
+             * {@link #dispatch} routes fractional doubles to {@link #numericComparison} because
+             * IEEE subtraction does not invert IEEE addition). When no solution exists (e.g.
+             * {@code "projects:123" == "users:" + R.id} can never be true), eq is always-false;
+             * ne is NOT always-true — a missing attribute makes the concatenation a CEL
+             * evaluation error ({@code "users:" + null}) → deny, so NULL rows must stay
              * excluded: IS NOT NULL, never an unconditional {@code 1=1} (which would leak exactly
              * the rows the PDP denies).
              */

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -63,6 +63,7 @@ class AdversarialConformanceTest {
             Map.entry("request.resource.attr.aBool", AttributeMapping.field("aBool")),
             Map.entry("request.resource.attr.aString", AttributeMapping.field("aString")),
             Map.entry("request.resource.attr.aNumber", AttributeMapping.field("aNumber")),
+            Map.entry("request.resource.attr.aDouble", AttributeMapping.field("aDouble")),
             Map.entry("request.resource.attr.aOptionalString", AttributeMapping.field("aOptionalString")),
             // ISO-date string column + flattened struct member for the p-* probes
             Map.entry("request.resource.attr.createdBy", AttributeMapping.field("createdBy")),
@@ -146,6 +147,26 @@ class AdversarialConformanceTest {
         return s.aNumber() >= 2 ? "2024-06-01T00:00:00Z" : "2026-06-01T00:00:00Z";
     }
 
+    /**
+     * Deterministic fractional double per seed for the IEEE add-solve probes
+     * ({@code arith-add-*-frac*}). a1 carries the algebraic-solve trap: {@code -0.6} is
+     * EXACTLY what solving {@code aDouble + 0.7 == 0.1} yields in Java double space, yet
+     * {@code check()} denies it ({@code -0.6 + 0.7 == 0.09999999999999998 != 0.1}) — so a
+     * pre-solved filter diverges from the oracle on this row. a2 is the exact-arithmetic
+     * agreement witness ({@code 0.25 + 0.5 == 0.75} holds bit-for-bit: both filter and
+     * oracle INCLUDE it). a3 has NO aDouble (missing attribute → CEL error → deny; SQL NULL
+     * arithmetic → UNKNOWN → excluded). The rest get an unremarkable fractional value both
+     * sides agree to exclude.
+     */
+    private static Double doubleFor(Seed s) {
+        return switch (s.id()) {
+            case "a1" -> -0.6;
+            case "a2" -> 0.25;
+            case "a3" -> null;
+            default -> s.aNumber() + 0.3;
+        };
+    }
+
     private static GenericContainer<?> cerbos;
     private static CerbosBlockingClient client;
     private static EntityManagerFactory emf;
@@ -191,6 +212,7 @@ class AdversarialConformanceTest {
             r.setaBool(s.aBool());
             r.setaString(s.aString());
             r.setaNumber(s.aNumber());
+            r.setaDouble(doubleFor(s));
             r.setaOptionalString(s.aOptionalString());
             r.setCreatedBy(isoFor(s));
             for (Tag tag : s.tags()) {
@@ -245,6 +267,9 @@ class AdversarialConformanceTest {
         // deny (CEL error), matching SQL three-valued logic excluding the row.
         if (s.aOptionalString() != null) {
             r = r.withAttribute("aOptionalString", AttributeValue.stringValue(s.aOptionalString()));
+        }
+        if (doubleFor(s) != null) {
+            r = r.withAttribute("aDouble", AttributeValue.doubleValue(doubleFor(s)));
         }
         // mainCategory mirrors the row's single category as ONE nested object (the seeder
         // creates at most one category per seed), so direct dotted-chain CEL expressions
@@ -324,6 +349,10 @@ class AdversarialConformanceTest {
             "f2f-contains", "f2f-startswith", "f2f-endswith",
             "arith-add", "arith-vf", "arith-sub", "arith-mult-neg",
             "arith-div", "arith-div-frac", "arith-both",
+            // IEEE add-solve probes: fractional eq/ne must lower to SQL double arithmetic,
+            // never to a Java-side algebraic solve (a1 aDouble=-0.6 is the divergence
+            // witness; a2 aDouble=0.25 pins the exact-arithmetic inclusion).
+            "arith-add-eq-frac", "arith-add-ne-frac", "arith-add-eq-frac-exact",
             // clean-room probes (GROUP A)
             "p-ternary-in-exists", "p-arith-in-lambda", "p-lambda-inner-f2f",
             "p-lambda-f2f-like", "p-size-nested",

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -49,6 +49,7 @@ class SpringDataQueryPlanAdapterTest {
             Map.entry("request.resource.attr.aBool", AttributeMapping.field("aBool")),
             Map.entry("request.resource.attr.aString", AttributeMapping.field("aString")),
             Map.entry("request.resource.attr.aNumber", AttributeMapping.field("aNumber")),
+            Map.entry("request.resource.attr.aDouble", AttributeMapping.field("aDouble")),
             Map.entry("request.resource.attr.aOptionalString", AttributeMapping.field("aOptionalString")),
             Map.entry("request.resource.attr.createdBy", AttributeMapping.field("createdBy")),
             Map.entry("request.resource.attr.ownedBy", AttributeMapping.relation("ownedBy")),
@@ -696,6 +697,14 @@ class SpringDataQueryPlanAdapterTest {
                 sval("projects:123"),
                 exprOp("add", sval("projects:"), var("request.resource.attr.aString")));
         assertEquals(0, runCount(cond));
+
+        // Concatenation is exact — the solve path must keep working: aString="123" row in,
+        // aString="456" row out.
+        ResourceEntity match = new ResourceEntity("add-str-1");
+        match.setaString("123");
+        ResourceEntity miss = new ResourceEntity("add-str-2");
+        miss.setaString("456");
+        withResource(match, () -> withResource(miss, () -> assertEquals(1, runCount(cond))));
     }
 
     @Test
@@ -711,11 +720,75 @@ class SpringDataQueryPlanAdapterTest {
 
     @Test
     void addSolveNumeric() {
-        // eq(10, add(3, R.attr.aNumber))  →  aNumber == 7
+        // eq(10, add(3, R.attr.aNumber))  →  aNumber == 7. Long/long solves within ±2^53 are
+        // algebraically exact and must keep solving in Java: seeded rows prove the filter
+        // keeps the aNumber=7 row and drops the aNumber=8 row.
         Operand cond = exprOp("eq",
                 nval(10),
                 exprOp("add", nval(3), var("request.resource.attr.aNumber")));
         assertEquals(0, runCount(cond));
+
+        ResourceEntity match = new ResourceEntity("add-long-1");
+        match.setaNumber(7);
+        ResourceEntity miss = new ResourceEntity("add-long-2");
+        miss.setaNumber(8);
+        withResource(match, () -> withResource(miss, () -> assertEquals(1, runCount(cond))));
+    }
+
+    @Test
+    void addSolveFractionalEqIsIeeeFaithful() {
+        // Policy `R.attr.aDouble + 0.7 == 0.1` arrives as eq(add(variable, 0.7), 0.1) —
+        // wire shape verified against a live PDP. The old algebraic solve computed
+        // 0.1 - 0.7 = exactly -0.6 in Java and emitted `WHERE a_double = -0.6`, but IEEE
+        // subtraction does not invert IEEE addition: check(aDouble=-0.6) DENIES because
+        // -0.6 + 0.7 == 0.09999999999999998 != 0.1 (verified against a live PDP). The row
+        // must be EXCLUDED for eq (over-inclusion = authz bypass) and INCLUDED for ne
+        // (the mirror under-inclusion). The fix lowers the comparison to SQL-side
+        // fl(a_double + 0.7) == 0.1 in double space.
+        Operand eqCond = exprOp("eq",
+                exprOp("add", var("request.resource.attr.aDouble"), nval(0.7)),
+                nval(0.1));
+        Operand neCond = exprOp("ne",
+                exprOp("add", var("request.resource.attr.aDouble"), nval(0.7)),
+                nval(0.1));
+
+        ResourceEntity trap = new ResourceEntity("add-frac-1");
+        trap.setaDouble(-0.6);
+        withResource(trap, () -> {
+            assertEquals(0, runCount(eqCond), "aDouble=-0.6 must be excluded for eq: "
+                    + "-0.6 + 0.7 != 0.1 in IEEE double space, the PDP denies it");
+            assertEquals(1, runCount(neCond), "aDouble=-0.6 must be included for ne: "
+                    + "-0.6 + 0.7 != 0.1 holds, the PDP allows it");
+        });
+    }
+
+    @Test
+    void addSolveFractionalEqKeepsExactlySatisfiedRow() {
+        // 0.25 + 0.5 == 0.75 is EXACT in binary floating point, so the SQL lowering must not
+        // degenerate to always-false: the aDouble=0.25 row stays in (PDP-verified ALLOW).
+        Operand cond = exprOp("eq",
+                exprOp("add", var("request.resource.attr.aDouble"), nval(0.5)),
+                nval(0.75));
+
+        ResourceEntity match = new ResourceEntity("add-frac-2");
+        match.setaDouble(0.25);
+        ResourceEntity miss = new ResourceEntity("add-frac-3");
+        miss.setaDouble(-0.6);
+        withResource(match, () -> withResource(miss, () -> assertEquals(1, runCount(cond))));
+    }
+
+    @Test
+    void addSolveOversizedLongRoutesToSqlArithmetic() {
+        // 2^54 is outside the ±2^53 exactly-representable range: the check-time double
+        // arithmetic has gaps there, so the long-space solve must NOT fire — the shape
+        // routes through SQL double arithmetic instead (and must not throw).
+        Operand cond = exprOp("eq",
+                exprOp("add", var("request.resource.attr.aNumber"), nval(1)),
+                nval(0x1p54));
+
+        ResourceEntity row = new ResourceEntity("add-big-1");
+        row.setaNumber(5);
+        withResource(row, () -> assertEquals(0, runCount(cond)));
     }
 
     @Test

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/testmodel/ResourceEntity.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/testmodel/ResourceEntity.java
@@ -37,6 +37,11 @@ public class ResourceEntity {
     @Column(name = "a_number")
     private Integer aNumber;
 
+    // Fractional-value column for the IEEE add-solve probes: the -0.6 reproduction needs a
+    // stored double, which the Integer aNumber column cannot hold.
+    @Column(name = "a_double")
+    private Double aDouble;
+
     @Column(name = "a_optional_string")
     private String aOptionalString;
 
@@ -88,6 +93,8 @@ public class ResourceEntity {
     public void setaString(String aString) { this.aString = aString; }
     public Integer getaNumber() { return aNumber; }
     public void setaNumber(Integer aNumber) { this.aNumber = aNumber; }
+    public Double getaDouble() { return aDouble; }
+    public void setaDouble(Double aDouble) { this.aDouble = aDouble; }
     public String getaOptionalString() { return aOptionalString; }
     public void setaOptionalString(String aOptionalString) { this.aOptionalString = aOptionalString; }
     public String getCreatedBy() { return createdBy; }

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -368,6 +368,36 @@ resourcePolicy:
         match:
           expr: 'R.attr.aNumber + 1.0 > R.attr.aNumber * 2.0'
 
+    # -- IEEE add-solve probes: eq/ne over field + FRACTIONAL constant. An algebraic solve
+    # computes 0.1 - 0.7 = exactly -0.6 in Java, but IEEE subtraction does not invert IEEE
+    # addition: check(aDouble=-0.6) DENIES eq because -0.6 + 0.7 == 0.09999999999999998 !=
+    # 0.1 (and ALLOWS ne). The a1 seed holds aDouble=-0.6 so a pre-solved `a_double = -0.6`
+    # filter diverges from the oracle in both directions; the adapter must lower these to
+    # SQL-side double arithmetic like the ordering operators.
+    - actions: ["arith-add-eq-frac"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.aDouble + 0.7 == 0.1'
+
+    - actions: ["arith-add-ne-frac"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.aDouble + 0.7 != 0.1'
+
+    # Exactly-representable witness: 0.25 + 0.5 == 0.75 IS exact in binary floating point,
+    # so the a2 seed (aDouble=0.25) must be INCLUDED — pins that the SQL lowering of eq is
+    # not just always-false.
+    - actions: ["arith-add-eq-frac-exact"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.aDouble + 0.5 == 0.75'
+
     # ==================== clean-room probes (coverage gap hunt) ====================
 
     # -- GROUP A: compositions claimed-supported but unproven e2e --


### PR DESCRIPTION
Finding 3/27 from an internal adversarial review of the Spring Data adapter.

## Mechanism

`eq`/`ne` comparisons whose operands are `(field + constant, constant)` were routed into `solveAddComparison`, which inverted the addition algebraically in Java: `solveAdd` computed `target - constant` via `doubleValue()` subtraction and emitted a plain `WHERE field = solved`. But **floating-point subtraction does not invert floating-point addition**: `fl(fl(t - c) + c) != t` for many double pairs, so the pre-solved filter returns rows the PDP's `check()` API denies — a silent authorization bypass (and the `ne` mirror silently hides rows the PDP allows).

## Live-PDP reproduction (re-verified against `ghcr.io/cerbos/cerbos:latest` while building this PR)

Policy `R.attr.aDouble + 0.7 == 0.1` arrives on the wire as:

```json
{"operator":"eq","operands":[
  {"expression":{"operator":"add","operands":[{"variable":"request.resource.attr.aDouble"},{"value":0.7}]}},
  {"value":0.1}]}
```

`check(aDouble = -0.6)` returns **DENY** (`-0.6 + 0.7 == 0.09999999999999998 != 0.1`), yet the old solve yields exactly `-0.6` (in Java, `0.1d - 0.7d` rounds to the double `-0.6` bit-for-bit) and the filter `WHERE a_double = -0.6` **includes** the row. The `ne` direction was also verified: `check` ALLOWS the row, the old filter excluded it.

Also verified live: `check(aDouble = 0.25)` ALLOWS `R.attr.aDouble + 0.5 == 0.75` (exact in binary FP) — the fix must keep such rows included, not degenerate to always-false.

## Fix

The gt/lt/ge/le paths already lower arithmetic to SQL-side CAST-to-double precisely because DB decimal arithmetic is not IEEE double arithmetic; only the eq/ne shortcut bypassed that machinery. Now:

- `PlanValues.solveAdd` is restricted to the algebraically exact shapes: **string concatenation** and **long/long integer arithmetic where the target, the constant, and the solution all lie within ±2^53** (beyond that, check-time double arithmetic — CEL attribute arithmetic is always double-typed — has gaps between representable integers, so the wire value and the long-space solve can disagree; protobuf `Value.getNumberValue()` returns `double`, so "integer" is decided from the double value).
- `dispatch` consults the new `PlanValues.requiresSqlLowering(target, constant)` before taking the solve branch; fractional or out-of-range numeric pairs now **fall through to the existing `numericComparison` CAST-to-double path**, so eq/ne share IEEE semantics with the ordering operators. The SQL side computes `fl(field + const) == target` in double space (CAST column + double bind parameter) — it does **not** compare the field against a pre-solved Java-side value.
- Non-numeric pairings (string/string, type mismatches) keep their existing translation and pinned error messages.

## Tests

- **Unit** (`SpringDataQueryPlanAdapterTest`): hand-built plan `eq(add(variable aDouble, 0.7), 0.1)` with a seeded `aDouble = -0.6` row — asserts the row is **excluded for eq and included for ne**; an exact-arithmetic witness (`0.25 + 0.5 == 0.75` keeps its row); the long/long solve (`eq(10, add(3, aNumber))` keeps the `aNumber=7` row, drops `aNumber=8`) and string-concat solve (`"projects:123" == "projects:" + aString` keeps `"123"`, drops `"456"`) now assert row identities against seeded rows; a `2^54` target routes through SQL arithmetic without throwing.
- **Differential oracle** (`AdversarialConformanceTest` + `adversarial-policy.yaml`): three new actions — `arith-add-eq-frac` (`R.attr.aDouble + 0.7 == 0.1`), `arith-add-ne-frac`, and `arith-add-eq-frac-exact` (`+ 0.5 == 0.75`) — over a new nullable `Double` test column: seed `a1` holds `-0.6` (CEL check false, old algebraic solve true — the divergence witness), `a2` holds `0.25` (both agree: included), `a3` has no value (missing attribute → CEL error → deny; SQL NULL → UNKNOWN → excluded). The oracle compares adapter row-sets against per-row `check()` on the same live PDP, so it owns these semantics permanently.

### Negative control

With the fix reverted (main-branch `PlanValues.java` + `SpringDataQueryPlanAdapter.java`, new tests kept), the new tests fail exactly as the finding predicts:

```
AdversarialConformanceTest > adapterMatchesCheckOracle > arith-add-eq-frac FAILED
    adapter result diverges from check-API oracle ==> expected: <[]> but was: <[a1]>          # over-inclusion: the PDP-denied -0.6 row leaks
AdversarialConformanceTest > adapterMatchesCheckOracle > arith-add-ne-frac FAILED
    expected: <[a1, a2, a4, ...]> but was: <[a2, a4, ...]>                                    # under-inclusion: the PDP-allowed -0.6 row is hidden
SpringDataQueryPlanAdapterTest > addSolveFractionalEqIsIeeeFaithful FAILED
    aDouble=-0.6 must be excluded for eq ==> expected: <0> but was: <1>
SpringDataQueryPlanAdapterTest > addSolveOversizedLongRoutesToSqlArithmetic FAILED
    org.hibernate.type.descriptor.java.CoercionException (old code solved 2^54 - 1 in long space)
BUILD FAILED in 29s
```

`arith-add-eq-frac-exact` and the retained long/long + string-concat solve tests pass on both old and new code, as designed (agreement witnesses).

### Full build

Full Docker Gradle build (`gradle clean build`, testcontainers PDP + H2), on the fixed code:

```
BUILD SUCCESSFUL
362 tests passed, 0 failed
AdversarialConformanceTest > adapterMatchesCheckOracle > arith-add-eq-frac PASSED
AdversarialConformanceTest > adapterMatchesCheckOracle > arith-add-ne-frac PASSED
AdversarialConformanceTest > adapterMatchesCheckOracle > arith-add-eq-frac-exact PASSED
```

## Notes

- **MySQL caveat (interacts with a separately tracked finding):** this fix routes fractional eq/ne through the same CAST-to-double lowering the ordering operators use. On MySQL with default Connector/J client-side prepared statements, double binds are interpolated as DECIMAL literals and the arithmetic evaluates in exact decimal rather than IEEE double — that pre-existing divergence now also covers these eq/ne shapes. Deployments need `useServerPrepStmts=true` (as the MySQL CI leg proposed in #272 sets) for CEL-faithful arithmetic. Correctness on H2 (CI default) is unaffected.
- Residual known edge (out of scope, documented for completeness): the retained long/long solve compares the column against the exact integer solution. If a **double** column stores a value one ULP away from an integer (e.g. `1 - 2^-53`) and the policy uses integer-valued constants, round-to-nearest-even at check time can accept a value the solved equality rejects. This requires a pathological stored value; routing it away would break exact integer-column solves, so it is intentionally retained.
- The gt/lt/ge/le lowering is untouched.
