### PR TITLE
feat(spring-data): support timestamp(field) comparisons against folded instants

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -195,6 +195,7 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | Field-to-field (`R.attr.a == R.attr.b`) | `cb.equal(pathA, pathB)` and friends for `eq`/`ne`/`lt`/`gt`/`le`/`ge`, incl. inside lambdas |
 | Ternary (`cond ? a : b`)         | Predicate rewrite: `(cond AND cmp(a, v)) OR (NOT cond AND cmp(b, v))` — nested, boolean-position, and value-first forms compose; constant residues fold (see Gotchas for `NULL` semantics) |
 | Arithmetic in comparisons (`add`/`sub`/`mult`/`div`) | `cb.sum`/`diff`/`prod`/`quot` in double space, compared via `eq`/`ne`/`lt`/`gt`/`le`/`ge`; nested and both-sides shapes compose (see Gotchas — CEL attribute arithmetic is double arithmetic) |
+| Timestamp comparisons (`timestamp(R.attr.createdAt) < now() - duration("24h")`) | Temporal column comparison for all of `eq`/`ne`/`lt`/`gt`/`le`/`ge`, both operand orders (value-first forms mirror). The planner folds `now()`/`now() - duration(...)` to a constant RFC-3339 instant at **plan time**, so the window is fixed per query — re-plan to refresh it. The mapped column must be `java.time.Instant` or `java.time.OffsetDateTime` (both denote an absolute instant; Hibernate 6 stores them UTC-normalized). `LocalDateTime`, `java.util.Date`, and `String` columns throw a named error — they are ambiguous about the absolute instant they store (see Gotchas). A `NULL` column value is excluded, matching `check()` denying on the missing attribute. |
 | Field-to-field `contains`/`startsWith`/`endsWith` | `cb.like` over a `REPLACE`-escaped column-derived pattern (`\`, `%`, `_`), with an `IS NOT NULL` needle guard |
 | Multi-hop relation chains (`R.attr.categories.subCategories`) | Correlated subquery joining through every hop; `exists`/`in`/`hasIntersection`/`size` all treat the chain as the flattened union of tail elements |
 | `exists(coll, lambda)`           | Correlated `EXISTS` with lambda body                                |
@@ -208,7 +209,8 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | `hierarchy(...).overlaps / ancestorOf / descendentOf` | Segment/prefix predicates (`IN` over ancestor prefixes, `LIKE 'a:b:%'` for descendants), mirroring the Prisma adapter |
 | Value-first comparisons (`5 < R.attr.x`) | Normalized field-first with the operator mirrored (`x > 5`) |
 
-Unsupported operators raise `IllegalArgumentException` — override them with `OperatorFunction`:
+Unsupported constructs raise `IllegalArgumentException`. Some — but not all — can be
+overridden with an `OperatorFunction`:
 
 ```java
 Map<String, OperatorFunction> overrides = Map.of(
@@ -220,21 +222,33 @@ Result<Contact> result =
     SpringDataQueryPlanAdapter.toSpecification(planResult, MAPPING, overrides);
 ```
 
+An override is consulted only where the adapter has already resolved a `(field, value)`
+pair for a top-level operator — the plain comparisons (`eq`/`ne`/`lt`/`gt`/`le`/`ge`,
+consulted under the mirrored name for value-first forms), the LIKE family, unknown
+top-level leaf operators such as `matches`, and timestamp comparisons (the override
+receives the parsed `java.time.Instant` as the value, including for column types the
+default translation rejects). Constructs rejected **while resolving an operand** — `mod`,
+`int()`/type casts, list indexing — throw before any override lookup and **cannot be
+intercepted**; the "Not yet supported" table below marks each row.
+
 ## Not yet supported
 
 The Criteria-based predicate builder has no shape for these CEL constructs; they
-throw `IllegalArgumentException` with a message naming the operator. Override
-via `OperatorFunction` when the runtime can express them (e.g. database-specific
-SQL fragments), or wait for adapter support.
+throw `IllegalArgumentException` with a message naming the operator. The
+"Overridable" column says whether a registered `OperatorFunction` can intercept
+the construct: rows marked **no** are rejected while resolving an operand,
+*before* any override consultation, so an override genuinely cannot fire for them.
 
-| Construct                                       | Example CEL                                       | Notes |
-|-------------------------------------------------|---------------------------------------------------|-------|
-| `mod`                                           | `R.attr.aNumber % 2 == 0`                         | CEL `%` is int-only and Cerbos attribute numbers are doubles, so `%` on an attribute always errors → the check API denies every row; translating to SQL `MOD` would fabricate matches. |
-| Arithmetic on non-numeric operands              | `R.attr.aString + "x" < "y"`                      | Ordering through string concatenation is not translated; `add` string folding remains `eq`/`ne`-only. |
-| Regex match                                     | `R.attr.aString.matches("^foo.*")`                | JPA has no portable regex predicate; override per-dialect (`regexp_like`, `~`, `REGEXP`). |
-| List indexing                                   | `R.attr.tags[0] == "x"`                           | JPA collections are unordered sets — no positional access. |
-| Type casts (`int(...)` / `double(...)` / `string(...)`) | `int(R.attr.aString) > 0`                 | No portable `CAST` in Criteria; override per-dialect. |
-| `eq(map(...), [...])`                           | `R.attr.tags.map(t, t.id) == ["tag1", "tag2"]`    | Use `hasIntersection(map(...), [...])` instead. |
+| Construct                                       | Example CEL                                       | Overridable | Notes |
+|-------------------------------------------------|---------------------------------------------------|-------------|-------|
+| `mod`                                           | `R.attr.aNumber % 2 == 0`                         | no          | CEL `%` is int-only and Cerbos attribute numbers are doubles, so `%` on an attribute always errors → the check API denies every row; translating to SQL `MOD` would fabricate matches. |
+| Arithmetic on non-numeric operands              | `R.attr.aString + "x" < "y"`                      | no          | Ordering through string concatenation is not translated; `add` string folding remains `eq`/`ne`-only. |
+| Regex match                                     | `R.attr.aString.matches("^foo.*")`                | yes (`matches`) | JPA has no portable regex predicate; override per-dialect (`regexp_like`, `~`, `REGEXP`). |
+| List indexing                                   | `R.attr.tags[0] == "x"`                           | no          | JPA collections are unordered sets — no positional access. |
+| Type casts (`int(...)` / `double(...)` / `string(...)`) | `int(R.attr.aString) > 0`                 | no          | No portable `CAST` in Criteria. |
+| `eq(map(...), [...])`                           | `R.attr.tags.map(t, t.id) == ["tag1", "tag2"]`    | no          | Use `hasIntersection(map(...), [...])` instead. |
+| Timestamp comparison on an ambiguous column type | `timestamp(R.attr.createdAt) < now() - duration("24h")` with `createdAt` mapped to `LocalDateTime`/`java.util.Date`/`String` | yes (the comparison operator) | The supported shape (see table above) requires an `Instant` or `OffsetDateTime` column. Other types don't pin the absolute instant they store — a wrong zone/format assumption would silently diverge from `check()`. The override receives the parsed `Instant` and can apply schema-specific knowledge. |
+| Timestamp shapes beyond `timestamp(field) vs constant` | `timestamp(R.attr.a) < timestamp(R.attr.b)`, `timestamp(...)` inside arithmetic | no | Only the leaf comparison shape the planner emits for time-window policies is translated; nested/derived shapes keep their named errors. |
 
 ## Gotchas
 
@@ -262,6 +276,30 @@ forms produce an identical wire plan), so the adapter translates the double read
 the only satisfiable one: `/` is true double division (`5 / 2.0 == 2.5`), never
 integer truncation. Write double literals (`1.0`, `2.0`) in policy arithmetic over
 attributes, or the plan-based filter and per-resource `check` calls will disagree.
+
+### Timestamp comparisons: plan-time `now()`, and only unambiguous column types
+
+`timestamp(R.attr.createdAt) < now() - duration("24h")` reaches the adapter as a
+comparison against a **constant** instant: the planner evaluates `now()` and folds the
+duration arithmetic when the plan is produced, wrapping the result back in
+`timestamp("<RFC-3339>")`. Two consequences:
+
+- The cutoff is frozen at plan time. A cached `Specification` keeps filtering against the
+  old instant — call `plan` (and re-translate) per request if the window must track wall
+  clock.
+- The mapped column must be `java.time.Instant` or `java.time.OffsetDateTime`. Both
+  unambiguously denote an absolute instant, and Hibernate 6 binds them UTC-normalized
+  (`TIMESTAMP_UTC`), so the database comparison is an instant comparison on H2,
+  PostgreSQL, and MySQL alike (the differential oracle runs all three). `LocalDateTime`
+  has no zone, `java.util.Date` binding routes through zone conversions, and `String`
+  ordering depends on format and offset — the adapter throws a named error for those
+  rather than guessing an assumption that could silently diverge from `check()`. If you
+  know your schema's zone semantics, register an `OperatorFunction` override for the
+  comparison operator: it receives the parsed `Instant` as the value.
+
+  On MySQL, Hibernate maps these columns to `TIMESTAMP`, whose range ends at
+  2038-01-19 — instants beyond that need a schema-controlled `DATETIME(6)` column
+  (still UTC-normalized by Hibernate).
 
 ### Field-to-field string matching builds its pattern with `REPLACE`
 

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -16,6 +16,10 @@ import jakarta.persistence.criteria.Subquery;
 
 import com.google.protobuf.Value;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -287,22 +291,23 @@ public final class SpringDataQueryPlanAdapter {
          * caller-knows-best coupling the seam exists to remove. The chosen shape classifies
          * structurally and converts lazily at the dispatch site that consumes the operand.
          *
-         * <p><b>Extension recipe — adding a new comparison-operand type</b>, worked example
-         * {@code timestamp("2024-01-01T00:00:00Z")} appearing as a comparison operand:
+         * <p><b>Extension recipe — adding a new comparison-operand type</b>. The
+         * {@code timestamp()} support is the worked example, implemented exactly this way:
          * <ol>
-         *   <li>Add a {@code Resolved} case: {@code record Timestamp(Operand arg)} with a lazy
-         *       accessor that parses the argument (its errors are then part of the contract);</li>
-         *   <li>Classify it in {@link #resolve}'s EXPRESSION arm (before the {@code Opaque}
-         *       fallback): {@code "timestamp".equals(exprOp) -> new Resolved.Timestamp(...)};
-         *       a pure-constant argument folds HERE, in the accessor — never in dispatch;</li>
+         *   <li>Add {@code Resolved} cases: {@link Resolved.TimestampField} /
+         *       {@link Resolved.TimestampConstant}, the latter with a lazy accessor that
+         *       parses the argument (its errors are then part of the contract);</li>
+         *   <li>Classify them in {@link #resolve}'s EXPRESSION arm (before the {@code Opaque}
+         *       fallback); a pure-constant argument folds in the accessor — never in
+         *       dispatch;</li>
          *   <li>Handle the new pairings in {@link #dispatch} next to the existing typed cases
-         *       (e.g. {@code Field vs Timestamp} → compare the column against the parsed
-         *       instant via {@link #applyLeaf} so {@link OperatorFunction} overrides keep
+         *       ({@link #timestampLeaf} compares the column against the parsed instant via
+         *       {@link #withOverride} so {@link OperatorFunction} overrides keep
          *       working).</li>
          * </ol>
          * Nothing else changes: no new probe, no re-scan, no ordering decision — unmatched
          * pairings still fall through to {@link #leafOperandError}, whose "Unexpected
-         * timestamp() expression in leaf operand of X" message is the pinned behavior today.
+         * X() expression in leaf operand of Y" message stays the pinned fail-closed behavior.
          */
         private final class ComparisonTranslator {
 
@@ -541,10 +546,48 @@ public final class SpringDataQueryPlanAdapter {
                 record Arithmetic(String operator) implements Resolved {}
 
                 /**
-                 * An operand no leaf comparison understands ({@code timestamp()}, {@code map()},
-                 * {@code lambda}, an unset node...). Dispatch routes these to
-                 * {@link #leafOperandError}, which reports from the RAW operands so each shape
-                 * keeps its exact message.
+                 * {@code timestamp(variable)} — a temporal column wrapped in the CEL
+                 * {@code timestamp()} cast. The path resolves at the consuming dispatch site
+                 * ({@link #timestampLeaf}), which also owns the column-type contract.
+                 */
+                record TimestampField(String variable) implements Resolved {}
+
+                /**
+                 * {@code timestamp(value)} — a constant instant. The planner constant-folds
+                 * {@code now()}/{@code now() - duration(...)} arithmetic and re-wraps the result
+                 * in {@code timestamp("<RFC-3339>")} on the wire (PDP-verified), so both policy
+                 * literals and folded relative windows arrive in this shape. {@link #instant()}
+                 * parses lazily: {@link Instant#parse} first, {@link OffsetDateTime#parse} as
+                 * the fallback for non-UTC offsets (Cerbos emits literals verbatim, including
+                 * offsets and nanosecond precision) — normalizing to the absolute instant,
+                 * matching CEL timestamp equality across offsets.
+                 */
+                record TimestampConstant(Operand operand) implements Resolved {
+                    Instant instant() {
+                        Object raw = PlanValues.protoValueToJava(operand.getValue());
+                        if (!(raw instanceof String s)) {
+                            throw new IllegalArgumentException(
+                                    "timestamp() constant must be an RFC-3339 string, got "
+                                            + (raw == null ? "null" : raw.getClass().getSimpleName()));
+                        }
+                        try {
+                            return Instant.parse(s);
+                        } catch (DateTimeParseException e) {
+                            try {
+                                return OffsetDateTime.parse(s).toInstant();
+                            } catch (DateTimeParseException e2) {
+                                throw new IllegalArgumentException(
+                                        "timestamp() constant could not be parsed as an RFC-3339 instant", e2);
+                            }
+                        }
+                    }
+                }
+
+                /**
+                 * An operand no leaf comparison understands ({@code map()}, {@code lambda},
+                 * {@code timestamp()} over a nested expression, an unset node...). Dispatch
+                 * routes these to {@link #leafOperandError}, which reports from the RAW operands
+                 * so each shape keeps its exact message.
                  */
                 record Opaque() implements Resolved {}
             }
@@ -560,6 +603,21 @@ public final class SpringDataQueryPlanAdapter {
                     case EXPRESSION -> {
                         PlanResourcesFilter.Expression e = o.getExpression();
                         String exprOp = e.getOperator();
+                        // timestamp(variable) / timestamp(value) — the only shapes the planner
+                        // emits for temporal comparisons (PDP-verified: the folded now()-duration
+                        // constant is re-wrapped in timestamp(), never a bare string). A nested
+                        // expression inside timestamp() has no verified translation and stays
+                        // Opaque → leafOperandError.
+                        if ("timestamp".equals(exprOp) && e.getOperandsCount() == 1) {
+                            Operand arg = e.getOperands(0);
+                            if (arg.getNodeCase() == Operand.NodeCase.VARIABLE) {
+                                yield new Resolved.TimestampField(arg.getVariable());
+                            }
+                            if (arg.getNodeCase() == Operand.NodeCase.VALUE) {
+                                yield new Resolved.TimestampConstant(arg);
+                            }
+                            yield new Resolved.Opaque();
+                        }
                         if (!ARITHMETIC_OPS.contains(exprOp)) {
                             yield new Resolved.Opaque();
                         }
@@ -648,6 +706,26 @@ public final class SpringDataQueryPlanAdapter {
                 }
 
                 if (COMPARISON_OPS.contains(op)) {
+                    // timestamp(field) vs timestamp(constant) — the wire shape of every
+                    // time-window / retention-cutoff policy (`timestamp(R.attr.createdAt) <
+                    // now() - duration("24h")` folds its RHS to timestamp("<instant>")).
+                    // NormalizedBinary cannot reorder these (both operands are EXPRESSION
+                    // nodes, equal rank), so the value-first form is MIRRORED here — never
+                    // inverted: the planner preserves policy source order.
+                    if (left instanceof Resolved.TimestampField tsField
+                            && right instanceof Resolved.TimestampConstant tsConst) {
+                        return timestampLeaf(op, tsField, tsConst, scope);
+                    }
+                    if (left instanceof Resolved.TimestampConstant tsConst
+                            && right instanceof Resolved.TimestampField tsField) {
+                        return timestampLeaf(NormalizedBinary.mirror(op), tsField, tsConst, scope);
+                    }
+                    // Two constant instants — reachable through ternary substitution, like the
+                    // numeric constant-vs-constant fold above; instant comparison is exact.
+                    if (left instanceof Resolved.TimestampConstant lts
+                            && right instanceof Resolved.TimestampConstant rts) {
+                        return timestampConstantComparison(op, lts.instant(), rts.instant());
+                    }
                     // Fold: `field op add(value, value)` — the folded constant compares like any
                     // plan constant (normalization guarantees the field arrives first). Strings
                     // concatenate here, matching CEL — this shape never enters double space.
@@ -715,6 +793,79 @@ public final class SpringDataQueryPlanAdapter {
                 }
 
                 return applyLeaf(op, path, value);
+            }
+
+            /**
+             * {@code timestamp(field) op timestamp(constant)}: compare a temporal column against
+             * a parsed constant instant. {@code op} is already field-first (the dispatch mirrors
+             * value-first forms before calling here).
+             *
+             * <p><b>Column-type contract.</b> Only column types that unambiguously denote an
+             * absolute instant are translated:
+             * <ul>
+             *   <li>{@link Instant} — bound as-is;</li>
+             *   <li>{@link OffsetDateTime} — bound as the instant at UTC. Hibernate 6 stores
+             *       both with {@code SqlTypes.TIMESTAMP_UTC} (normalized to UTC before
+             *       binding), so the database comparison is an instant comparison regardless
+             *       of the bound offset.</li>
+             * </ul>
+             * {@code LocalDateTime} (no zone — the stored wall-clock time could mean any
+             * instant), {@code java.util.Date} (JDBC binding routes through zone conversions),
+             * {@code String} (format- and offset-dependent lexicographic order) and everything
+             * else throw a NAMED error instead of guessing: a wrong zone assumption here would
+             * silently include rows the PDP's {@code check()} denies (or vice versa) — an
+             * authorization-relevant divergence, so the adapter fails closed. A registered
+             * {@link OperatorFunction} override is consulted FIRST (with the parsed
+             * {@link Instant} as the value), so callers who know their column's zone semantics
+             * can translate those types themselves.
+             *
+             * <p>A NULL column value makes every comparison UNKNOWN under SQL three-valued
+             * logic → the row is excluded, matching CEL: a missing attribute is an evaluation
+             * error and {@code check()} denies (PDP-verified for eq/ne/lt and mirrored forms).
+             */
+            private Predicate timestampLeaf(String op, Resolved.TimestampField field,
+                                            Resolved.TimestampConstant constant, Scope scope) {
+                Instant instant = constant.instant();
+                Path<?> path = scope.resolvePath(field.variable());
+                return withOverride(op, path, instant, () -> {
+                    Class<?> javaType = path.getJavaType();
+                    Object bound;
+                    if (Instant.class.equals(javaType)) {
+                        bound = instant;
+                    } else if (OffsetDateTime.class.equals(javaType)) {
+                        bound = instant.atOffset(ZoneOffset.UTC);
+                    } else {
+                        throw new IllegalArgumentException(
+                                "timestamp() comparison requires a column mapped to java.time.Instant "
+                                        + "or java.time.OffsetDateTime, but '" + field.variable()
+                                        + "' maps to " + javaType.getSimpleName()
+                                        + ". Other temporal representations (LocalDateTime, "
+                                        + "java.util.Date, String) are ambiguous about the absolute "
+                                        + "instant they store; remap the column or register an "
+                                        + "OperatorFunction override for '" + op + "'.");
+                    }
+                    return defaultLeaf(op, path, bound);
+                });
+            }
+
+            /**
+             * Statically evaluate a comparison between two constant instants — reachable via
+             * ternary substitution, mirroring {@link #constantComparison}. Instant comparison
+             * is total and exact, so the collapse is oracle-faithful.
+             */
+            private Predicate timestampConstantComparison(String op, Instant left, Instant right) {
+                int cmp = left.compareTo(right);
+                boolean result = switch (op) {
+                    case "eq" -> cmp == 0;
+                    case "ne" -> cmp != 0;
+                    case "lt" -> cmp < 0;
+                    case "gt" -> cmp > 0;
+                    case "le" -> cmp <= 0;
+                    case "ge" -> cmp >= 0;
+                    default -> throw new IllegalArgumentException(
+                            "Unsupported constant timestamp comparison operator: " + op);
+                };
+                return result ? cb.conjunction() : cb.disjunction();
             }
 
             /**

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -80,6 +80,8 @@ class AdversarialConformanceTest {
             Map.entry("request.resource.attr.aOptionalString", AttributeMapping.field("aOptionalString")),
             // ISO-date string column + flattened struct member for the p-* probes
             Map.entry("request.resource.attr.createdBy", AttributeMapping.field("createdBy")),
+            // Instant column for the ts-* timestamp() comparison actions
+            Map.entry("request.resource.attr.createdAt", AttributeMapping.field("createdAt")),
             Map.entry("request.resource.attr.obj.inner", AttributeMapping.field("aString")),
             Map.entry("request.resource.attr.tags", AttributeMapping.relation("tags", Map.of(
                     "id", AttributeMapping.field("id"),
@@ -170,6 +172,31 @@ class AdversarialConformanceTest {
     /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
     private static String isoFor(Seed s) {
         return s.aNumber() >= 2 ? "2024-06-01T00:00:00Z" : "2026-06-01T00:00:00Z";
+    }
+
+    /**
+     * Deterministic {@link Instant} per seed for the {@code ts-*} timestamp() comparison
+     * actions. The split matters: a1/a5 and the {@code aNumber < 2} seeds are firmly in the
+     * past (the {@code ts-window} retention cutoff, {@code now() - 24h}, must include them),
+     * a2 and the {@code aNumber >= 2} seeds are far enough in the future to stay AFTER any
+     * plan-time {@code now()} yet inside MySQL's {@code TIMESTAMP} range (which ends
+     * 2038-01-19 — the CI MySQL leg stores Instant as {@code timestamp}), a3 is NULL
+     * (missing attribute → CEL error → {@code check()} denies; SQL NULL comparison →
+     * UNKNOWN → excluded — both sides must agree), a4 is the {@code ts-eq} witness, and a5
+     * carries sub-second (microsecond) precision — exactly representable on H2, PostgreSQL,
+     * and MySQL {@code timestamp(6)} columns.
+     */
+    private static java.time.Instant tsFor(Seed s) {
+        return switch (s.id()) {
+            case "a1" -> java.time.Instant.parse("2020-03-15T10:30:00Z");
+            case "a2" -> java.time.Instant.parse("2037-01-01T00:00:00Z");
+            case "a3" -> null;
+            case "a4" -> java.time.Instant.parse("2024-06-01T00:00:00Z");
+            case "a5" -> java.time.Instant.parse("2020-03-15T10:30:00.123456Z");
+            default -> s.aNumber() >= 2
+                    ? java.time.Instant.parse("2036-06-06T06:06:06Z")
+                    : java.time.Instant.parse("2021-05-05T05:05:05Z");
+        };
     }
 
     /**
@@ -301,6 +328,7 @@ class AdversarialConformanceTest {
             r.setaDouble(doubleFor(s));
             r.setaOptionalString(s.aOptionalString());
             r.setCreatedBy(isoFor(s));
+            r.setCreatedAt(tsFor(s));
             for (Tag tag : s.tags()) {
                 r.addTag(tag.id(), tag.name());
             }
@@ -356,6 +384,11 @@ class AdversarialConformanceTest {
         }
         if (doubleFor(s) != null) {
             r = r.withAttribute("aDouble", AttributeValue.doubleValue(doubleFor(s)));
+        }
+        // A NULL created_at column is a missing attribute on the check side: timestamp()
+        // over it is a CEL evaluation error → deny, matching SQL NULL exclusion.
+        if (tsFor(s) != null) {
+            r = r.withAttribute("createdAt", AttributeValue.stringValue(tsFor(s).toString()));
         }
         // mainCategory mirrors the row's single category as ONE nested object (the seeder
         // creates at most one category per seed), so direct dotted-chain CEL expressions
@@ -470,6 +503,13 @@ class AdversarialConformanceTest {
             // multi-hop relation chains via DIRECT dotted syntax (W1) and a root relation
             // subquery anchored from inside a lambda body (W2)
             "w1-exists-chain", "w1-size-chain", "w1-in-chain", "w2-outer-relation",
+            // timestamp(field) vs folded constant instants against the Instant column
+            // (created_at). ts-window is the retention-cutoff shape (now()-duration folds
+            // at plan time); ts-vf pins value-first MIRRORING (an inversion bug flips the
+            // included set); ts-eq/ts-eq-offset pin instant equality incl. non-UTC offset
+            // normalization; ts-ne pins NULL exclusion (a3 has no created_at: check()
+            // denies on the missing attribute AND SQL excludes the NULL row).
+            "ts-window", "ts-vf", "ts-eq", "ts-eq-offset", "ts-ne",
     })
     void adapterMatchesCheckOracle(String action) {
         List<String> oracle = oracleAllowedIds(action);
@@ -484,7 +524,6 @@ class AdversarialConformanceTest {
      */
     @ParameterizedTest(name = "{0}")
     @CsvSource({
-            "p-timestamp, Unexpected timestamp() expression in leaf operand of lt",
             "p-matches, Unsupported operator: matches",
             "p-index, Unexpected get-field() expression in leaf operand of eq",
     })
@@ -492,6 +531,22 @@ class AdversarialConformanceTest {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class, () -> adapterFilteredIds(action));
         assertEquals(expectedMessage, ex.getMessage());
+    }
+
+    /**
+     * {@code p-timestamp} compares {@code timestamp(R.attr.createdBy)} where {@code createdBy}
+     * maps to a STRING column: timestamp() comparisons are supported only on columns that
+     * unambiguously denote an absolute instant (Instant / OffsetDateTime), so this must keep
+     * failing closed — with the column-type error, not the old pre-support operand error.
+     */
+    @Test
+    void timestampOnNonTemporalColumnThrowsNamedError() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> adapterFilteredIds("p-timestamp"));
+        assertTrue(ex.getMessage().contains("timestamp() comparison requires a column mapped to")
+                        && ex.getMessage().contains("String")
+                        && ex.getMessage().contains("request.resource.attr.createdBy"),
+                "unexpected message: " + ex.getMessage());
     }
 
     @Test

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -55,6 +55,9 @@ class SpringDataQueryPlanAdapterTest {
             Map.entry("request.resource.attr.aDouble", AttributeMapping.field("aDouble")),
             Map.entry("request.resource.attr.aOptionalString", AttributeMapping.field("aOptionalString")),
             Map.entry("request.resource.attr.createdBy", AttributeMapping.field("createdBy")),
+            Map.entry("request.resource.attr.createdAt", AttributeMapping.field("createdAt")),
+            Map.entry("request.resource.attr.updatedAt", AttributeMapping.field("updatedAt")),
+            Map.entry("request.resource.attr.localCreatedAt", AttributeMapping.field("localCreatedAt")),
             Map.entry("request.resource.attr.ownedBy", AttributeMapping.relation("ownedBy")),
             Map.entry("request.resource.attr.tags", AttributeMapping.relation("tags", Map.of(
                     "id", AttributeMapping.field("id"),
@@ -2832,6 +2835,232 @@ class SpringDataQueryPlanAdapterTest {
             } finally {
                 em.close();
             }
+        }
+    }
+
+    // -- timestamp(field) vs timestamp(constant) comparisons --
+    // Wire shape (PDP-verified): `timestamp(R.attr.createdAt) < now() - duration("24h")`
+    // arrives as lt(timestamp(variable), timestamp(value "<RFC-3339>")) — the planner folds
+    // now()-duration to a constant instant and RE-WRAPS it in timestamp(); a bare string
+    // constant never appears. Value-first policies keep source order (both operands are
+    // EXPRESSION nodes, so NormalizedBinary cannot reorder them) and must be MIRRORED.
+
+    @Nested
+    class TimestampComparisons {
+
+        private static final String CONST = "2025-01-01T00:00:00Z";
+
+        private Operand tsVar(String attr) {
+            return exprOp("timestamp", var("request.resource.attr." + attr));
+        }
+
+        private Operand tsVal(String iso) {
+            return exprOp("timestamp", sval(iso));
+        }
+
+        /** Seed rows: two before {@link #CONST}, one exactly at it, one after, one NULL. */
+        private void withTimestampRows(Runnable body) {
+            ResourceEntity old1 = new ResourceEntity("ts-old1");
+            old1.setCreatedAt(java.time.Instant.parse("2024-03-01T00:00:00Z"));
+            old1.setUpdatedAt(java.time.OffsetDateTime.parse("2024-03-01T00:00:00Z"));
+            old1.setaBool(true);
+            ResourceEntity old2 = new ResourceEntity("ts-old2");
+            old2.setCreatedAt(java.time.Instant.parse("2024-06-01T00:00:00.123456Z"));
+            old2.setUpdatedAt(java.time.OffsetDateTime.parse("2024-06-01T00:00:00.123456Z"));
+            old2.setaBool(false);
+            ResourceEntity exact = new ResourceEntity("ts-exact");
+            exact.setCreatedAt(java.time.Instant.parse(CONST));
+            exact.setUpdatedAt(java.time.OffsetDateTime.parse(CONST));
+            exact.setaBool(false);
+            ResourceEntity newer = new ResourceEntity("ts-new");
+            newer.setCreatedAt(java.time.Instant.parse("2026-02-01T00:00:00Z"));
+            newer.setUpdatedAt(java.time.OffsetDateTime.parse("2026-02-01T00:00:00Z"));
+            newer.setaBool(false);
+            ResourceEntity nul = new ResourceEntity("ts-null"); // createdAt/updatedAt NULL
+            nul.setaBool(false);
+            withResource(old1, () -> withResource(old2, () -> withResource(exact,
+                    () -> withResource(newer, () -> withResource(nul, body)))));
+        }
+
+        @Test
+        void allSixOperatorsFieldFirstOnInstantColumn() {
+            withTimestampRows(() -> {
+                // Row set: old1, old2 < CONST; exact == CONST; new > CONST; null excluded
+                // everywhere (SQL three-valued logic == CEL missing-attribute deny).
+                assertEquals(2, runCount(exprOp("lt", tsVar("createdAt"), tsVal(CONST))));
+                assertEquals(3, runCount(exprOp("le", tsVar("createdAt"), tsVal(CONST))));
+                assertEquals(1, runCount(exprOp("gt", tsVar("createdAt"), tsVal(CONST))));
+                assertEquals(2, runCount(exprOp("ge", tsVar("createdAt"), tsVal(CONST))));
+                assertEquals(1, runCount(exprOp("eq", tsVar("createdAt"), tsVal(CONST))));
+                assertEquals(3, runCount(exprOp("ne", tsVar("createdAt"), tsVal(CONST))));
+            });
+        }
+
+        @Test
+        void allSixOperatorsValueFirstAreMirroredNotInverted() {
+            withTimestampRows(() -> {
+                // `CONST < field` selects rows AFTER the instant (1 row) — an inversion bug
+                // (treating it as `field < CONST`) would return the 2 older rows instead.
+                assertEquals(1, runCount(exprOp("lt", tsVal(CONST), tsVar("createdAt"))));
+                assertEquals(2, runCount(exprOp("le", tsVal(CONST), tsVar("createdAt"))));
+                assertEquals(2, runCount(exprOp("gt", tsVal(CONST), tsVar("createdAt"))));
+                assertEquals(3, runCount(exprOp("ge", tsVal(CONST), tsVar("createdAt"))));
+                assertEquals(1, runCount(exprOp("eq", tsVal(CONST), tsVar("createdAt"))));
+                assertEquals(3, runCount(exprOp("ne", tsVal(CONST), tsVar("createdAt"))));
+            });
+        }
+
+        @Test
+        void offsetDateTimeColumnSupportsAllSixOperators() {
+            withTimestampRows(() -> {
+                assertEquals(2, runCount(exprOp("lt", tsVar("updatedAt"), tsVal(CONST))));
+                assertEquals(3, runCount(exprOp("le", tsVar("updatedAt"), tsVal(CONST))));
+                assertEquals(1, runCount(exprOp("gt", tsVar("updatedAt"), tsVal(CONST))));
+                assertEquals(2, runCount(exprOp("ge", tsVar("updatedAt"), tsVal(CONST))));
+                assertEquals(1, runCount(exprOp("eq", tsVar("updatedAt"), tsVal(CONST))));
+                assertEquals(3, runCount(exprOp("ne", tsVar("updatedAt"), tsVal(CONST))));
+                // Value-first mirror on the OffsetDateTime column too.
+                assertEquals(1, runCount(exprOp("lt", tsVal(CONST), tsVar("updatedAt"))));
+            });
+        }
+
+        @Test
+        void nonUtcOffsetConstantNormalizesToTheSameInstant() {
+            // 2025-01-01T02:00:00+02:00 IS 2025-01-01T00:00:00Z: eq must match the `exact`
+            // row (CEL timestamp equality is instant equality — PDP-verified), and lt must
+            // select the same two older rows as the Z-offset constant.
+            withTimestampRows(() -> {
+                assertEquals(1, runCount(exprOp("eq",
+                        tsVar("createdAt"), tsVal("2025-01-01T02:00:00+02:00"))));
+                assertEquals(2, runCount(exprOp("lt",
+                        tsVar("createdAt"), tsVal("2025-01-01T02:00:00+02:00"))));
+            });
+        }
+
+        @Test
+        void subSecondPrecisionConstantDiscriminates() {
+            // The folded now()-duration constant carries nanosecond precision on the wire.
+            // A threshold BETWEEN old2 (…00.123456Z) and its whole second must split them.
+            withTimestampRows(() -> {
+                assertEquals(1, runCount(exprOp("le",
+                        tsVar("createdAt"), tsVal("2024-06-01T00:00:00.000001Z"))));
+                assertEquals(2, runCount(exprOp("le",
+                        tsVar("createdAt"), tsVal("2024-06-01T00:00:00.123456Z"))));
+            });
+        }
+
+        @Test
+        void nullColumnIsExcludedByEveryOperator() {
+            // Only the NULL row seeded: every comparison is UNKNOWN → zero rows, matching
+            // check() denying on the missing attribute (PDP-verified).
+            ResourceEntity nul = new ResourceEntity("ts-only-null");
+            withResource(nul, () -> {
+                for (String op : List.of("lt", "le", "gt", "ge", "eq", "ne")) {
+                    assertEquals(0, runCount(exprOp(op, tsVar("createdAt"), tsVal(CONST))),
+                            "NULL column must be excluded for " + op);
+                    assertEquals(0, runCount(exprOp(op, tsVal(CONST), tsVar("createdAt"))),
+                            "NULL column must be excluded for value-first " + op);
+                }
+            });
+        }
+
+        @Test
+        void constantVsConstantFoldsViaTernarySubstitution() {
+            // (aBool ? timestamp(A) : timestamp(B)) == timestamp(A) — substitution yields
+            // timestamp-constant vs timestamp-constant comparisons; the fold must select
+            // exactly the aBool=true row (old1).
+            withTimestampRows(() -> assertEquals(1, runCount(exprOp("eq",
+                    exprOp("if",
+                            var("request.resource.attr.aBool"),
+                            tsVal("2024-01-01T00:00:00Z"),
+                            tsVal("2030-01-01T00:00:00Z")),
+                    tsVal("2024-01-01T00:00:00Z")))));
+        }
+
+        @Test
+        void localDateTimeColumnThrowsNamedError() {
+            // LocalDateTime has no zone: the stored wall-clock could denote any instant, and
+            // guessing UTC could silently include rows check() denies. Fail closed, by name.
+            assertConditionThrows(
+                    exprOp("lt", tsVar("localCreatedAt"), tsVal(CONST)),
+                    "timestamp() comparison", "LocalDateTime", "localCreatedAt");
+        }
+
+        @Test
+        void stringColumnThrowsNamedError() {
+            assertConditionThrows(
+                    exprOp("lt", tsVar("createdBy"), tsVal(CONST)),
+                    "timestamp() comparison", "String", "createdBy");
+        }
+
+        @Test
+        void overrideIsConsultedBeforeColumnTypeCheck() {
+            // The README's OperatorFunction escape hatch must be REACHABLE for timestamp
+            // comparisons — including on column types the default translation rejects.
+            assertThrows(OverrideInvoked.class, () -> runCount(
+                    exprOp("lt", tsVar("localCreatedAt"), tsVal(CONST)),
+                    Map.of("lt", THROWING_OVERRIDE)));
+        }
+
+        @Test
+        void valueFirstOverrideIsConsultedUnderTheMirroredOperator() {
+            // Same contract as NormalizedBinary: a value-first lt is looked up as gt.
+            assertThrows(OverrideInvoked.class, () -> runCount(
+                    exprOp("lt", tsVal(CONST), tsVar("createdAt")),
+                    Map.of("gt", THROWING_OVERRIDE)));
+        }
+
+        @Test
+        void bareStringConstantStillThrows() {
+            // The PDP never emits timestamp(variable) vs a bare string (verified against a
+            // live PDP: even folded now()-duration constants are re-wrapped in timestamp()).
+            // Unverifiable shape → keep failing closed.
+            assertConditionThrows(
+                    exprOp("lt", tsVar("createdAt"), sval(CONST)),
+                    "Unexpected timestamp() expression in leaf operand of lt");
+        }
+
+        @Test
+        void numberConstantAgainstTimestampFieldThrows() {
+            assertConditionThrows(
+                    exprOp("gt", tsVar("createdAt"), nval(5)),
+                    "Unexpected timestamp() expression in leaf operand of gt");
+        }
+
+        @Test
+        void timestampOverNestedExpressionThrows() {
+            // timestamp(<expression>) has no verified wire shape → Opaque → named error.
+            assertConditionThrows(
+                    exprOp("lt",
+                            exprOp("timestamp", exprOp("add", sval("a"), sval("b"))),
+                            tsVal(CONST)),
+                    "Unexpected timestamp() expression in leaf operand of lt");
+        }
+
+        @Test
+        void timestampInsideArithmeticStillThrows() {
+            // Nested shapes the numeric machinery routes through resolveNumericOperand keep
+            // their named error — no partial support for shapes the oracle cannot verify.
+            assertConditionThrows(
+                    exprOp("lt",
+                            exprOp("add", tsVar("createdAt"), nval(1)),
+                            nval(5)),
+                    "timestamp() expression inside an arithmetic");
+        }
+
+        @Test
+        void malformedConstantThrowsNamedError() {
+            assertConditionThrows(
+                    exprOp("lt", tsVar("createdAt"), tsVal("not-a-timestamp")),
+                    "timestamp() constant could not be parsed");
+        }
+
+        @Test
+        void nonStringConstantInsideTimestampThrows() {
+            assertConditionThrows(
+                    exprOp("lt", tsVar("createdAt"),
+                            exprOp("timestamp", nval(1735689600))),
+                    "timestamp() constant must be an RFC-3339 string");
         }
     }
 }

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/testmodel/ResourceEntity.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/testmodel/ResourceEntity.java
@@ -14,6 +14,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,6 +50,18 @@ public class ResourceEntity {
 
     @Column(name = "created_by")
     private String createdBy;
+
+    // Temporal columns for the timestamp() comparison support: Instant and OffsetDateTime are
+    // the two column types the adapter translates (both unambiguously denote an absolute
+    // instant); localCreatedAt exists to pin the named error for ambiguous temporal types.
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+
+    @Column(name = "local_created_at")
+    private LocalDateTime localCreatedAt;
 
     @Column(name = "scope")
     private String scope;
@@ -99,6 +114,12 @@ public class ResourceEntity {
     public void setaOptionalString(String aOptionalString) { this.aOptionalString = aOptionalString; }
     public String getCreatedBy() { return createdBy; }
     public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+    public OffsetDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; }
+    public LocalDateTime getLocalCreatedAt() { return localCreatedAt; }
+    public void setLocalCreatedAt(LocalDateTime localCreatedAt) { this.localCreatedAt = localCreatedAt; }
     public String getScope() { return scope; }
     public void setScope(String scope) { this.scope = scope; }
     public List<String> getOwnedBy() { return ownedBy; }

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -521,7 +521,10 @@ resourcePolicy:
 
     # -- GROUP B: suspected-unsupported shapes; record throw vs silent-wrong --
 
-    # B11: timestamp comparison over an ISO-date string column (createdBy is seeded with ISO dates).
+    # B11: timestamp comparison over an ISO-date STRING column (createdBy is seeded with ISO
+    # dates). Supported timestamp() comparisons require an Instant/OffsetDateTime column —
+    # a String column is ambiguous about the instant it stores, so this stays fail-closed
+    # with the named column-type error (see the ts-* actions for the supported shape).
     - actions: ["p-timestamp"]
       effect: EFFECT_ALLOW
       roles: ["USER"]
@@ -773,3 +776,57 @@ resourcePolicy:
       condition:
         match:
           expr: '(R.attr.aBool ? 1.0/0.0 : -1.0/0.0) > 0.5'
+
+    # -- timestamp(field) vs constant-instant comparisons (ts-*) --
+    # Wire shape (PDP-verified): the planner folds now()-duration arithmetic to a constant
+    # instant and re-wraps it in timestamp("<RFC-3339>"); both operand orders keep policy
+    # source order (both sides are EXPRESSION nodes — no normalization applies), so the
+    # value-first form below exercises the adapter's mirroring, not inversion.
+
+    # The retention-cutoff / time-window shape: rows older than 24h. now() is evaluated at
+    # PLAN time; the seeds are split firmly before 2026 and after 2036 so the boundary never
+    # lands near a seed. a3 has no created_at: timestamp(missing attr) is a CEL error →
+    # check() denies, and the SQL comparison over NULL excludes the row — both sides agree.
+    - actions: ["ts-window"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'timestamp(R.attr.createdAt) < now() - duration("24h")'
+
+    # Value-first form of the same window: gt(timestamp(constant), timestamp(variable)) on
+    # the wire. An inversion bug (translating lt instead of the mirrored gt) flips the
+    # entire included set — the oracle catches it on every seed.
+    - actions: ["ts-vf"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'now() - duration("24h") > timestamp(R.attr.createdAt)'
+
+    # Instant equality against a literal (a4 is the exact-match witness).
+    - actions: ["ts-eq"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'timestamp(R.attr.createdAt) == timestamp("2024-06-01T00:00:00Z")'
+
+    # The same instant expressed at a non-UTC offset: CEL timestamp equality is INSTANT
+    # equality (PDP-verified), so a4 must still match — pins the adapter's offset
+    # normalization (OffsetDateTime.parse fallback → Instant).
+    - actions: ["ts-eq-offset"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'timestamp(R.attr.createdAt) == timestamp("2024-06-01T02:00:00+02:00")'
+
+    # ne: allows every row EXCEPT the equal one — and except a3 (NULL created_at), whose
+    # missing attribute errors at check time while SQL three-valued logic excludes it.
+    - actions: ["ts-ne"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'timestamp(R.attr.createdAt) != timestamp("2024-06-01T00:00:00Z")'


### PR DESCRIPTION
## Summary

Time-window / retention-cutoff policies (`timestamp(R.attr.createdAt) < now() - duration("24h")`) are arguably the most common compliance policy shape — and until this PR, **every** `findAll(spec)` for such an action threw `IllegalArgumentException` (a guaranteed 500 for the caller). Worse, the README claimed unsupported operators could be overridden with `OperatorFunction`, but the throw happened during operand resolution, *before* any override consultation — the documented escape hatch could provably never fire for these shapes.

This PR implements `timestamp(field)` vs constant-instant comparisons for all six comparison operators in both operand orders, and corrects the override documentation for the shapes that genuinely cannot be intercepted. Finding 6/28 from an internal adversarial review of the adapter.

## Wire-shape evidence (scratch PDP, `ghcr.io/cerbos/cerbos:latest`)

All probes were captured from a live PDP before writing any code:

- `timestamp(R.attr.createdAt) < now() - duration("24h")` arrives as
  `lt(timestamp(variable), timestamp(value "2026-07-22T10:31:16.579844479Z"))` — the planner folds `now()-duration` to a constant instant **and re-wraps it in `timestamp(...)`**. A bare string constant is never emitted, for any probed shape (literal, folded `now()`, folded `now()-duration`), so the bare-string pairing deliberately stays fail-closed.
- Value-first `now() - duration("24h") > timestamp(R.attr.createdAt)` arrives as `gt(timestamp(value), timestamp(variable))` — source order preserved. Both operands are EXPRESSION nodes, so `NormalizedBinary` cannot reorder them; the dispatch **mirrors** (`gt` → `lt`), never inverts.
- Constants arrive verbatim: nanosecond precision (`…16.579844479Z`) and non-UTC offsets (`2025-06-01T12:30:45.123456789+02:00`) both reach the adapter unchanged. Parsing is `Instant.parse` with an `OffsetDateTime.parse(...).toInstant()` fallback.
- `check()` oracle: missing `createdAt` → DENY (CEL error on all six operators, both orders); malformed string → DENY; equivalent instant at a different offset (`2025-01-01T02:00:00+02:00` vs stored `2025-01-01T00:00:00Z`) → ALLOW for `eq` (instant equality, not string equality).

## Column-type support matrix (deliberate)

| Mapped Java type | Behavior | Why |
|---|---|---|
| `java.time.Instant` | supported | Unambiguous absolute instant; Hibernate 6 binds as `TIMESTAMP_UTC` |
| `java.time.OffsetDateTime` | supported (bound at UTC) | Same — UTC-normalized before binding, DB comparison is an instant comparison |
| `LocalDateTime` | named error | No zone: the stored wall-clock could denote any instant — a guessed UTC assumption could silently diverge from `check()` (authorization-relevant), so fail closed |
| `java.util.Date` | named error | JDBC binding routes through zone conversions |
| `String` | named error | Lexicographic order is format/offset-dependent |

The `OperatorFunction` override is consulted **before** the column-type check (with the parsed `Instant` as the value), so users who know their schema's zone semantics can translate the ambiguous types themselves — the escape hatch is now genuinely reachable for timestamp comparisons.

A `NULL` column is excluded by every operator (SQL three-valued logic), matching `check()` denying on the missing attribute — PDP-verified and pinned by the `ts-ne` oracle action (seed `a3` has no `created_at`).

Nested shapes stay fail-closed with named errors: `timestamp()` inside arithmetic, `timestamp(<expression>)`, `timestamp(field)` vs bare string/number, field-vs-field. No partial support for shapes the oracle cannot verify.

## Documentation contract fixed

- Supported-operators table: new timestamp row (incl. the plan-time-`now()` caveat — the cutoff freezes when the plan is produced).
- New Gotchas section: plan-time `now()`, column-type rules, MySQL `TIMESTAMP` 2038 range note.
- The "override them with `OperatorFunction`" claim is corrected: overrides only fire where a `(field, value)` pair was resolved. The "Not yet supported" table now has an **Overridable** column — `mod`, `int()`/casts, list indexing, and `eq(map(...), ...)` are marked as **not** interceptable (they throw during operand resolution; unchanged by this PR and still pinned as throwing).

## Tests

- **Unit** (`TimestampComparisons`, 15 tests): all six operators × both operand orders × `Instant` and `OffsetDateTime` columns with seeded before/at/after/NULL rows (counts chosen so a mirror-vs-invert bug flips them); non-UTC offset normalization; sub-second discrimination; NULL exclusion for all 12 operator/order combos; ternary constant-fold; named errors for `LocalDateTime`/`String` columns, bare-string/number constants, `timestamp(<expr>)`, timestamp-inside-arithmetic, malformed/non-string constants; override reachability (incl. mirrored consultation for value-first forms).
- **Differential oracle** (`adversarial-policy.yaml`, new `ts-*` actions): `ts-window` (the `now()-duration` retention shape), `ts-vf` (value-first mirror witness), `ts-eq`, `ts-eq-offset` (instant equality across offsets), `ts-ne` (NULL-exclusion witness). `ResourceEntity` gained `created_at` (`Instant`) plus `updated_at`/`local_created_at` for the unit matrix; oracle seeds mirror the column (seed `a3` deliberately NULL). Seed instants stay inside MySQL's `TIMESTAMP` range (ends 2038) for the CI MySQL leg.
- **Pinned fail-closed test updated**: `p-timestamp` (String column) moved from the pass-through-error pin to a dedicated test asserting the new named column-type error; `p-matches`/`p-index` keep their exact-message pins, and `mod` keeps throwing (re-pinned in unit tests).

## Test results (Docker Gradle 8.12 / JDK 17, Testcontainers PDP `cerbos:latest`)

- **H2** (default leg): `gradle build` — BUILD SUCCESSFUL, 398 tests / 0 failures, including all 93 `AdversarialConformanceTest` cases with the five new `ts-*` oracle actions.
- **PostgreSQL** (`ADAPTER_TEST_DB=postgres`): BUILD SUCCESSFUL — 93/93 conformance tests against `postgres:16` (`ts-window`, `ts-vf`, `ts-eq`, `ts-eq-offset`, `ts-ne` all match the `check()` oracle).
- **MySQL** (`ADAPTER_TEST_DB=mysql`, the third CI leg): BUILD SUCCESSFUL — 93/93 conformance tests against `mysql:8.4` (seed instants deliberately stay inside MySQL's `TIMESTAMP` range).
- **Negative control**: with the pre-PR adapter source restored (new tests kept), exactly the six new tests FAIL — each `ts-*` action throws, reproducing the guaranteed-500 gap this PR closes:

  ```
  ts-window    FAILED  IllegalArgumentException: Unexpected timestamp() expression in leaf operand of lt
  ts-vf        FAILED  IllegalArgumentException: Unexpected timestamp() expression in leaf operand of gt
  ts-eq        FAILED  IllegalArgumentException: Unexpected timestamp() expression in leaf operand of eq
  ts-eq-offset FAILED  IllegalArgumentException: Unexpected timestamp() expression in leaf operand of eq
  ts-ne        FAILED  IllegalArgumentException: Unexpected timestamp() expression in leaf operand of ne
  timestampOnNonTemporalColumnThrowsNamedError FAILED (old code throws the pre-support operand error)
  93 tests completed, 6 failed
  ```

## Merge note

Open PR #277 touches `leafFieldValue` and the README "Not yet supported" table; this PR adds rows/columns to that same table, so expect a trivial keep-both conflict whichever lands second.
