### PR TITLE
test(spring-data): assert hierarchy operator row sets and add differential oracle coverage

### DIFF
--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -80,6 +80,8 @@ class AdversarialConformanceTest {
             Map.entry("request.resource.attr.aOptionalString", AttributeMapping.field("aOptionalString")),
             // ISO-date string column + flattened struct member for the p-* probes
             Map.entry("request.resource.attr.createdBy", AttributeMapping.field("createdBy")),
+            // Delimited hierarchy path column for the hier-* actions
+            Map.entry("request.resource.attr.scope", AttributeMapping.field("scope")),
             Map.entry("request.resource.attr.obj.inner", AttributeMapping.field("aString")),
             Map.entry("request.resource.attr.tags", AttributeMapping.relation("tags", Map.of(
                     "id", AttributeMapping.field("id"),
@@ -192,6 +194,40 @@ class AdversarialConformanceTest {
         };
     }
 
+    /**
+     * Deterministic hierarchy path per seed for the {@code hier-*} actions. The paths
+     * triangulate the translator's branches: strict-prefix IN lists (ancestor-side fields),
+     * prefix LIKE (descendant-side fields), the EQUAL path (ancestorOf/descendentOf are
+     * strict — verified against a live PDP — while overlaps is inclusive), sibling STRING
+     * prefixes that are not PATH prefixes ({@code "dept.engineering"},
+     * {@code "dept.eng.platform2"}), LIKE metacharacters in segments (b2 is the
+     * unescaped-{@code %} trap, b3 the unescaped-{@code _} trap, b4 the equal-path
+     * strictness trap for the colon-delimited metachar actions), a trailing-delimiter empty
+     * segment (c2), a case variant for the collation legs (c1), and a NULL (a7: missing
+     * attribute → CEL error → deny on the check side vs SQL NULL → excluded on the SQL side).
+     */
+    private static String scopeFor(Seed s) {
+        return switch (s.id()) {
+            case "a1" -> "dept";
+            case "a2" -> "dept.eng";
+            case "a3" -> "dept.eng.platform";
+            case "a4" -> "dept.eng.platform.obs";
+            case "a5" -> "dept.engineering";
+            case "a6" -> "dept.sales";
+            case "a8" -> "";
+            case "a9" -> "50%";
+            case "b1" -> "50%:a_b:x";
+            case "b2" -> "50x:a_b:y";
+            case "b3" -> "50%:aXb:y";
+            case "b4" -> "50%:a_b";
+            case "b5" -> "dept.eng.platform2";
+            case "b6" -> "50%.a_b";
+            case "c1" -> "Dept.Eng";
+            case "c2" -> "dept.eng.";
+            default -> null; // a7: NULL scope — a missing attribute on the check side
+        };
+    }
+
     private static GenericContainer<?> cerbos;
     private static CerbosBlockingClient client;
     private static EntityManagerFactory emf;
@@ -301,6 +337,7 @@ class AdversarialConformanceTest {
             r.setaDouble(doubleFor(s));
             r.setaOptionalString(s.aOptionalString());
             r.setCreatedBy(isoFor(s));
+            r.setScope(scopeFor(s));
             for (Tag tag : s.tags()) {
                 r.addTag(tag.id(), tag.name());
             }
@@ -356,6 +393,9 @@ class AdversarialConformanceTest {
         }
         if (doubleFor(s) != null) {
             r = r.withAttribute("aDouble", AttributeValue.doubleValue(doubleFor(s)));
+        }
+        if (scopeFor(s) != null) {
+            r = r.withAttribute("scope", AttributeValue.stringValue(scopeFor(s)));
         }
         // mainCategory mirrors the row's single category as ONE nested object (the seeder
         // creates at most one category per seed), so direct dotted-chain CEL expressions
@@ -470,6 +510,12 @@ class AdversarialConformanceTest {
             // multi-hop relation chains via DIRECT dotted syntax (W1) and a root relation
             // subquery anchored from inside a lambda body (W2)
             "w1-exists-chain", "w1-size-chain", "w1-in-chain", "w2-outer-relation",
+            // hierarchy operators: both operand orders per operator (field-first ancestorOf
+            // and constant-first descendentOf route to the strict-prefix IN-list branch;
+            // the mirrored orders route to the prefix-LIKE branch) plus LIKE-metacharacter
+            // paths — seeds are documented on scopeFor(...)
+            "hier-ancestor-ff", "hier-ancestor-cf", "hier-descendent-ff", "hier-descendent-cf",
+            "hier-overlaps-ff", "hier-overlaps-cf", "hier-meta-like", "hier-meta-in",
     })
     void adapterMatchesCheckOracle(String action) {
         List<String> oracle = oracleAllowedIds(action);

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -41,10 +41,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests that exercise the adapter without a live Cerbos PDP. They build protobuf operands
- * directly and verify the produced Specification by executing it against an empty H2 schema —
- * Hibernate translates to SQL, which catches mapping/type errors. We assert via empty result
- * lists (the schema is empty), so the tests really check that no exception is thrown and the
- * query compiles correctly.
+ * directly and verify the produced Specification by executing it against an H2 schema —
+ * Hibernate translates to SQL, which catches mapping/type errors. Tests whose names promise row
+ * semantics seed rows and assert row identities; the remainder run against an empty table and
+ * check that translation succeeds (or throws the pinned error).
  */
 class SpringDataQueryPlanAdapterTest {
 
@@ -1326,69 +1326,233 @@ class SpringDataQueryPlanAdapterTest {
             return exprOp("list", segs);
         }
 
+        /**
+         * The standard scope fixture, chosen so a correct translation and every plausible
+         * regression return DIFFERENT row sets:
+         * <ul>
+         *   <li>{@code "a:b"} — equal to the ancestor constant (strict-vs-inclusive
+         *       discriminator: strict operators must NOT match the equal path),</li>
+         *   <li>{@code "a:b:c"} — equal to the descendant constant (off-by-one strict-prefix
+         *       discriminator: an IN list wrongly including the full path would match it),</li>
+         *   <li>{@code "a:bb:c"} — shares the STRING prefix {@code "a:b"} but not the PATH
+         *       prefix (separator-mishandling discriminator: {@code LIKE 'a:b%'} without the
+         *       trailing delimiter would match it),</li>
+         *   <li>{@code "a:b:c:d"} — multi-level descendant,</li>
+         *   <li>{@code "x:y"} — unrelated control.</li>
+         * </ul>
+         * Verified against a live PDP (Cerbos 0.54.0): {@code check()} treats
+         * ancestorOf/descendentOf as STRICT (the equal path is denied) and overlaps as
+         * inclusive; sibling string prefixes are denied.
+         */
+        private static final List<String> SCOPES =
+                List.of("a", "a:b", "a:b:c", "a:b:c:d", "a:bb:c", "x:y");
+
+        /**
+         * Seed one row per path — the row's ID doubles as its {@code aString} scope path —
+         * run {@code body}, then delete the rows. Row-identity assertions then read
+         * naturally: the expected set IS the set of matching paths.
+         */
+        private void withScopeRows(List<String> paths, Runnable body) {
+            EntityManager em = emf.createEntityManager();
+            em.getTransaction().begin();
+            for (String path : paths) {
+                ResourceEntity r = new ResourceEntity(path);
+                r.setaString(path);
+                em.persist(r);
+            }
+            em.getTransaction().commit();
+            em.close();
+            try {
+                body.run();
+            } finally {
+                EntityManager cleanup = emf.createEntityManager();
+                cleanup.getTransaction().begin();
+                for (String path : paths) {
+                    ResourceEntity managed = cleanup.find(ResourceEntity.class, path);
+                    if (managed != null) {
+                        cleanup.remove(managed);
+                    }
+                }
+                cleanup.getTransaction().commit();
+                cleanup.close();
+            }
+        }
+
+        /** Translate {@code condition}, run it, and return the matched row IDs (= scope paths). */
+        private Set<String> runIds(Operand condition) {
+            PlanResourcesResponse resp =
+                    buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+            Result<ResourceEntity> result =
+                    SpringDataQueryPlanAdapter.toSpecification(resp, MAPPER, Map.of());
+            assertInstanceOf(Result.Conditional.class, result);
+            Specification<ResourceEntity> spec =
+                    ((Result.Conditional<ResourceEntity>) result).specification();
+            EntityManager em = emf.createEntityManager();
+            try {
+                CriteriaBuilder cb = em.getCriteriaBuilder();
+                CriteriaQuery<String> cq = cb.createQuery(String.class);
+                Root<ResourceEntity> root = cq.from(ResourceEntity.class);
+                cq.select(root.get("id"));
+                Predicate p = spec.toPredicate(root, cq, cb);
+                if (p != null) {
+                    cq.where(p);
+                }
+                return Set.copyOf(em.createQuery(cq).getResultList());
+            } finally {
+                em.close();
+            }
+        }
+
         @Test
         void ancestorOfConstantPrefixOfField() {
-            // ancestorOf(hierarchy("a:b", ":"), hierarchy(field, ":")) → field LIKE 'a:b:%'
+            // ancestorOf(hierarchy("a:b", ":"), hierarchy(field, ":")) → field LIKE 'a:b:%' —
+            // strict descendants only: NOT the equal path "a:b", NOT the string-prefix
+            // sibling "a:bb:c" (the trailing delimiter in the pattern excludes it).
             Operand cond = exprOp("ancestorOf",
                     hierarchy(sval("a:b"), ":"),
                     hierarchy(var("request.resource.attr.aString"), ":"));
-            assertEquals(0, runCount(cond));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of("a:b:c", "a:b:c:d"), runIds(cond)));
         }
 
         @Test
         void ancestorOfFieldPrefixOfConstant() {
             // ancestorOf(hierarchy(field, ":"), hierarchy("a:b:c", ":")) → field IN ('a', 'a:b')
+            // — the strict-prefix IN list. An off-by-one regression including the full path
+            // would wrongly add the "a:b:c" row (a path is not its own strict ancestor).
             Operand cond = exprOp("ancestorOf",
                     hierarchy(var("request.resource.attr.aString"), ":"),
                     hierarchy(sval("a:b:c"), ":"));
-            assertEquals(0, runCount(cond));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of("a", "a:b"), runIds(cond)));
         }
 
         @Test
         void descendentOfFieldUnderConstant() {
-            // descendentOf(hierarchy(field, ":"), hierarchy("a:b", ":")) → field LIKE 'a:b:%'
+            // descendentOf(hierarchy(field, ":"), hierarchy("a:b", ":")) → field LIKE 'a:b:%'.
+            // Same discriminators as ancestorOfConstantPrefixOfField (mirrored operator).
             Operand cond = exprOp("descendentOf",
                     hierarchy(var("request.resource.attr.aString"), ":"),
                     hierarchy(sval("a:b"), ":"));
-            assertEquals(0, runCount(cond));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of("a:b:c", "a:b:c:d"), runIds(cond)));
+        }
+
+        @Test
+        void descendentOfConstantUnderField() {
+            // Constant-first operand order: descendentOf(hierarchy("a:b:c", ":"),
+            // hierarchy(field, ":")) — the FIELD is the ancestor side, routing to the
+            // strict-prefix IN-list branch: field IN ('a', 'a:b').
+            Operand cond = exprOp("descendentOf",
+                    hierarchy(sval("a:b:c"), ":"),
+                    hierarchy(var("request.resource.attr.aString"), ":"));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of("a", "a:b"), runIds(cond)));
         }
 
         @Test
         void overlapsFieldHierarchyWithConstant() {
             // overlaps(hierarchy(field, ":"), hierarchy("a:b", ":"))
-            //   → field IN ('a') OR field = 'a:b' OR field LIKE 'a:b:%'
+            //   → field IN ('a') OR field = 'a:b' OR field LIKE 'a:b:%' — inclusive in both
+            // directions (ancestors, the equal path, and descendants), but never the
+            // string-prefix sibling "a:bb:c" or the unrelated "x:y".
             Operand cond = exprOp("overlaps",
                     hierarchy(var("request.resource.attr.aString"), ":"),
                     hierarchy(sval("a:b"), ":"));
-            assertEquals(0, runCount(cond));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of("a", "a:b", "a:b:c", "a:b:c:d"), runIds(cond)));
+        }
+
+        @Test
+        void overlapsConstantHierarchyWithField() {
+            // Constant-first operand order: overlaps is symmetric, so the same union must
+            // come back with the operands mirrored.
+            Operand cond = exprOp("overlaps",
+                    hierarchy(sval("a:b"), ":"),
+                    hierarchy(var("request.resource.attr.aString"), ":"));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of("a", "a:b", "a:b:c", "a:b:c:d"), runIds(cond)));
+        }
+
+        @Test
+        void ancestorOfSingleSegmentConstantMatchesNothing() {
+            // ancestorOf(field, "a") — a single-segment path has NO strict ancestors, so the
+            // translation is always-false: even the row whose scope is exactly "a" must not
+            // match (a path is not its own ancestor).
+            Operand cond = exprOp("ancestorOf",
+                    hierarchy(var("request.resource.attr.aString"), ":"),
+                    hierarchy(sval("a"), ":"));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of(), runIds(cond)));
+        }
+
+        @Test
+        void descendentOfSingleSegmentConstant() {
+            // descendentOf(field, "a") → field LIKE 'a:%': every path under the root —
+            // including the sibling branch "a:bb:c" (a genuine descendant of "a") — but not
+            // the root itself and not "x:y".
+            Operand cond = exprOp("descendentOf",
+                    hierarchy(var("request.resource.attr.aString"), ":"),
+                    hierarchy(sval("a"), ":"));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.of("a:b", "a:b:c", "a:b:c:d", "a:bb:c"), runIds(cond)));
+        }
+
+        @Test
+        void ancestorOfMetacharacterSegments() {
+            // Field-first with LIKE metacharacters in the constant path: the strict-prefix
+            // IN list ('50%', '50%:a_b') compares by equality — no pattern matching, so the
+            // '50x'/'50_' rows must not match.
+            Operand cond = exprOp("ancestorOf",
+                    hierarchy(var("request.resource.attr.aString"), ":"),
+                    hierarchy(sval("50%:a_b:x"), ":"));
+            withScopeRows(List.of("50%", "50%:a_b", "50x", "50_", "50%:a_b:x"), () ->
+                    assertEquals(Set.of("50%", "50%:a_b"), runIds(cond)));
+        }
+
+        @Test
+        void descendentOfMetacharacterPrefixIsEscaped() {
+            // Constant-first LIKE branch: the prefix '50%:a_b:' must be escaped so '%' and
+            // '_' are literals. Unescaped, LIKE '50%:a_b:%' would match the '50x:a_b:y'
+            // (via %) and '50%:aXb:y' (via _) traps; the equal path '50%:a_b' pins strictness.
+            Operand cond = exprOp("descendentOf",
+                    hierarchy(var("request.resource.attr.aString"), ":"),
+                    hierarchy(sval("50%:a_b"), ":"));
+            withScopeRows(List.of("50%:a_b:y", "50x:a_b:y", "50%:aXb:y", "50%:a_b"), () ->
+                    assertEquals(Set.of("50%:a_b:y"), runIds(cond)));
         }
 
         @Test
         void overlapsSegmentedWithField() {
             // The policy shape: hierarchy("projects:123", ":").overlaps(hierarchy(["projects", R.id]))
-            //   → segment-wise: const "projects" matches, then field == "123"
+            //   → segment-wise: const "projects" matches, then field == "123".
             Operand cond = exprOp("overlaps",
                     hierarchy(sval("projects:123"), ":"),
                     hierarchy(segList(sval("projects"), var("request.resource.attr.aString"))));
-            assertEquals(0, runCount(cond));
+            withScopeRows(List.of("123", "456", "projects"), () ->
+                    assertEquals(Set.of("123"), runIds(cond)));
         }
 
         @Test
         void overlapsConstantsMatchingPrefixIsAlwaysTrue() {
-            // overlaps("a", "a:b") — "a" is a prefix of "a:b", all constant → unconditionally true.
+            // overlaps("a", "a:b") — "a" is a prefix of "a:b", all constant → unconditionally
+            // true: EVERY seeded row must come back (a regression to always-false returns none).
             Operand cond = exprOp("overlaps",
                     hierarchy(sval("a"), ":"),
                     hierarchy(sval("a:b"), ":"));
-            assertEquals(0, runCount(cond));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.copyOf(SCOPES), runIds(cond)));
         }
 
         @Test
         void ancestorOfConstantsSatisfied() {
-            // ancestorOf("a", "a:b") — satisfied by constants alone → unconditionally true.
+            // ancestorOf("a", "a:b") — satisfied by constants alone → unconditionally true:
+            // every seeded row comes back regardless of its own scope value.
             Operand cond = exprOp("ancestorOf",
                     hierarchy(sval("a"), ":"),
                     hierarchy(sval("a:b"), ":"));
-            assertEquals(0, runCount(cond));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.copyOf(SCOPES), runIds(cond)));
 
             // A trailing delimiter is a real (empty) segment: "a:b:" splits to ["a","b",""],
             // so "a:b" is still a strict prefix. If splitLiteral dropped trailing empties this
@@ -1396,7 +1560,8 @@ class SpringDataQueryPlanAdapterTest {
             Operand trailing = exprOp("ancestorOf",
                     hierarchy(sval("a:b"), ":"),
                     hierarchy(sval("a:b:"), ":"));
-            assertEquals(0, runCount(trailing));
+            withScopeRows(SCOPES, () ->
+                    assertEquals(Set.copyOf(SCOPES), runIds(trailing)));
         }
 
         @Test

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -773,3 +773,82 @@ resourcePolicy:
       condition:
         match:
           expr: '(R.attr.aBool ? 1.0/0.0 : -1.0/0.0) > 0.5'
+
+    # ==================== hierarchy operators (hier-*) ====================
+    # Both operand orders for each operator, plus LIKE-metacharacter path segments. The
+    # planner preserves source order (PDP-verified: hierarchy(...) wrappers survive to the
+    # plan verbatim in both orders), so field-first spellings put hierarchy(variable) FIRST:
+    # when the field lands on the ANCESTOR side the adapter emits a strict-prefix IN list,
+    # and when it lands on the DESCENDANT side an escaped prefix LIKE. ancestorOf and
+    # descendentOf are STRICT (a path is never its own ancestor/descendant — the a3/b4
+    # equal-path seeds pin this); overlaps is inclusive. The scope seeds also include
+    # sibling STRING prefixes that are not PATH prefixes ("dept.engineering",
+    # "dept.eng.platform2") and unescaped-wildcard traps (b2/b3) — see scopeFor(...) in
+    # AdversarialConformanceTest.
+
+    # field-first ancestorOf → scope IN ('dept', 'dept.eng') — the strict-prefix IN list.
+    - actions: ["hier-ancestor-ff"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy(R.attr.scope).ancestorOf(hierarchy("dept.eng.platform"))'
+
+    # constant-first ancestorOf → scope LIKE 'dept.eng.%' (strict descendants only).
+    - actions: ["hier-ancestor-cf"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy("dept.eng").ancestorOf(hierarchy(R.attr.scope))'
+
+    # field-first descendentOf → scope LIKE 'dept.eng.%'.
+    - actions: ["hier-descendent-ff"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy(R.attr.scope).descendentOf(hierarchy("dept.eng"))'
+
+    # constant-first descendentOf → the FIELD is the ancestor → strict-prefix IN list.
+    - actions: ["hier-descendent-cf"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy("dept.eng.platform").descendentOf(hierarchy(R.attr.scope))'
+
+    # field-first overlaps → IN ('dept') OR = 'dept.eng' OR LIKE 'dept.eng.%' (inclusive).
+    - actions: ["hier-overlaps-ff"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy(R.attr.scope).overlaps(hierarchy("dept.eng"))'
+
+    # constant-first overlaps → the same union with the operands mirrored.
+    - actions: ["hier-overlaps-cf"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy("dept.eng").overlaps(hierarchy(R.attr.scope))'
+
+    # metachar LIKE branch: the prefix '50%:a_b:' must be escaped ('%'/'_' literal). The
+    # b2 seed ("50x:a_b:y") is the unescaped-% trap, b3 ("50%:aXb:y") the unescaped-_ trap,
+    # and b4 ("50%:a_b") the equal-path strictness trap.
+    - actions: ["hier-meta-like"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy(R.attr.scope, ":").descendentOf(hierarchy("50%:a_b", ":"))'
+
+    # metachar IN branch: strict prefixes ('50%', '50%.a_b') compared by equality — the
+    # a9/b6 seeds match; no pattern matching may occur.
+    - actions: ["hier-meta-in"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy(R.attr.scope).ancestorOf(hierarchy("50%.a_b.x"))'


### PR DESCRIPTION
## Problem

Finding 10/28 from an internal adversarial review of the spring-data adapter.

Seven of the eleven hierarchy unit tests asserted `assertEquals(0, runCount(cond))` against an **empty table** — an always-true translation and an always-false regression both yield 0, so tests named `overlapsConstantsMatchingPrefixIsAlwaysTrue` or `ancestorOfConstantsSatisfied` could not distinguish the semantics their names promise (the class javadoc even admitted they "really check that no exception is thrown"). On top of that, `adversarial-policy.yaml` contained **zero** hierarchy actions, so the differential `check()` oracle never owned hierarchy row semantics, and the strict-prefix IN-list branch of `HierarchyTranslator` (`getStrictPrefixes`) — the branch behind field-first `ancestorOf` — had no row-level assertion anywhere.

Concretely: an off-by-one regression in `getStrictPrefixes` that includes the full path in the IN list would return rows whose scope **equals** the constant — rows strict `ancestorOf` denies — with every pre-existing test green. Silent over-grant in tenant-scoping policies.

This PR is **test-only**: `HierarchyTranslator` itself is correct (verified below); no production code changes.

## Wire-shape findings (scratch PDP, Cerbos 0.54.0 image)

Captured empirically before writing any test — every shape below is planner-emitted, none are hand-invented:

| CEL form | Wire plan |
|---|---|
| `hierarchy(R.attr.scope).ancestorOf(hierarchy("a.b.c"))` | `ancestorOf(hierarchy(variable), hierarchy(value))` — **field-first**, routes to the strict-prefix IN-list branch |
| `hierarchy("a.b").ancestorOf(hierarchy(R.attr.scope))` | `ancestorOf(hierarchy(value), hierarchy(variable))` — constant-first, prefix-LIKE branch |
| `hierarchy(R.attr.scope).descendentOf(hierarchy("a.b"))` | field-first `descendentOf` — prefix-LIKE branch |
| `hierarchy("a.b.c").descendentOf(hierarchy(R.attr.scope))` | constant-first `descendentOf` — field is the ancestor side → strict-prefix IN-list branch |
| `overlaps` in both orders | both survive verbatim |
| `hierarchy(x, ":")` | two operands: the value/variable plus the delimiter as a second `value` operand |
| `hierarchy(["projects", R.id])` | `hierarchy(list(value, variable))` |
| metachar segments (`"50%:a_b"`) | constants pass through verbatim — LIKE escaping is entirely the adapter's job |

Operand order is source order in every case (consistent with the repo's established planner facts).

`check()` boundary semantics (same PDP, per-row probes):

- `ancestorOf` / `descendentOf` are **strict**: the equal path is DENIED (`scope="a.b.c"` vs constant `"a.b.c"` → deny).
- `overlaps` is **inclusive**: ancestors, the equal path, and descendants all ALLOW.
- Sibling **string** prefixes that are not **path** prefixes are denied (`scope="a.bb.c"` vs `"a.b"` → deny).
- Metacharacters are literal: `"50x:a_b:y"` and `"50%:aXb:y"` are denied under `"50%:a_b"` descendant checks.

All of these match `HierarchyTranslator`'s current behavior — confirming this is a coverage task, not a bug fix.

## What changed

**Unit tests** (`SpringDataQueryPlanAdapterTest.HierarchyOperators`):

- The seven vacuous tests now seed rows (row ID = scope path) and assert **row-identity sets**, using a fixture chosen so every plausible regression returns a different set: the equal path (strict-vs-inclusive), `"a:bb:c"` (string-prefix-but-not-path-prefix separator trap), multi-level descendants, and an unrelated control.
- Both operand orders are now covered for all three operators (new: `descendentOfConstantUnderField`, `overlapsConstantHierarchyWithField`).
- New boundary tests: single-segment constant on each side (`ancestorOfSingleSegmentConstantMatchesNothing`, `descendentOfSingleSegmentConstant`), metachar segments through the IN branch (`ancestorOfMetacharacterSegments`) and the LIKE branch (`descendentOfMetacharacterPrefixIsEscaped` — pins the `%`/`_` escaping with explicit trap rows).
- The four meaningful throw-assertion tests are untouched.

**Differential oracle** (`adversarial-policy.yaml` + `AdversarialConformanceTest`):

- Eight new `hier-*` actions: field-first + constant-first for `ancestorOf`/`descendentOf`/`overlaps`, plus metachar LIKE-branch and metachar IN-branch actions.
- Seeds gain a deterministic `scope` path via `scopeFor(Seed)` (mirrored into both the DB column and the `check()` attributes; one seed stays NULL to pin missing-attr-deny vs SQL-NULL-excluded alignment; one seed is a case variant so the collation legs also discriminate hierarchy predicates).
- Verified non-degenerate before running: every action's oracle set is non-empty and non-total (e.g. `hier-ancestor-ff → {a1, a2}`, `hier-meta-like → {b1}`).

## Negative-control evidence

Applied a scratch off-by-one regression to `getStrictPrefixes` (loop bound `segments.size() - 1` → `segments.size()`, i.e. the IN list wrongly includes the full path), reran, then reverted byte-identical (checksum-verified):

```
SpringDataQueryPlanAdapterTest$HierarchyOperators
  FAIL ancestorOfFieldPrefixOfConstant   expected <[a, a:b]>       but was <[a, a:b, a:b:c]>
  FAIL descendentOfConstantUnderField    expected <[a, a:b]>       but was <[a, a:b, a:b:c]>
  FAIL ancestorOfMetacharacterSegments   expected <[50%, 50%:a_b]> but was <[50%, 50%:a_b, 50%:a_b:x]>

AdversarialConformanceTest (differential oracle)
  FAIL hier-ancestor-ff    adapter diverges from check-API oracle: expected <[a1, a2]> but was <[a1, a2, a3]>
  FAIL hier-descendent-cf  adapter diverges from check-API oracle: expected <[a1, a2]> but was <[a1, a2, a3]>
```

Exactly the review's failure scenario: the regressed IN list matches rows whose scope **equals** the constant (`a:b:c` / seed a3 `dept.eng.platform`) — rows strict `ancestorOf` denies — and both the unit row-set tests and the differential oracle catch it. Before this PR, that regression was green across the entire suite.

With the regression reverted, everything is green again.

## Test outputs

Full Docker Gradle build (H2 default): `BUILD SUCCESSFUL` — 390 tests, 0 failures (includes the 8 new `hier-*` oracle actions and the reworked/new unit tests).

PostgreSQL oracle leg (`ADAPTER_TEST_DB=postgres`, Testcontainers postgres:16): `BUILD SUCCESSFUL` — 96 `AdversarialConformanceTest` cases, 0 failures, all 8 `hier-*` actions included (verified `jdbc:postgresql` / `postgres:16` in the test report).

## Merge note

PR #279 also appends actions to `adversarial-policy.yaml` (`ts-*` prefix). This PR uses the disjoint `hier-*` prefix and appends in its own block, so whichever merges second hits a trivial keep-both conflict at the end of the file.
