### PR TITLE
fix(spring-data): CEL-faithful double arithmetic on MySQL

### DIFF
--- a/.github/workflows/spring-data.yaml
+++ b/.github/workflows/spring-data.yaml
@@ -41,10 +41,21 @@ jobs:
   # documented in spring-data/README.md "Database collation requirements": the MySQL leg
   # creates its schema with utf8mb4_0900_as_cs; the suite's mixed-case seeds fail the
   # oracle comparison on MySQL's default case-insensitive collation.
+  #
+  # The MySQL leg runs TWICE: once with Connector/J's default client-side prepared
+  # statements (pins the adapter's `cast(... as double)` rendering — under the
+  # MySQLDialect decimal(53,20) cast, interpolated DECIMAL literals would evaluate the
+  # adapter's IEEE double arithmetic exactly and p-double-frac would fail; see the README
+  # "MySQL: keeping arithmetic IEEE-faithful" gotcha) and once with
+  # useServerPrepStmts=true (typed binds — the mode customers may opt into).
   test-database:
     strategy:
       matrix:
-        database: ["postgres", "mysql"]
+        include:
+          - database: postgres
+          - database: mysql
+          - database: mysql
+            server-prep-stmts: "true"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -62,6 +73,7 @@ jobs:
         run: gradle build --no-daemon
         env:
           ADAPTER_TEST_DB: ${{ matrix.database }}
+          ADAPTER_TEST_MYSQL_SERVER_PREP_STMTS: ${{ matrix.server-prep-stmts || '' }}
 
   # Compiles the standalone example app (a composite build over the adapter source — building
   # the adapter alone never compiles it) and runs example/scripts/smoke.sh end-to-end: a live

--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -278,6 +278,53 @@ the only satisfiable one: `/` is true double division (`5 / 2.0 == 2.5`), never
 integer truncation. Write double literals (`1.0`, `2.0`) in policy arithmetic over
 attributes, or the plan-based filter and per-resource `check` calls will disagree.
 
+### MySQL: keeping arithmetic IEEE-faithful
+
+Affects only policies with **arithmetic inside a comparison** (`R.attr.aNumber * 0.1 ==
+0.3`, `R.attr.aDouble + 0.7 != 0.1`, …). Plain comparisons, `in`, LIKE, and collection
+shapes are not involved.
+
+Two MySQL defaults each pull the adapter's deliberately-IEEE double arithmetic into
+**exact decimal** evaluation:
+
+- Hibernate's `MySQLDialect` renders to-double casts as `cast(col as decimal(53,20))` —
+  its cast mapping predates MySQL 8.0.17, which added `CAST(... AS DOUBLE)`.
+- MySQL Connector/J's default **client-side** prepared statements
+  (`useServerPrepStmts=false`) interpolate double bind parameters into the statement
+  text, where MySQL parses them as exact `DECIMAL` literals.
+
+Decimal arithmetic is not IEEE double arithmetic: `3 * 0.1 == 0.3` is TRUE in decimal
+but FALSE in CEL (`0.30000000000000004`), so on those defaults the SQL filter returns
+rows the PDP's `check()` API **denies** — a silent over-grant (verified on MySQL 8.4:
+`CAST(3 AS DECIMAL(53,20)) * 0.1 = 0.3` → 1, `CAST(3 AS DOUBLE) * 0.1 = 0.3` → 0).
+
+**What the adapter does about it.** The library ships a Hibernate `FunctionContributor`
+(`MySqlDoubleCastFunctionContributor`, discovered automatically via
+`META-INF/services`) that, on MySQL 8.0.17+, registers a cast function rendering
+`cast(col as double)`; every column entering arithmetic goes through it. Because MySQL
+promotes any expression with an approximate (DOUBLE) operand to double, the
+interpolated decimal literals stop mattering — client- and server-side prepared
+statements both agree with `check()`, with **no JDBC URL settings required**. H2 and
+PostgreSQL already render IEEE-correct casts; the contributor registers nothing there
+and their SQL is unchanged.
+
+**When you still need `useServerPrepStmts=true`** (typed double binds restore IEEE
+semantics even under the decimal cast) — set it in the JDBC URL if any of these apply:
+
+- MySQL older than 8.0.17 (no `CAST(... AS DOUBLE)`).
+- MariaDB (own dialect lineage and driver; not covered by the contributor).
+- A non-Hibernate JPA provider (the contributor is Hibernate-only; the adapter then
+  falls back to the portable `cast(col as float(53))`, which MySQL would need typed
+  binds to keep in double space).
+- Hibernate configured with `hibernate.boot.allow_jdbc_metadata_access=false` and only
+  `hibernate.dialect` set: the dialect then reports its minimum supported version and
+  the version-gated registration is skipped.
+
+The differential oracle's MySQL CI leg runs with Connector/J's default client-side
+prepared statements precisely so this stays pinned (`p-double-frac` fails within
+seconds if the cast regresses to decimal); set `ADAPTER_TEST_MYSQL_SERVER_PREP_STMTS=true`
+to run the same leg in server-side mode — both must pass.
+
 ### Timestamp comparisons: plan-time `now()`, and only unambiguous column types
 
 `timestamp(R.attr.createdAt) < now() - duration("24h")` reaches the adapter as a

--- a/spring-data/build.gradle.kts
+++ b/spring-data/build.gradle.kts
@@ -26,6 +26,12 @@ dependencies {
     // as `<optional>true</optional>`.
     compileOnly("org.springframework.data:spring-data-jpa:3.5.1")
     compileOnly("jakarta.persistence:jakarta.persistence-api:3.2.0")
+    // Hibernate is needed only to compile MySqlDoubleCastFunctionContributor (the MySQL
+    // IEEE double-cast registration) and the adapter's classpath-guarded probe for it.
+    // `compileOnly` for the same reason as Spring Data JPA above: the consuming
+    // application provides its own Hibernate, and the adapter degrades gracefully (plain
+    // cb.toDouble casts) when Hibernate is absent at runtime.
+    compileOnly("org.hibernate.orm:hibernate-core:6.6.18.Final")
 
     testImplementation("org.springframework.data:spring-data-jpa:3.5.1")
     testImplementation("jakarta.persistence:jakarta.persistence-api:3.2.0")
@@ -75,5 +81,14 @@ tasks.test {
         ?: System.getenv("ADAPTER_TEST_MYSQL_COLLATION")
     if (mysqlCollation != null) {
         systemProperty("adapter.test.mysql.collation", mysqlCollation)
+    }
+    // The MySQL leg runs with Connector/J's default CLIENT-side prepared statements so the
+    // differential oracle pins the adapter's `cast(... as double)` rendering (see the README
+    // "MySQL: keeping arithmetic IEEE-faithful" gotcha). Set this to true to run the same
+    // leg with server-side prepared statements — both modes must pass.
+    val mysqlServerPrep = System.getProperty("adapter.test.mysql.serverPrepStmts")
+        ?: System.getenv("ADAPTER_TEST_MYSQL_SERVER_PREP_STMTS")
+    if (mysqlServerPrep != null) {
+        systemProperty("adapter.test.mysql.serverPrepStmts", mysqlServerPrep)
     }
 }

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/MySqlDoubleCastFunctionContributor.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/MySqlDoubleCastFunctionContributor.java
@@ -1,0 +1,95 @@
+package dev.cerbos.queryplan.springdata;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.MariaDBDialect;
+import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.type.StandardBasicTypes;
+
+/**
+ * Hibernate {@link FunctionContributor} (discovered via {@link java.util.ServiceLoader};
+ * see {@code META-INF/services/org.hibernate.boot.model.FunctionContributor}) that keeps
+ * the adapter's double-space arithmetic IEEE-faithful on MySQL.
+ *
+ * <p><strong>Why this exists.</strong> The adapter deliberately lowers CEL arithmetic
+ * comparisons to SQL computed in IEEE double space, because that is exactly how the Cerbos
+ * PDP evaluates them at check time (CEL attribute arithmetic is always double-typed). On
+ * MySQL two defaults conspire to break that:
+ *
+ * <ul>
+ *   <li>Hibernate's {@code MySQLDialect} renders {@code cast(x as Double)} as
+ *       {@code cast(x as decimal(53,20))} — its {@code castType} still assumes MySQL cannot
+ *       cast to DOUBLE, which has been supported since MySQL 8.0.17.</li>
+ *   <li>MySQL Connector/J's DEFAULT client-side prepared statements interpolate double bind
+ *       parameters into the statement text, where MySQL parses them as exact DECIMAL
+ *       literals.</li>
+ * </ul>
+ *
+ * <p>Together the adapter's "double" arithmetic becomes all-DECIMAL and evaluates exactly:
+ * {@code 3 * 0.1 == 0.3} is TRUE in decimal but FALSE in CEL/IEEE double
+ * ({@code 0.30000000000000004}), so the SQL filter returns rows the PDP's {@code check()}
+ * API denies. Verified on MySQL 8.4: {@code CAST(3 AS DECIMAL(53,20)) * 0.1 = 0.3} yields
+ * 1, {@code CAST(3 AS DOUBLE) * 0.1 = 0.3} yields 0.
+ *
+ * <p><strong>What it does.</strong> On MySQL 8.0.17+ this contributor registers the
+ * {@value #FUNCTION_NAME} function rendering {@code cast(?1 as double)}. The adapter routes
+ * every column entering arithmetic through it (instead of {@code cb.toDouble}), which makes
+ * every arithmetic node double-typed: MySQL promotes any expression with an approximate
+ * operand to double, so the interpolated DECIMAL literals no longer drag the evaluation
+ * into exact decimal — client- and server-side prepared statements then agree with CEL.
+ *
+ * <p><strong>Where it does nothing</strong> (the adapter falls back to {@code cb.toDouble},
+ * i.e. exactly the pre-existing behavior):
+ *
+ * <ul>
+ *   <li>H2 and PostgreSQL: their dialects already render IEEE-correct casts
+ *       ({@code cast(x as float(53))}); registering nothing keeps their SQL byte-identical.</li>
+ *   <li>MySQL older than 8.0.17: {@code CAST(... AS DOUBLE)} is unsupported there — such
+ *       deployments must set {@code useServerPrepStmts=true} instead (README, "MySQL:
+ *       keeping arithmetic IEEE-faithful").</li>
+ *   <li>MariaDB: ships its own dialect lineage and JDBC driver whose literal behavior this
+ *       adapter has not verified; the README's server-side-prepared-statements guidance
+ *       applies.</li>
+ *   <li>Non-Hibernate JPA providers: this class never loads (it is only reachable via
+ *       Hibernate's ServiceLoader discovery and the adapter's classpath-guarded probe).</li>
+ * </ul>
+ */
+public final class MySqlDoubleCastFunctionContributor implements FunctionContributor {
+
+    /**
+     * Name of the registered cast function. Referenced from
+     * {@link SpringDataQueryPlanAdapter} only as a compile-time String constant (inlined by
+     * javac) or from Hibernate-guarded code, so the adapter never triggers loading this
+     * Hibernate-dependent class on non-Hibernate runtimes.
+     */
+    static final String FUNCTION_NAME = "cerbos_ieee_double";
+
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        Dialect dialect = functionContributions.getDialect();
+        if (!(dialect instanceof MySQLDialect) || dialect instanceof MariaDBDialect) {
+            return;
+        }
+        if (!dialect.getVersion().isSameOrAfter(8, 0, 17)) {
+            // CAST(... AS DOUBLE) arrived in MySQL 8.0.17. NOTE: when Hibernate cannot read
+            // JDBC metadata (hibernate.boot.allow_jdbc_metadata_access=false with only
+            // hibernate.dialect set), the dialect reports its minimum supported version and
+            // the registration is skipped — fail-safe to the documented
+            // useServerPrepStmts=true guidance rather than emitting SQL an older server
+            // rejects.
+            return;
+        }
+        functionContributions.getFunctionRegistry()
+                .patternDescriptorBuilder(FUNCTION_NAME, "cast(?1 as double)")
+                .setExactArgumentCount(1)
+                .setInvariantType(functionContributions.getTypeConfiguration()
+                        .getBasicTypeRegistry().resolve(StandardBasicTypes.DOUBLE))
+                .register();
+    }
+
+    @Override
+    public int ordinal() {
+        return 600; // library range (500–1000); the name is namespaced, collisions are not expected
+    }
+}

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -1254,11 +1254,20 @@ public final class SpringDataQueryPlanAdapter {
              * marker only) and {@code cb.toDouble(literal)} elides the cast on a node already
              * Double-typed, both leaving the arithmetic decimal. Therefore:
              * <ul>
-             *   <li>columns go through {@code cb.toDouble} (renders {@code cast(col as float(53))});</li>
+             *   <li>columns go through {@link #toIeeeDouble}: {@code cb.toDouble} (renders
+             *       {@code cast(col as float(53))}) — except on MySQL, where Hibernate's
+             *       {@code MySQLDialect} renders that cast as exact {@code decimal(53,20)} and
+             *       the adapter instead emits the {@code cerbos_ieee_double} function
+             *       ({@code cast(col as double)}) registered by
+             *       {@link MySqlDoubleCastFunctionContributor};</li>
              *   <li>constant subtrees fold in Java ({@link NumericOperand.Constant});</li>
              *   <li>constants mixed into SQL arithmetic bind through the plain-{@code Number}
              *       CriteriaBuilder overloads, which emit genuine double-typed bind parameters
-             *       instead of decimal literals.</li>
+             *       instead of decimal literals. (MySQL Connector/J's default client-side
+             *       prepared statements still interpolate those binds as DECIMAL literals in
+             *       the statement text — harmless once every column cast is a true DOUBLE,
+             *       because MySQL promotes arithmetic and comparisons with an approximate
+             *       operand to double space; see {@link MySqlDoubleCastFunctionContributor}.)</li>
              * </ul>
              *
              * <p>Division guard: SQL raises an error on a zero divisor — a data-dependent runtime
@@ -1279,7 +1288,7 @@ public final class SpringDataQueryPlanAdapter {
                         jakarta.persistence.criteria.Expression<? extends Number> path =
                                 (jakarta.persistence.criteria.Expression<? extends Number>)
                                         scope.resolvePath(operand.getVariable());
-                        return new NumericOperand.Sql(cb.toDouble(path));
+                        return new NumericOperand.Sql(toIeeeDouble(path));
                     }
                     case VALUE -> {
                         Object v = PlanValues.protoValueToJava(operand.getValue());
@@ -1326,6 +1335,26 @@ public final class SpringDataQueryPlanAdapter {
                             "Unexpected operand type in arithmetic comparison: "
                                     + operand.getNodeCase());
                 }
+            }
+
+            /**
+             * Force a column into IEEE double space for arithmetic (see
+             * {@link #resolveNumericOperand}). Renders {@code cb.toDouble} everywhere except
+             * when {@link MySqlDoubleCastFunctionContributor} has registered the
+             * {@code cerbos_ieee_double} function (Hibernate on MySQL 8.0.17+), which renders
+             * {@code cast(col as double)} instead of the {@code MySQLDialect}'s exact-decimal
+             * {@code decimal(53,20)} cast. Keyed off the ACTUAL function registration — not
+             * dialect name sniffing — so H2/PostgreSQL SQL stays byte-identical and a missing
+             * registration (non-Hibernate provider, old MySQL, contributor not discovered)
+             * degrades to the previous behavior, never to an unknown-function SQL error.
+             */
+            private jakarta.persistence.criteria.Expression<Double> toIeeeDouble(
+                    jakarta.persistence.criteria.Expression<? extends Number> path) {
+                if (IeeeDoubleCast.isRegistered(cb)) {
+                    return cb.function(
+                            MySqlDoubleCastFunctionContributor.FUNCTION_NAME, Double.class, path);
+                }
+                return cb.toDouble(path);
             }
 
             /**
@@ -1961,6 +1990,43 @@ public final class SpringDataQueryPlanAdapter {
             cs.sub().select(cb.literal(1));
             cs.sub().where(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()));
             return cb.exists(cs.sub());
+        }
+    }
+
+    /**
+     * Classpath-guarded probe for the {@code cerbos_ieee_double} MySQL cast function
+     * registered by {@link MySqlDoubleCastFunctionContributor}. The adapter itself depends
+     * only on Jakarta Persistence; everything that touches Hibernate types lives in the
+     * nested {@link Probe} class, which is only loaded after {@code hibernate-core} has been
+     * confirmed present — on non-Hibernate providers {@link #isRegistered} is a constant
+     * {@code false} and the caller keeps the portable {@code cb.toDouble} path.
+     */
+    private static final class IeeeDoubleCast {
+
+        private static final boolean HIBERNATE_PRESENT = detectHibernate();
+
+        private static boolean detectHibernate() {
+            try {
+                Class.forName("org.hibernate.query.sqm.NodeBuilder", false,
+                        IeeeDoubleCast.class.getClassLoader());
+                return true;
+            } catch (ClassNotFoundException | LinkageError e) {
+                return false;
+            }
+        }
+
+        /** True when the current CriteriaBuilder's session factory has the function registered. */
+        static boolean isRegistered(CriteriaBuilder cb) {
+            return HIBERNATE_PRESENT && Probe.isRegistered(cb);
+        }
+
+        /** The only code that references Hibernate types; never loaded without hibernate-core. */
+        private static final class Probe {
+            static boolean isRegistered(CriteriaBuilder cb) {
+                return cb instanceof org.hibernate.query.sqm.NodeBuilder nb
+                        && nb.getQueryEngine().getSqmFunctionRegistry().findFunctionDescriptor(
+                                MySqlDoubleCastFunctionContributor.FUNCTION_NAME) != null;
+            }
         }
     }
 }

--- a/spring-data/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/spring-data/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+dev.cerbos.queryplan.springdata.MySqlDoubleCastFunctionContributor

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -311,17 +311,23 @@ class AdversarialConformanceTest {
                         "adapter.test.mysql.collation", "utf8mb4_0900_as_cs");
                 MySQLContainer<?> my = new MySQLContainer<>("mysql:8.4")
                         .withCommand("--character-set-server=utf8mb4",
-                                "--collation-server=" + collation)
-                        // Server-side prepared statements so JDBC double binds keep their
-                        // type. Connector/J's default client-side prepared statements
-                        // interpolate double parameters as DECIMAL literals, and Hibernate's
-                        // MySQLDialect renders the adapter's to-double casts as
-                        // decimal(53,20) — together that evaluates the adapter's double-space
-                        // arithmetic in exact decimal (3 * 0.1 == 0.3 becomes TRUE, diverging
-                        // from CEL IEEE semantics; p-double-frac is the witness). With typed
-                        // double binds the decimal*double product promotes to double and the
-                        // oracle agrees. Verified empirically on MySQL 8.4.
-                        .withUrlParam("useServerPrepStmts", "true");
+                                "--collation-server=" + collation);
+                // The leg runs with Connector/J's DEFAULT client-side prepared statements,
+                // which interpolate double bind parameters as DECIMAL literals. Hibernate's
+                // MySQLDialect renders to-double casts as decimal(53,20), so without the
+                // adapter's own `cast(... as double)` rendering (registered by
+                // MySqlDoubleCastFunctionContributor) the double-space arithmetic would
+                // evaluate in exact decimal — 3 * 0.1 == 0.3 becomes TRUE, diverging from
+                // CEL IEEE semantics; p-double-frac is the witness. Running client-side by
+                // default makes the oracle pin the DOUBLE-cast fix; set
+                // -Dadapter.test.mysql.serverPrepStmts=true (env var
+                // ADAPTER_TEST_MYSQL_SERVER_PREP_STMTS) to verify the server-side prepared
+                // statement mode too — both
+                // modes must agree with the check() oracle. Verified empirically on
+                // MySQL 8.4.
+                if (Boolean.getBoolean("adapter.test.mysql.serverPrepStmts")) {
+                    my.withUrlParam("useServerPrepStmts", "true");
+                }
                 my.start();
                 database = my;
                 return Persistence.createEntityManagerFactory(
@@ -593,6 +599,30 @@ class AdversarialConformanceTest {
                         && ex.getMessage().contains("String")
                         && ex.getMessage().contains("request.resource.attr.createdBy"),
                 "unexpected message: " + ex.getMessage());
+    }
+
+    /**
+     * Pins the MySQL IEEE double-cast wiring. On the MySQL leg the ServiceLoader-discovered
+     * {@link MySqlDoubleCastFunctionContributor} must have registered the
+     * {@code cerbos_ieee_double} function — without it the adapter's arithmetic silently
+     * evaluates in exact decimal under Connector/J's default client-side prepared statements
+     * ({@code p-double-frac} catches the semantics; this test names the mechanism when it
+     * breaks, e.g. the META-INF/services entry going missing). On H2/PostgreSQL the function
+     * must NOT be registered: those dialects render IEEE-correct casts already, and the
+     * adapter must keep their SQL on the untouched {@code cb.toDouble} path.
+     */
+    @Test
+    void ieeeDoubleCastRegistrationMatchesDatabase() {
+        org.hibernate.query.sqm.NodeBuilder nb =
+                (org.hibernate.query.sqm.NodeBuilder) emf.getCriteriaBuilder();
+        boolean registered = nb.getQueryEngine().getSqmFunctionRegistry()
+                .findFunctionDescriptor(MySqlDoubleCastFunctionContributor.FUNCTION_NAME) != null;
+        boolean mysqlLeg = "mysql".equals(System.getProperty("adapter.test.db", "h2"));
+        assertEquals(mysqlLeg, registered, mysqlLeg
+                ? "cerbos_ieee_double must be registered on MySQL (is the "
+                        + "META-INF/services FunctionContributor entry intact?)"
+                : "cerbos_ieee_double must not be registered off-MySQL — H2/PostgreSQL "
+                        + "keep the cb.toDouble cast path");
     }
 
     @Test


### PR DESCRIPTION
Finding 28/28 from an internal adversarial review of the Spring Data adapter (discovered during the review's real-database CI work).

## Mechanism

The adapter deliberately lowers CEL arithmetic comparisons to SQL evaluated in IEEE double space, because that is how the PDP evaluates them at check time (CEL attribute arithmetic is always double-typed). On MySQL, two independent defaults conspire to evaluate that "double" arithmetic in **exact decimal** instead:

1. **Hibernate's `MySQLDialect` renders to-double casts as `decimal(53,20)`.** Its `castType` mapping (Hibernate 6.6.18, `MySQLDialect.java:301`: `case FLOAT: case REAL: case DOUBLE: ... return "decimal($p,$s)"`) predates MySQL 8.0.17, which added `CAST(... AS DOUBLE)`.
2. **MySQL Connector/J's DEFAULT client-side prepared statements interpolate double bind parameters into the statement text**, where MySQL parses them as exact DECIMAL literals.

Decimal arithmetic is not IEEE arithmetic: `3 * 0.1 == 0.3` is TRUE in decimal but FALSE in CEL (`0.30000000000000004`). So on MySQL with default JDBC settings, arithmetic-comparison filters return rows the PDP's `check()` API **denies** — a silent over-grant. The MySQL CI leg added in #272 masked this by setting `useServerPrepStmts=true` (typed double binds promote the arithmetic back to double space even under the decimal cast).

**Affected policy shapes:** arithmetic inside comparisons only (`R.attr.x * 0.1 == 0.3`, `R.attr.d + 0.7 != 0.1`, ...). Plain comparisons, `in`, LIKE, and collection shapes never enter the cast path.

## Empirical evidence (MySQL 8.4.10)

Direct SQL — the cast type alone decides the arithmetic space:

```
SELECT CAST(3 AS DECIMAL(53,20)) * 0.1 = 0.3;  -- 1  (exact decimal: 0.300000...)
SELECT CAST(3 AS DOUBLE)         * 0.1 = 0.3;  -- 0  (IEEE: 0.30000000000000004)
```

Connector/J 9.3.0 + `general_log`, `PreparedStatement.setDouble(0.1)/(0.3)` against a seeded row `(id='a6', n=3)` — the full 2×2 matrix; only the customer-default combination diverges:

```
-- client-side prep (DEFAULT): server receives interpolated DECIMAL literals
Query    select id from r where cast(n as decimal(53,20)) * 0.1 = 0.3   -> returns a6  (WRONG: check() denies)
Query    select id from r where cast(n as double)         * 0.1 = 0.3   -> no rows     (correct)
-- server-side prep (useServerPrepStmts=true): typed double binds
Execute  select id from r where cast(n as decimal(53,20)) * 0.1 = 0.3   -> no rows     (correct: double bind promotes)
Execute  select id from r where cast(n as double)         * 0.1 = 0.3   -> no rows     (correct)
```

Hibernate-rendered SQL on the MySQL oracle leg, **before**:

```sql
select distinct re1_0.id from resources re1_0 where (cast(re1_0.a_number as decimal(53,20))*?)=? order by 1
select distinct re1_0.id from resources re1_0 where (cast(re1_0.a_double as decimal(53,20))+?)=? order by 1
```

**after** (this PR):

```sql
select distinct re1_0.id from resources re1_0 where (cast(re1_0.a_number as double)*?)=? order by 1
select distinct re1_0.id from resources re1_0 where (cast(re1_0.a_double as double)+?)=? order by 1
```

(The nullif-guarded division, both-sides arithmetic, and in-lambda arithmetic shapes all render the same way — verified in the captured SQL.)

## Fix

A Hibernate `FunctionContributor` (`MySqlDoubleCastFunctionContributor`, auto-discovered via `META-INF/services/org.hibernate.boot.model.FunctionContributor`) registers a `cerbos_ieee_double` function rendering `cast(?1 as double)` — **only** when the dialect is MySQL (not MariaDB) at version >= 8.0.17. The adapter routes every column entering arithmetic through a new `toIeeeDouble` helper that uses the registered function when — and only when — it is actually present in the session factory's `SqmFunctionRegistry`, falling back to the existing `cb.toDouble` otherwise. Because MySQL promotes any expression with an approximate (DOUBLE) operand to double space, the interpolated DECIMAL literals stop mattering: client- and server-side prepared statements now both agree with `check()`, with no JDBC URL settings required.

Why keying off the **actual function registration** (not dialect sniffing at query time):

- H2/PostgreSQL: the contributor registers nothing, so the probe returns false and their SQL stays **byte-identical** to before (confirmed: the H2 and PostgreSQL legs run the whole suite through the unchanged `cb.toDouble` path, and a pinning test asserts the function is absent there).
- Non-Hibernate JPA providers: all Hibernate-touching code is behind a `Class.forName` classpath guard; the adapter keeps its portable Jakarta-only path. `hibernate-core` is `compileOnly`, mirroring how `spring-data-jpa` is declared.
- Missing registration on Hibernate+MySQL (old server, metadata access disabled, exotic classloading): degrades to the previous behavior — never to an unknown-function SQL error — and the README documents the `useServerPrepStmts=true` fallback for exactly those setups.

Alternatives considered and rejected:

- **Documentation-only (`useServerPrepStmts=true` requirement):** leaves every default-configured Connector/J deployment silently over-granting; rejected since a clean automatic fix exists.
- **Unconditional `cb.function` for all dialects:** would break non-Hibernate providers and change (even if only cosmetically) H2/PostgreSQL SQL.
- **Query-time dialect sniffing via `SessionFactoryImplementor`:** decides "MySQL" from internals without knowing whether the function is renderable; the registry probe is the ground truth and fails safe.
- **Asking users to subclass `MySQLDialect`:** pushes the correctness burden onto every consumer.

## Tests / tripwires

- The MySQL oracle leg now runs with Connector/J's **default client-side prepared statements** (the `useServerPrepStmts=true` URL flag from #272 is gone from the default path): the existing differential-oracle actions `p-double-frac` (`R.attr.aNumber * 0.1 == 0.3`) and `arith-add-eq/ne-frac` are the semantic tripwire — they fail within seconds if the cast regresses to decimal (proven below).
- The CI matrix gains a second MySQL leg with `ADAPTER_TEST_MYSQL_SERVER_PREP_STMTS=true` (`-Dadapter.test.mysql.serverPrepStmts=true`) so the typed-bind mode customers may opt into stays covered too.
- New `ieeeDoubleCastRegistrationMatchesDatabase` test pins the mechanism across all three legs: `cerbos_ieee_double` MUST be registered on the MySQL leg (names the cause — e.g. a lost `META-INF/services` entry — when the semantic tripwire fires) and MUST NOT be registered on H2/PostgreSQL (pins that their SQL stays on the untouched `cb.toDouble` path).
- README gains a "MySQL: keeping arithmetic IEEE-faithful" gotcha: affected policy shapes, both mechanisms, what the adapter does automatically, and the exact configurations that still require `useServerPrepStmts=true` (MySQL < 8.0.17, MariaDB, non-Hibernate providers, `allow_jdbc_metadata_access=false`).

### Negative control (fix bypassed, new tests kept, MySQL leg, client-side prep)

```
AdversarialConformanceTest > adapterMatchesCheckOracle > arith-add-eq-frac FAILED
    expected: <[]> but was: <[a1]>                 # over-inclusion: PDP-denied row leaks
AdversarialConformanceTest > adapterMatchesCheckOracle > arith-add-ne-frac FAILED
    expected: <[a1, a2, a4, ...]> but was: <[a2, a4, ...]>   # under-inclusion mirror
AdversarialConformanceTest > adapterMatchesCheckOracle > p-double-frac FAILED
    expected: <[]> but was: <[a6]>                 # 3 * 0.1 == 0.3 decimal trap
BUILD FAILED
```

The same failures reproduce on unmodified `main` once the leg runs client-side — i.e. the pre-existing MySQL CI leg was green only because of its URL flag.

### Full builds (Docker Gradle, testcontainers PDP)

| Leg | Command | Result |
|---|---|---|
| H2 (default) | `gradle clean build` | BUILD SUCCESSFUL — 429 tests |
| PostgreSQL 16 | `ADAPTER_TEST_DB=postgres gradle clean build` | BUILD SUCCESSFUL — 429 tests |
| MySQL 8.4, client-side prep (new default) | `ADAPTER_TEST_DB=mysql gradle clean build` | BUILD SUCCESSFUL — 429 tests, incl. the three former failures |
| MySQL 8.4, server-side prep | `ADAPTER_TEST_DB=mysql ADAPTER_TEST_MYSQL_SERVER_PREP_STMTS=true gradle test --tests AdversarialConformanceTest` | BUILD SUCCESSFUL — 102 tests |

## Notes

- The residual edge documented in #274 (a double column one ULP from an integer under integer constants in the retained long/long solve) is untouched: that path emits a plain uncast equality and never enters the cast rendering this PR changes.
- The gt/lt/ge/le and eq/ne lowering logic itself is unchanged — only the SQL spelling of the to-double cast on MySQL.
