### PR TITLE
fix(spring-data): throw a named error for eq/ne against list constants

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -235,6 +235,7 @@ SQL fragments), or wait for adapter support.
 | List indexing                                   | `R.attr.tags[0] == "x"`                           | JPA collections are unordered sets — no positional access. |
 | Type casts (`int(...)` / `double(...)` / `string(...)`) | `int(R.attr.aString) > 0`                 | No portable `CAST` in Criteria; override per-dialect. |
 | `eq(map(...), [...])`                           | `R.attr.tags.map(t, t.id) == ["tag1", "tag2"]`    | Use `hasIntersection(map(...), [...])` instead. |
+| `eq`/`ne` against a list constant               | `R.attr.tags == ["a", "b"]`                       | Whole-list equality has no scalar-column translation (the plan arrives as `eq(variable, value-list)` verbatim). Map the attribute as a Relation and use `in`/`hasIntersection`, or compare elements individually. |
 
 ## Gotchas
 

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -702,6 +702,28 @@ public final class SpringDataQueryPlanAdapter {
             private Predicate leafFieldValue(String op, Resolved.Field field,
                                              Resolved.Constant constant, Scope scope) {
                 Object value = constant.value();
+
+                // A structured constant — a CEL list literal (`R.attr.tags == ["a", "b"]`
+                // arrives as eq(variable, value-list) verbatim; PDP-verified in both operand
+                // orders) or, defensively, a struct VALUE (protoValueToJava can produce a Map,
+                // though the planner emits map literals as struct() expressions, which
+                // leafOperandError already names). No scalar-column comparison exists for
+                // these: letting the value through dies inside Hibernate with a raw coercion
+                // error ("Could not convert ... ListN to java.lang.String") instead of the
+                // adapter's named-IllegalArgumentException contract. Checked BEFORE path
+                // resolution so a Relation-mapped attribute reports this shape too, not the
+                // generic "is a Relation" resolution error. Reports the shape only — element
+                // values never leak into the message.
+                if (value instanceof List<?> || value instanceof Map<?, ?>) {
+                    throw new IllegalArgumentException(
+                            op + " comparison against a " + constantShape(value)
+                                    + " constant is not supported for attribute "
+                                    + field.variable() + ". Whole-" + kindWord(value)
+                                    + " equality is not translatable to a scalar column"
+                                    + " comparison; map the attribute as a Relation and use"
+                                    + " in/hasIntersection, or compare elements individually.");
+                }
+
                 Path<?> path = scope.resolvePath(field.variable());
 
                 if (value == null) {
@@ -715,6 +737,23 @@ public final class SpringDataQueryPlanAdapter {
                 }
 
                 return applyLeaf(op, path, value);
+            }
+
+            /**
+             * Shape description for a structured constant in an error message: size and kind
+             * only — never element values, matching the adapter's no-value-leak discipline
+             * (see {@link #typeName}).
+             */
+            private static String constantShape(Object value) {
+                if (value instanceof List<?> l) {
+                    return "list of " + l.size() + " element" + (l.size() == 1 ? "" : "s");
+                }
+                Map<?, ?> m = (Map<?, ?>) value;
+                return "map of " + m.size() + " entr" + (m.size() == 1 ? "y" : "ies");
+            }
+
+            private static String kindWord(Object value) {
+                return value instanceof List<?> ? "list" : "map";
             }
 
             /**

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -2,6 +2,7 @@ package dev.cerbos.queryplan.springdata;
 
 import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
+import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter;
 import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter.Expression;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -678,6 +680,94 @@ class SpringDataQueryPlanAdapterTest {
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> runCount(cond));
         assertTrue(ex.getMessage().contains("Unsupported operator"));
+    }
+
+    // -- eq/ne against a structured (list/map) constant: named error, not a raw Hibernate one --
+
+    /**
+     * PDP-verified wire shapes (Cerbos {@code :latest}, 2026-07-23): {@code R.attr.tags ==
+     * ["a", "b"]} arrives as {@code eq(variable, value-list)} verbatim — in BOTH operand
+     * orders — and {@code ne} likewise. Without the guard, {@code cb.equal(stringPath, List)}
+     * dies inside Hibernate with a raw coercion error ("Could not convert
+     * java.util.ImmutableCollections$ListN to java.lang.String"), violating the README's
+     * contract that unsupported constructs throw {@link IllegalArgumentException} naming the
+     * operator. These tests pin the named error AND that no element values leak into it.
+     */
+    @Nested
+    class StructuredConstantComparison {
+
+        /** Distinctive element values so the no-leak assertions cannot false-negative. */
+        private static final String ELEM_A = "leak-canary-alpha";
+        private static final String ELEM_B = "leak-canary-beta";
+
+        private static IllegalArgumentException assertNamedError(Operand cond, String op,
+                                                                 String attribute, String shape) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> runCount(cond));
+            String msg = ex.getMessage();
+            assertTrue(msg.contains(op), "expected operator '" + op + "' in: " + msg);
+            assertTrue(msg.contains(attribute), "expected attribute '" + attribute + "' in: " + msg);
+            assertTrue(msg.contains(shape), "expected shape '" + shape + "' in: " + msg);
+            assertTrue(msg.contains("hasIntersection"),
+                    "expected the supported alternative in: " + msg);
+            assertFalse(msg.contains(ELEM_A), "element value leaked into: " + msg);
+            assertFalse(msg.contains(ELEM_B), "element value leaked into: " + msg);
+            return ex;
+        }
+
+        @Test
+        void eqFieldAgainstListConstantThrowsNamedError() {
+            assertNamedError(
+                    exprOp("eq", var("request.resource.attr.aString"), listOp(ELEM_A, ELEM_B)),
+                    "eq", "request.resource.attr.aString", "list of 2 elements");
+        }
+
+        @Test
+        void neFieldAgainstListConstantThrowsNamedError() {
+            assertNamedError(
+                    exprOp("ne", var("request.resource.attr.aString"), listOp(ELEM_A, ELEM_B)),
+                    "ne", "request.resource.attr.aString", "list of 2 elements");
+        }
+
+        @Test
+        void eqValueFirstListConstantThrowsNamedError() {
+            // ["a", "b"] == R.attr.x — source order is preserved on the wire; NormalizedBinary
+            // mirrors it back to field-first, so the same named error must surface.
+            assertNamedError(
+                    exprOp("eq", listOp(ELEM_A), var("request.resource.attr.aString")),
+                    "eq", "request.resource.attr.aString", "list of 1 element");
+        }
+
+        @Test
+        void neValueFirstListConstantThrowsNamedError() {
+            assertNamedError(
+                    exprOp("ne", listOp(ELEM_A, ELEM_B), var("request.resource.attr.aString")),
+                    "ne", "request.resource.attr.aString", "list of 2 elements");
+        }
+
+        @Test
+        void eqRelationAgainstListConstantThrowsNamedError() {
+            // Relation-mapped attribute: previously surfaced the generic "is a Relation;
+            // cannot resolve as a scalar path" — the structured-constant guard runs before
+            // path resolution so this shape gets the same actionable message.
+            assertNamedError(
+                    exprOp("eq", var("request.resource.attr.tags"), listOp(ELEM_A, ELEM_B)),
+                    "eq", "request.resource.attr.tags", "list of 2 elements");
+        }
+
+        @Test
+        void eqFieldAgainstStructConstantThrowsNamedError() {
+            // Defensive: the planner emits map literals as struct() expressions (which throw a
+            // named error via leafOperandError), but protoValueToJava can produce a Map from a
+            // STRUCT_VALUE — pin the same contract for that shape.
+            Operand structConstant = Operand.newBuilder()
+                    .setValue(Value.newBuilder().setStructValue(Struct.newBuilder()
+                            .putFields("k", Value.newBuilder().setStringValue(ELEM_A).build())))
+                    .build();
+            assertNamedError(
+                    exprOp("eq", var("request.resource.attr.aString"), structConstant),
+                    "eq", "request.resource.attr.aString", "map of 1 entry");
+        }
     }
 
     // -- add operator --


### PR DESCRIPTION
## Problem

The README promises that unsupported CEL constructs throw `IllegalArgumentException` naming the operator. Comparing an attribute to a list literal breaks that contract: `leafFieldValue` only null-checks the constant, so `cb.equal(stringPath, List)` dies deep inside Hibernate instead of failing at the adapter boundary.

This is a PDP-reachable shape, not a synthetic one. Verified against a live Cerbos PDP (`ghcr.io/cerbos/cerbos:latest`, 2026-07-23):

- `request.resource.attr.tags == ["a", "b"]` → `eq(variable, value-list)` verbatim
- `request.resource.attr.tags != ["a", "b"]` → `ne(variable, value-list)` verbatim
- `["a", "b"] == request.resource.attr.tags` → `eq(value-list, variable)` (source order preserved; `NormalizedBinary` mirrors it back to field-first)
- Constant-folded principal attributes holding lists (`R.attr.tags == P.attr.ptags`) fold to the same `eq(variable, value-list)` shape
- Map literals (`R.attr.meta == {"k": "v"}`) arrive as `struct()` **expressions**, not VALUE structs — even when folded from principal attributes — and already throw a named error via `leafOperandError`

Observed old behavior (Hibernate 6.6.x / H2):

- Field-mapped attribute: `org.hibernate.HibernateException: Could not convert 'java.util.ImmutableCollections$ListN' to 'java.lang.String' using 'org.hibernate.type.descriptor.java.StringJavaType' to wrap`
- Struct VALUE (defensive, hand-built): same with `'java.util.LinkedHashMap'`
- Relation-mapped attribute: the unrelated `Attribute request.resource.attr.tags is a Relation; cannot resolve as a scalar path`

Fail-closed either way — this is an error-contract fix, not a semantics fix. Whole-list equality is deliberately NOT implemented.

## Fix

`leafFieldValue` now detects a structured constant (`List`, and defensively `Map` — `protoValueToJava` can produce one from a STRUCT_VALUE even though the planner emits map literals as `struct()` expressions) and throws a named `IllegalArgumentException` **before** path resolution. Message shape:

```
eq comparison against a list of 2 elements constant is not supported for attribute
request.resource.attr.tags. Whole-list equality is not translatable to a scalar column
comparison; map the attribute as a Relation and use in/hasIntersection, or compare
elements individually.
```

It names the operator, the attribute path, the constant's shape (size + kind only — element values never leak, matching the adapter's no-value-leak error discipline), and the supported alternative.

**Relation-mapped variant:** because the guard runs before `scope.resolvePath`, the Relation-mapped case now gets the same actionable message instead of the generic "is a Relation; cannot resolve as a scalar path". This was the cheap way to cover it — `Scope.resolvePath` has no operator/constant context, so improving the message there would have meant threading comparison context through the resolution API.

Note: the throw is pre-override, consistent with the other unsupported operand-shape errors (`timestamp()`, `mod`, `map()` — none of which reach the `withOverride` hook either).

## Tests

New `StructuredConstantComparison` nested suite (6 tests) hand-building the PDP-verified wire shapes: `eq`/`ne` × (field-first, value-first mirror), the Relation-mapped variant, and the defensive struct VALUE. Each asserts `IllegalArgumentException` containing the operator, the attribute path, the shape description, and the `hasIntersection` alternative — and asserts distinctive canary element values do NOT appear in the message.

**Negative control** — all 6 tests fail on the old code (fix stashed, tests kept):

```
6 tests completed, 6 failed
Unexpected exception type thrown, expected: <java.lang.IllegalArgumentException>
  but was: <org.hibernate.HibernateException>
HibernateException: Could not convert 'java.util.ImmutableCollections$ListN' to 'java.lang.String' ...
```

**Full build** (Docker `gradle:8.12-jdk17`, testcontainers PDP): `BUILD SUCCESSFUL` — all suites green, including `AdversarialConformanceTest` (88 differential-oracle tests) and the integration suites.

## README

Added the `eq`/`ne`-vs-list-constant row to the "Not yet supported" table with the recommended alternative.

---

Finding 14/28 from an internal adversarial review of the spring-data adapter.
