### PR TITLE
ci(spring-data): build the example app and run its smoke test in CI

### DIFF
--- a/.github/workflows/spring-data.yaml
+++ b/.github/workflows/spring-data.yaml
@@ -62,3 +62,35 @@ jobs:
         run: gradle build --no-daemon
         env:
           ADAPTER_TEST_DB: ${{ matrix.database }}
+
+  # Compiles the standalone example app (a composite build over the adapter source — building
+  # the adapter alone never compiles it) and runs example/scripts/smoke.sh end-to-end: a live
+  # Cerbos PDP via docker compose, the Spring Boot app on H2, and row-set + PDP audit-log
+  # assertions for every (user, role, action) scenario. This is the repo's only end-to-end
+  # live-PDP row-set verification and the primary onboarding artifact, so an adapter API
+  # change that breaks the example must fail CI. On failure the script dumps the Cerbos
+  # container logs and the Spring Boot log before tearing the environment down.
+  example:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup JDK
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          # The example's Spring Boot 3.5.x Gradle plugin is validated against Gradle 8.x
+          # (smoke.sh's documented prerequisite), not the runner's floating preinstall.
+          gradle-version: "8.12"
+
+      - name: Build example
+        run: gradle -p example build --no-daemon
+
+      - name: Run smoke test
+        run: ./example/scripts/smoke.sh

--- a/spring-data/example/scripts/smoke.sh
+++ b/spring-data/example/scripts/smoke.sh
@@ -17,9 +17,20 @@ fail() { printf "${RED}FAIL${NC} %s\n" "$*" >&2; exit 1; }
 ok()   { printf "${GREEN}OK${NC}   %s\n" "$*"; }
 
 cleanup() {
+    local status=$?
     if [[ -n "${APP_PID:-}" ]]; then
         kill "$APP_PID" 2>/dev/null || true
         wait "$APP_PID" 2>/dev/null || true
+    fi
+    # On failure, dump diagnostics BEFORE `compose down` discards the container —
+    # this is what CI (and anyone running headless) gets to debug with.
+    if (( status != 0 )); then
+        echo "==> smoke test failed (exit $status): Cerbos container logs" >&2
+        docker compose logs --no-color cerbos >&2 || true
+        if [[ -f build/smoke/app.log ]]; then
+            echo "==> smoke test failed (exit $status): last 200 lines of Spring Boot log" >&2
+            tail -n 200 build/smoke/app.log >&2 || true
+        fi
     fi
     docker compose down --remove-orphans >/dev/null 2>&1 || true
 }


### PR DESCRIPTION
## The gap

The `spring-data/example/` app is the primary onboarding artifact — the adapter README points customers at it as the runnable end-to-end reference — yet no CI job ever compiled or ran it. `settings.gradle.kts` does not include `example/`; the example is an independent composite build (`includeBuild("..")` is directional), so the workflow's `gradle build` in `spring-data/` never touches it. `example/scripts/smoke.sh` — the repo's **only** end-to-end live-PDP row-set verification (42 (user, role, action) scenarios across 3 resource kinds, cross-checked against the PDP's own audit log) — was never executed by any workflow. An adapter public-API rename would merge green while breaking the example and silently rotting the smoke assertions.

Finding 12/28 from an internal adversarial review of the spring-data adapter.

## What this PR does

**New `example` job in `.github/workflows/spring-data.yaml`** (existing `test` / `test-database` jobs untouched):

1. Checkout + Temurin JDK 17 + Gradle via the same SHA-pinned actions as the existing jobs. Gradle is pinned to 8.12 for this job (Spring Boot 3.5.x's Gradle plugin is validated against 8.x — smoke.sh's documented prerequisite — rather than the runner's floating preinstall).
2. `gradle -p example build --no-daemon` — compiles the example against the adapter source via the composite build, so an adapter API break now fails CI.
3. `./example/scripts/smoke.sh` — the script itself brings up the Cerbos PDP via `example/docker-compose.yml`, waits on its healthcheck, starts the Spring Boot app in the background with readiness polling on :8080, runs all row-set assertions plus the PDP audit-log cross-checks, and tears everything down. Any assertion failure fails the job.

No `on:` path changes needed: `spring-data/**` already covers `example/**`.

**One minimal smoke.sh adjustment** (no assertion touched): the cleanup trap previously ran `docker compose down` unconditionally, destroying the PDP container — and its logs — before CI could collect anything. It now dumps the Cerbos container logs and the last 200 lines of the Spring Boot log to stderr on failure, *before* teardown. The script was already fully headless (bounded readiness loops, non-interactive); nothing else needed.

## Evidence

**Local run (macOS, JDK 17 / Gradle 8.12): `gradle -p example build` → BUILD SUCCESSFUL; `./scripts/smoke.sh`:**

```
OK   alice/view  => p1,p2,p5,p6,p7,p8
OK   alice/edit  => p1,p2,p6
OK   alice/comment  => p1,p2,p5,p6,p7,p8
OK   bob/view  => p1,p3,p4,p5,p7,p8
OK   bob/edit  => p3,p4
OK   charlie/comment  => p1,p2,p5,p7,p8
OK   admin/view  => p1,p2,p3,p4,p5,p6,p7,p8
OK   admin/delete  => p1,p2,p3,p4,p5,p6,p7,p8
OK   admin/globex  => p9
OK   alice/view/rating  => p1,p5
OK   discover  => p1,p3,p5,p7,p8
OK   located  => p1,p3,p4,p5,p6,p8
OK   similar/travel  => p1,p5
OK   similar/multiple  => p1,p2,p5
OK   similar/empty  =>
OK   delegated/direct  => p3
OK   delegated/groups  => p2,p3,p5
OK   delegated/finance  => p2
OK   delegated/mismatched-tenant  =>
OK   delegated/globex  => p9
OK   grant/positive-unknown  => p2,p7
OK   grant/negated-unknown  => p4,p5,p6
OK   grant/guarded-negation  => p1,p3,p4,p5,p6,p8
OK   needs-moderation  => p2,p3
OK   fully-reviewed  => p1,p3,p4,p6,p7,p8
OK   unlabelled  => p4,p6,p7,p8
OK   exactly-one  => p1,p2,p3,p5
OK   literal-percent  => p7
OK   literal-underscore  => p8
OK   always-denied  =>
OK   moderation/page-0  => ids=p2 total=2 pages=2
OK   moderation/page-1  => ids=p3 total=2 pages=2
OK   delegated/page-0  => ids=p2,p3 total=3 pages=2
OK   delegated/page-1  => ids=p5 total=3 pages=2
OK   album/alice-view  => a1,a2
OK   album/bob-manage  => a2
OK   album/admin-globex  => a3
OK   album/always-denied  =>
OK   workspace/alice-access  => w1
OK   workspace/bob-administer  => w1
OK   workspace/admin-globex  => w3
OK   workspace/always-denied  =>
OK   HTTP -> service -> PDP  => 42 calls across 3 resource kinds
OK   pagination/negative-page  => HTTP 400
OK   pagination/oversized  => HTTP 400
OK   filter/invalid-rating  => HTTP 400
OK   controller rejection -> no PDP call
OK   all HTTP, database result, and PDP audit assertions passed
```

**Failure path verified**: a temp copy with one deliberately wrong expected row-set exits 1 and dumps the Cerbos audit log + Spring Boot log through the new cleanup path.

**Workflow lint**: `actionlint` clean.

The new `example` job runs on this PR (the workflow change is in it) — see checks below.
