### PR TITLE
fix(spring-data): use IEEE ordering for constant comparisons so NaN excludes rows

### DIFF
--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -797,6 +797,14 @@ public final class SpringDataQueryPlanAdapter {
              * only splits Long/Double for whole-number cosmetics, not semantics. Strings compare
              * lexicographically; booleans (and mixed incomparable types) support eq/ne only —
              * eq → false, ne → true — while ordering them is a planner bug and throws.
+             *
+             * <p>Numeric ordering uses the primitive IEEE operators, NOT {@link Double#compare}:
+             * the total order ranks {@code NaN} above every number (and {@code -0.0} below
+             * {@code 0.0}), so {@code Double.compare} would collapse {@code gt}/{@code ge}
+             * against a NaN constant — reachable via an unfolded {@code div(0,0)}, e.g. the
+             * else arm of {@code (aBool ? 1.0 : 0.0/0.0) > 0.5} — to always-true, returning
+             * rows the PDP denies. CEL/IEEE define every ordering comparison involving NaN as
+             * false → {@code cb.disjunction()} (exclusion).
              */
             private Predicate constantComparison(String op, Object left, Object right) {
                 boolean result;
@@ -805,17 +813,19 @@ public final class SpringDataQueryPlanAdapter {
                             ? ln.doubleValue() == rn.doubleValue()
                             : Objects.equals(left, right);
                     result = "eq".equals(op) == equal;
-                } else {
-                    int cmp;
-                    if (left instanceof Number ln && right instanceof Number rn) {
-                        cmp = Double.compare(ln.doubleValue(), rn.doubleValue());
-                    } else if (left instanceof String ls && right instanceof String rs) {
-                        cmp = ls.compareTo(rs);
-                    } else {
-                        throw new IllegalArgumentException(
-                                "Cannot order constant operands of " + op + ": "
-                                        + typeName(left) + " vs " + typeName(right));
-                    }
+                } else if (left instanceof Number ln && right instanceof Number rn) {
+                    double l = ln.doubleValue();
+                    double r = rn.doubleValue();
+                    result = switch (op) {
+                        case "lt" -> l < r;
+                        case "gt" -> l > r;
+                        case "le" -> l <= r;
+                        case "ge" -> l >= r;
+                        default -> throw new IllegalArgumentException(
+                                "Unsupported constant comparison operator: " + op);
+                    };
+                } else if (left instanceof String ls && right instanceof String rs) {
+                    int cmp = ls.compareTo(rs);
                     result = switch (op) {
                         case "lt" -> cmp < 0;
                         case "gt" -> cmp > 0;
@@ -824,6 +834,10 @@ public final class SpringDataQueryPlanAdapter {
                         default -> throw new IllegalArgumentException(
                                 "Unsupported constant comparison operator: " + op);
                     };
+                } else {
+                    throw new IllegalArgumentException(
+                            "Cannot order constant operands of " + op + ": "
+                                    + typeName(left) + " vs " + typeName(right));
                 }
                 return result ? cb.conjunction() : cb.disjunction();
             }

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -345,6 +345,9 @@ class AdversarialConformanceTest {
             // arithmetic + size edges: zero column divisor (NaN → deny), fractional count
             // threshold (only ordering ops compile in CEL — int vs double eq/ne does not)
             "cr-div-zero", "cr-size-frac-ge",
+            // constant NaN / ±Infinity ordering: unfolded div(0,0) → NaN; every NaN
+            // ordering is false in CEL/IEEE, while ±Infinity orders normally
+            "nan-ord-ternary", "nan-ord-ternary-vf", "nan-ord-le", "nan-ord-inf",
             // multi-hop relation chains via DIRECT dotted syntax (W1) and a root relation
             // subquery anchored from inside a lambda body (W2)
             "w1-exists-chain", "w1-size-chain", "w1-in-chain", "w2-outer-relation",

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -2498,4 +2498,111 @@ class SpringDataQueryPlanAdapterTest {
                     "numeric");
         }
     }
+
+    // -- Constant NaN / ±Infinity ordering --
+    // CEL/IEEE define EVERY ordering comparison involving NaN as false. The planner does
+    // NOT fold div(0,0) (verified vs live PDP: `(R.attr.aBool ? 1.0 : 0.0/0.0) > 0.5`
+    // arrives as gt(if(aBool, 1, div(0,0)), 0.5)), so resolveNumericOperand folds it to
+    // NaN in Java and constantComparison must order with primitive IEEE operators.
+    // Double.compare's total order ranks NaN above every number (and -0.0 below 0.0),
+    // which would collapse gt/ge against a NaN constant to always-true — over-inclusion.
+
+    @Nested
+    class ConstantNanInfinityOrdering {
+
+        /** {@code div(0, 0)} — folds to NaN in Java, exactly as delivered on the wire. */
+        private Operand nan() {
+            return exprOp("div", nval(0), nval(0));
+        }
+
+        private Operand posInf() {
+            return exprOp("div", nval(1), nval(0));
+        }
+
+        private Operand negInf() {
+            return exprOp("div", nval(-1), nval(0));
+        }
+
+        /** An arithmetic subtree folding to 0.5, so both sides rank as expressions. */
+        private Operand half() {
+            return exprOp("div", nval(1), nval(2));
+        }
+
+        @Test
+        void nanOnLeftExcludesForAllOrderingOperators() {
+            // Expression-vs-value keeps source order: constantComparison sees (NaN, 0.5).
+            ResourceEntity r = new ResourceEntity("nan-ord-1");
+            withResource(r, () -> {
+                for (String op : List.of("gt", "ge", "lt", "le")) {
+                    assertEquals(0, runCount(exprOp(op, nan(), nval(0.5))),
+                            op + "(NaN, 0.5) must exclude every row");
+                }
+            });
+        }
+
+        @Test
+        void nanOnRightExcludesForAllOrderingOperators() {
+            // Arithmetic on BOTH sides so normalization cannot mirror the NaN to the left:
+            // constantComparison sees (0.5, NaN).
+            ResourceEntity r = new ResourceEntity("nan-ord-2");
+            withResource(r, () -> {
+                for (String op : List.of("gt", "ge", "lt", "le")) {
+                    assertEquals(0, runCount(exprOp(op, half(), nan())),
+                            op + "(0.5, NaN) must exclude every row");
+                }
+            });
+        }
+
+        @Test
+        void infinityOrderingFollowsIeee() {
+            // ±Infinity is ORDERED normally in IEEE space — it must NOT be excluded the
+            // way NaN is.
+            ResourceEntity r = new ResourceEntity("nan-ord-3");
+            withResource(r, () -> {
+                assertEquals(1, runCount(exprOp("gt", posInf(), nval(0.5))));
+                assertEquals(1, runCount(exprOp("ge", posInf(), nval(0.5))));
+                assertEquals(0, runCount(exprOp("lt", posInf(), nval(0.5))));
+                assertEquals(0, runCount(exprOp("le", posInf(), nval(0.5))));
+                assertEquals(1, runCount(exprOp("lt", negInf(), nval(0.5))));
+                assertEquals(1, runCount(exprOp("le", negInf(), nval(0.5))));
+                assertEquals(0, runCount(exprOp("gt", negInf(), nval(0.5))));
+                assertEquals(1, runCount(exprOp("lt", negInf(), posInf())));
+            });
+        }
+
+        @Test
+        void negativeZeroOrderingFollowsIeee() {
+            // mult(-1, 0) folds to -0.0 in Java. IEEE: -0.0 == 0.0, so lt is false and
+            // ge is true — Double.compare(-0.0, 0.0) = -1 would invert both (the same
+            // total-order defect as NaN, on the same line).
+            Operand negZero = exprOp("mult", nval(-1), nval(0));
+            Operand zero = exprOp("mult", nval(1), nval(0));
+            ResourceEntity r = new ResourceEntity("nan-ord-4");
+            withResource(r, () -> {
+                assertEquals(0, runCount(exprOp("lt", negZero, zero)));
+                assertEquals(1, runCount(exprOp("le", negZero, zero)));
+                assertEquals(1, runCount(exprOp("ge", negZero, zero)));
+                assertEquals(0, runCount(exprOp("gt", negZero, zero)));
+            });
+        }
+
+        @Test
+        void ternaryNanElseArmExcludesRows() {
+            // The live-PDP reproduction: `(R.attr.aBool ? 1.0 : 0.0/0.0) > 0.5` arrives
+            // as gt(if(aBool, 1, div(0,0)), 0.5). check() denies every aBool=false
+            // resource (NaN > 0.5 is false), so the rewritten else arm must contribute
+            // exclusion — old code produced (NOT aBool AND 1=1), returning the row.
+            Operand plan = exprOp("gt",
+                    exprOp("if", var("request.resource.attr.aBool"), nval(1), nan()),
+                    nval(0.5));
+
+            ResourceEntity allowed = new ResourceEntity("nan-tern-1");
+            allowed.setaBool(true);
+            withResource(allowed, () -> assertEquals(1, runCount(plan)));
+
+            ResourceEntity denied = new ResourceEntity("nan-tern-2");
+            denied.setaBool(false);
+            withResource(denied, () -> assertEquals(0, runCount(plan)));
+        }
+    }
 }

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -691,3 +691,43 @@ resourcePolicy:
       condition:
         match:
           expr: 'size(R.attr.tags) >= 1.5'
+
+    # ==================== constant NaN / ±Infinity ordering ====================
+    # CEL/IEEE define every ordering comparison involving NaN as false. The planner does
+    # NOT fold div(0,0): the else arm below arrives as an unfolded div(0,0) subtree, so
+    # the adapter folds it to NaN in Java and must order with IEEE semantics — a
+    # Double.compare total order ranks NaN above every number and would turn the else arm
+    # into always-true, returning every aBool=false row the PDP denies.
+    - actions: ["nan-ord-ternary"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '(R.attr.aBool ? 1.0 : 0.0/0.0) > 0.5'
+
+    # Value-first spelling: the planner preserves source order, so the mirrored branch
+    # comparison places the folded NaN on the normalized LEFT (lt → gt divergence arm).
+    - actions: ["nan-ord-ternary-vf"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '0.5 < (R.attr.aBool ? 1.0 : 0.0/0.0)'
+
+    # NaN on the RIGHT of the comparison (ternary vs ternary — both sides stay
+    # expressions, so no mirror moves the NaN): le(0.5, NaN) must also be false.
+    - actions: ["nan-ord-le"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '(R.attr.aBool ? 1.0/1.0 : 1.0/2.0) <= (R.attr.aBool ? 0.5 : 0.0/0.0)'
+
+    # ±Infinity sanity: infinities are ORDERED normally in IEEE space (+Inf > 0.5 allows,
+    # -Inf > 0.5 denies) — they must not be excluded the way NaN is.
+    - actions: ["nan-ord-inf"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '(R.attr.aBool ? 1.0/0.0 : -1.0/0.0) > 0.5'


### PR DESCRIPTION
Finding 4/27 from an internal adversarial review of the spring-data adapter.

## Problem: total order vs IEEE ordering

`constantComparison` statically evaluates comparisons where both operands fold to plan constants (the planner never emits these directly, but the ternary rewrite and arithmetic constant folding produce them). The numeric ordering arm used `Double.compare`, whose **total order** ranks `NaN` above every number (and `-0.0` below `0.0`). CEL — like IEEE 754 — defines **every** ordering comparison involving `NaN` as false.

Consequences on the old code:

- `gt`/`ge` against a left-side `NaN` constant: `Double.compare(NaN, 0.5) = +1` → the branch collapsed to `cb.conjunction()` (always-true) — the filter returns rows the PDP's `check()` denies (authorization over-inclusion).
- `lt`/`le` with `NaN` on the right (`Double.compare(0.5, NaN) = -1`): same always-true collapse.
- `-0.0` vs `0.0` orderings inverted (`lt` wrongly true, `ge` wrongly false) — same total-order defect on the same line.

NaN constants are reachable from real plans: the planner does **not** fold `div(0,0)`, so it arrives verbatim and `resolveNumericOperand` correctly folds it to `NaN` in Java (per its "full CEL fidelity, Infinity/NaN included" contract) — then the ordering arm inverted the result.

## Live-PDP reproduction

Verified against a scratch `ghcr.io/cerbos/cerbos:latest` PDP:

Policy `(R.attr.aBool ? 1.0 : 0.0/0.0) > 0.5` produces the wire plan
`gt(if(aBool, 1, div(0,0)), 0.5)` — `div(0,0)` unfolded. `check()`:

| resource | verdict |
|---|---|
| `aBool=true` | ALLOW (`1.0 > 0.5`) |
| `aBool=false` | DENY (`NaN > 0.5` is false) |

The old adapter's Specification returned the `aBool=false` row: the rewritten ternary else arm became `(NOT aBool AND 1=1)`.

Also verified live: `1.0/0.0` / `-1.0/0.0` arrive unfolded and `check()` orders the resulting infinities normally (`+Inf > 0.5` → ALLOW, `-Inf > 0.5` → DENY), and the ternary-vs-ternary shape delivers `NaN` on the right-hand side of `le`.

## Fix

Replace `Double.compare` with the primitive IEEE operators (`<`, `>`, `<=`, `>=`) in the numeric ordering arm of `constantComparison`. Any `NaN` operand now makes the comparison false → the branch contributes `cb.disjunction()` (exclusion), matching `check()`. This also corrects `-0.0` ordering for free.

Untouched by design:
- the `eq`/`ne` arm already uses IEEE `==` and is correct;
- the string `compareTo` arm is correct;
- the SQL-side `numericComparison` lowering is out of scope.

Audit: the only `Double.compare`/`compareTo` over plan-derived values in the main source tree was this one site — no other ordering consumers of the NaN fold exist.

## Tests

New unit tests (`ConstantNanInfinityOrdering`, hand-built plans, seeded rows so always-true vs exclusion is distinguishable):
- `NaN` on the left and on the right of all four ordering operators (`gt`/`ge`/`lt`/`le`) → row excluded;
- ±Infinity ordering sanity — infinities must follow normal IEEE ordering, not be excluded like `NaN`;
- `-0.0` vs `0.0` IEEE ordering;
- the live-PDP ternary reproduction: `aBool=true` row included, `aBool=false` row excluded.

New differential-oracle actions in `adversarial-policy.yaml` (adapter row-set vs per-row `check()` on a live PDP), pinning CEL NaN/Infinity semantics:
- `nan-ord-ternary` — `(R.attr.aBool ? 1.0 : 0.0/0.0) > 0.5` (diverges on old code for every `aBool=false` seed; agrees on `aBool=true` seeds);
- `nan-ord-ternary-vf` — value-first spelling (mirrored branch comparison);
- `nan-ord-le` — ternary-vs-ternary putting `NaN` on the right of `le`;
- `nan-ord-inf` — ±Infinity ordering sanity.

## Results

Full Docker Gradle build (`gradle clean build`, testcontainers PDP): **BUILD SUCCESSFUL — 365 tests, 0 failures**.

Negative control — with the fix reverted (ordering arm back on `Double.compare`), the new tests fail exactly as predicted (7 failures):

```
AdversarialConformanceTest > adapterMatchesCheckOracle > nan-ord-ternary FAILED
AdversarialConformanceTest > adapterMatchesCheckOracle > nan-ord-ternary-vf FAILED
AdversarialConformanceTest > adapterMatchesCheckOracle > nan-ord-le FAILED
ConstantNanInfinityOrdering > nanOnLeftExcludesForAllOrderingOperators FAILED
ConstantNanInfinityOrdering > nanOnRightExcludesForAllOrderingOperators FAILED
ConstantNanInfinityOrdering > negativeZeroOrderingFollowsIeee FAILED
ConstantNanInfinityOrdering > ternaryNanElseArmExcludesRows FAILED
```

`nan-ord-inf` and `infinityOrderingFollowsIeee` pass on both old and new code, as intended — they pin that the fix does not over-exclude ordinary IEEE-ordered specials.
