### PR TITLE
fix(spring-data): escape '[' in LIKE patterns for SQL Server portability

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -183,7 +183,7 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | `eq` / `ne`                      | `cb.equal` / `cb.notEqual` (auto `isNull`/`isNotNull` for `null` RHS) |
 | `lt` / `gt` / `le` / `ge`        | `cb.lessThan` / `greaterThan` / `lessThanOrEqualTo` / `greaterThanOrEqualTo` |
 | `in`                             | `path.in(values)` or correlated `EXISTS` for collections            |
-| `contains` / `startsWith` / `endsWith` | `cb.like(...)` with proper `_`/`%`/`\` escaping — incl. the constant-receiver form (`"a,b".contains(R.attr.x)`: the constant is the haystack, the column the needle) |
+| `contains` / `startsWith` / `endsWith` | `cb.like(...)` with proper `_`/`%`/`\`/`[` escaping (`[` guards SQL Server character classes — see Gotchas) — incl. the constant-receiver form (`"a,b".contains(R.attr.x)`: the constant is the haystack, the column the needle) |
 | `isSet(field, true/false)`       | `cb.isNotNull` / `cb.isNull`                                        |
 | `hasIntersection(coll, [values])` | Correlated `EXISTS` with `IN`                                      |
 | `hasIntersection(coll.map(x, x.f), [values])` | Correlated `EXISTS` with projected `IN`             |
@@ -196,7 +196,7 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | Ternary (`cond ? a : b`)         | Predicate rewrite: `(cond AND cmp(a, v)) OR (NOT cond AND cmp(b, v))` — nested, boolean-position, and value-first forms compose; constant residues fold (see Gotchas for `NULL` semantics) |
 | Arithmetic in comparisons (`add`/`sub`/`mult`/`div`) | `cb.sum`/`diff`/`prod`/`quot` in double space, compared via `eq`/`ne`/`lt`/`gt`/`le`/`ge`; nested and both-sides shapes compose (see Gotchas — CEL attribute arithmetic is double arithmetic) |
 | Timestamp comparisons (`timestamp(R.attr.createdAt) < now() - duration("24h")`) | Temporal column comparison for all of `eq`/`ne`/`lt`/`gt`/`le`/`ge`, both operand orders (value-first forms mirror). The planner folds `now()`/`now() - duration(...)` to a constant RFC-3339 instant at **plan time**, so the window is fixed per query — re-plan to refresh it. The mapped column must be `java.time.Instant` or `java.time.OffsetDateTime` (both denote an absolute instant; Hibernate 6 stores them UTC-normalized). `LocalDateTime`, `java.util.Date`, and `String` columns throw a named error — they are ambiguous about the absolute instant they store (see Gotchas). A `NULL` column value is excluded, matching `check()` denying on the missing attribute. |
-| Field-to-field `contains`/`startsWith`/`endsWith` | `cb.like` over a `REPLACE`-escaped column-derived pattern (`\`, `%`, `_`), with an `IS NOT NULL` needle guard |
+| Field-to-field `contains`/`startsWith`/`endsWith` | `cb.like` over a `REPLACE`-escaped column-derived pattern (`\`, `%`, `_`, `[`), with an `IS NOT NULL` needle guard |
 | Multi-hop relation chains (`R.attr.categories.subCategories`) | Correlated subquery joining through every hop; `exists`/`in`/`hasIntersection`/`size` all treat the chain as the flattened union of tail elements |
 | `exists(coll, lambda)`           | Correlated `EXISTS` with lambda body                                |
 | `exists_one(coll, lambda)`       | Correlated `(SELECT COUNT...) = 1`                                  |
@@ -305,7 +305,7 @@ duration arithmetic when the plan is produced, wrapping the result back in
 ### Field-to-field string matching builds its pattern with `REPLACE`
 
 `R.attr.a.contains(R.attr.b)` becomes `a LIKE CONCAT('%', <escaped b>, '%') ESCAPE '\'`
-where `b` is escaped via nested `REPLACE` calls (`\`, `%`, `_`) — chosen because
+where `b` is escaped via nested `REPLACE` calls (`\`, `%`, `_`, `[`) — chosen because
 `REPLACE` is available on H2, PostgreSQL, MySQL, Oracle, and SQL Server. A `NULL`
 needle column excludes the row (`IS NOT NULL` guard), which matches CEL
 missing-attribute → deny and also defends against dialects whose `CONCAT` treats
@@ -404,7 +404,7 @@ repository methods; don't cache the `Predicate` it returns.
 ### MySQL / MariaDB `LIKE` backslash escaping
 
 `contains` / `startsWith` / `endsWith` translate to `cb.like(path, pattern, '\\')` — the
-adapter escapes `%`, `_`, and `\` in the user value and declares `\` as the SQL escape
+adapter escapes `%`, `_`, `\`, and `[` in the user value and declares `\` as the SQL escape
 character (the three-arg `LIKE … ESCAPE '\'` form). On most databases this is exact and
 unambiguous.
 
@@ -419,6 +419,20 @@ backslashes and you target MySQL/MariaDB, either:
   the `LIKE` predicate with an escape character your dialect handles cleanly.
 
 Values without backslashes are unaffected.
+
+### SQL Server `LIKE` `[` character classes
+
+T-SQL `LIKE` treats `[...]` as a character class **even when an `ESCAPE` clause is
+declared**: an unescaped `'[SEC]%'` matches one character from `{S,E,C}` — returning rows
+the PDP denies — and does *not* match a literal `[SEC]` prefix. The adapter therefore
+escapes `[` as `\[` in every pattern it generates: the constant
+`contains`/`startsWith`/`endsWith` forms, the field-to-field `REPLACE` chain, and the
+hierarchy prefix `LIKE`. With the escape declared, `\[` denotes a literal `[` on every
+supported dialect — the differential oracle's H2, PostgreSQL, and MySQL legs verify the
+escape is a semantic no-op where `[` is inert.
+
+`]` is intentionally left unescaped: it is only special on SQL Server as the closer of a
+character class, and no class can open once every `[` is escaped.
 
 ## Build
 

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/PlanValues.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/PlanValues.java
@@ -153,8 +153,20 @@ final class PlanValues {
                 "add comparison type mismatch: " + comparisonValue.getClass() + " vs " + addConstant.getClass());
     }
 
-    /** Escape {@code LIKE} wildcards; pair with an explicit {@code '\\'} escape character. */
+    /**
+     * Escape {@code LIKE} wildcards; pair with an explicit {@code '\\'} escape character.
+     *
+     * <p>{@code [} is escaped because SQL Server / Sybase {@code LIKE} treats {@code [...]}
+     * as a character class even when an {@code ESCAPE} clause is declared — an unescaped
+     * {@code '[SEC]%'} matches one character from {@code {S,E,C}} instead of the literal
+     * prefix {@code [SEC]}. With the escape declared, {@code \[} means a literal {@code [}
+     * on every targeted dialect (verified empirically on H2, PostgreSQL, and MySQL, where
+     * {@code [} is otherwise inert — the escape is a semantic no-op there). {@code ]} needs
+     * no escaping: it is only special on SQL Server as the closer of a class, and no class
+     * can open once every {@code [} is escaped.
+     */
     static String escapeLike(String s) {
-        return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+        return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                .replace("[", "\\[");
     }
 }

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -1114,8 +1114,12 @@ public final class SpringDataQueryPlanAdapter {
              * {@code haystackColumn LIKE wildcards(escape(needleColumn))} — the column-to-column
              * analogue of the constant LIKE path in {@link #defaultLeaf}. The needle is data, so its
              * LIKE metacharacters are escaped dynamically with nested {@code REPLACE} (portable:
-             * H2/Postgres/MySQL/Oracle/SQL Server): {@code \} first, then {@code %} and {@code _},
-             * mirroring {@link PlanValues#escapeLike} and the same explicit {@code '\'} escape char.
+             * H2/Postgres/MySQL/Oracle/SQL Server): {@code \} first, then {@code %}, {@code _},
+             * and {@code [}, mirroring {@link PlanValues#escapeLike} and the same explicit
+             * {@code '\'} escape char. {@code [} is escaped because SQL Server LIKE treats
+             * {@code [...]} as a character class even under an ESCAPE clause; {@code \[} is a
+             * literal {@code [} on every targeted dialect ({@code ]} needs no escaping once no
+             * {@code [} can open a class — see {@link PlanValues#escapeLike}).
              *
              * <p>The explicit {@code IS NOT NULL} guard on the needle matches CEL (a missing
              * attribute is an evaluation error → deny) and also defends against dialects whose
@@ -1133,6 +1137,8 @@ public final class SpringDataQueryPlanAdapter {
                         escaped, cb.literal("%"), cb.literal("\\%"));
                 escaped = cb.function("replace", String.class,
                         escaped, cb.literal("_"), cb.literal("\\_"));
+                escaped = cb.function("replace", String.class,
+                        escaped, cb.literal("["), cb.literal("\\["));
                 jakarta.persistence.criteria.Expression<String> pattern = escaped;
                 if (leadingWildcard) {
                     pattern = cb.concat(cb.literal("%"), pattern);

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -168,7 +168,16 @@ class AdversarialConformanceTest {
             // ("xA_by" wrongly matches contains("a_b") under a CI collation).
             new Seed("c1", true, "One", 11, "Set",
                     List.of(new Tag("tc1", "Public")), List.of("Finance")),
-            new Seed("c2", false, "xA_by", 12, null, List.of(), List.of())
+            new Seed("c2", false, "xA_by", 12, null, List.of(), List.of()),
+            // SQL Server '[' escaping witnesses. d1 is the literal-bracket match: every
+            // generated pattern escapes '[' as '\[', which under ESCAPE '\' must STILL be a
+            // literal '[' on H2/PostgreSQL/MySQL (like-bracket startsWith, the f2f-* actions
+            // — its aOptionalString "[SEC]" is a bracket NEEDLE through the REPLACE chain —
+            // and hier-bracket via scopeFor). d2 is the character-class trap: on SQL Server
+            // an UNESCAPED '[SEC]%' would match "Secret" (one character from {S,E,C}); it
+            // must never match on any dialect.
+            new Seed("d1", true, "[SEC]ret", 13, "[SEC]", List.of(), List.of()),
+            new Seed("d2", false, "Secret", 14, "xSECy", List.of(), List.of())
     );
 
     /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
@@ -251,6 +260,8 @@ class AdversarialConformanceTest {
             case "b6" -> "50%.a_b";
             case "c1" -> "Dept.Eng";
             case "c2" -> "dept.eng.";
+            case "d1" -> "[env]:prod:eu"; // literal-bracket descendant for hier-bracket
+            case "d2" -> "e:prod:eu"; // SQL Server char-class trap sibling for hier-bracket
             default -> null; // a7: NULL scope — a missing attribute on the check side
         };
     }
@@ -494,7 +505,7 @@ class AdversarialConformanceTest {
     @ValueSource(strings = {
             "vf-le", "vf-ge", "vf-ne",
             "in-single", "in-empty",
-            "like-percent", "like-underscore", "like-backslash",
+            "like-percent", "like-underscore", "like-backslash", "like-bracket",
             "unicode-eq", "empty-string-eq",
             // explicit case-sensitivity witness (c1/c2 seeds also discriminate in-single,
             // like-underscore, lambda-in-principal, and p-hasintersection-map on
@@ -549,6 +560,7 @@ class AdversarialConformanceTest {
             // paths — seeds are documented on scopeFor(...)
             "hier-ancestor-ff", "hier-ancestor-cf", "hier-descendent-ff", "hier-descendent-cf",
             "hier-overlaps-ff", "hier-overlaps-cf", "hier-meta-like", "hier-meta-in",
+            "hier-bracket",
             // timestamp(field) vs folded constant instants against the Instant column
             // (created_at). ts-window is the retention-cutoff shape (now()-duration folds
             // at plan time); ts-vf pins value-first MIRRORING (an inversion bug flips the

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -1616,6 +1616,20 @@ class SpringDataQueryPlanAdapterTest {
         }
 
         @Test
+        void descendentOfBracketPrefixMatchesLiteralBracketPaths() {
+            // '[' in a path segment: the prefix pattern must escape it as '\[' because SQL
+            // Server LIKE treats '[...]' as a character class even under ESCAPE. On H2 the
+            // escaped pattern must keep matching the LITERAL '[env]:prod' descendants and
+            // must never match 'e:prod:eu' — the row an unescaped '[env]' class would match
+            // one character of on SQL Server. The equal path pins strictness.
+            Operand cond = exprOp("descendentOf",
+                    hierarchy(var("request.resource.attr.aString"), ":"),
+                    hierarchy(sval("[env]:prod"), ":"));
+            withScopeRows(List.of("[env]:prod:eu", "e:prod:eu", "[env]:prod"), () ->
+                    assertEquals(Set.of("[env]:prod:eu"), runIds(cond)));
+        }
+
+        @Test
         void overlapsSegmentedWithField() {
             // The policy shape: hierarchy("projects:123", ":").overlaps(hierarchy(["projects", R.id]))
             //   → segment-wise: const "projects" matches, then field == "123".
@@ -2519,6 +2533,27 @@ class SpringDataQueryPlanAdapterTest {
         }
 
         @Test
+        void bracketInNeedleColumn() {
+            // The REPLACE chain rewrites '[' to '\[' (SQL Server character-class guard);
+            // with ESCAPE '\' declared that must still be a literal '[' on H2 — the literal
+            // match keeps working and 'Secret' (the row an unescaped '[SEC]' class would
+            // match on SQL Server) never matches.
+            withResource(row("f2f-like-10", "x[SEC]y", "[SEC]"), () -> {
+                assertEquals(1, count("contains"));
+                assertEquals(0, count("startsWith"));
+            });
+            withResource(row("f2f-like-11", "[SEC]ret", "[SEC]"), () -> {
+                assertEquals(1, count("startsWith"));
+                assertEquals(1, count("contains"));
+            });
+            withResource(row("f2f-like-12", "Secret", "[SEC]"), () -> {
+                assertEquals(0, count("contains"));
+                assertEquals(0, count("startsWith"));
+                assertEquals(0, count("endsWith"));
+            });
+        }
+
+        @Test
         void nullNeedleColumnExcludesRow() {
             // CEL: missing attribute → error → deny. Guarded explicitly because some
             // dialects' CONCAT treats NULL as '' which would turn the pattern into
@@ -2537,6 +2572,68 @@ class SpringDataQueryPlanAdapterTest {
                 assertEquals(1, count("contains"));
                 assertEquals(1, count("startsWith"));
                 assertEquals(1, count("endsWith"));
+            });
+        }
+    }
+
+    // -- SQL Server '[' LIKE escaping --
+    // T-SQL LIKE treats '[...]' as a character class EVEN WITH an ESCAPE clause declared, so
+    // every '[' in a generated pattern must arrive as '\['. On H2 (and PostgreSQL/MySQL —
+    // covered by the differential oracle legs) '[' is inert and '\[' under ESCAPE '\' is
+    // still a literal '[', so the escape is a semantic no-op there: the row-behavior tests
+    // below pin that no-op, while the pattern assertions pin the escape itself (they are the
+    // tests that FAIL when the '[' rewrite is removed — H2 row behavior cannot distinguish).
+
+    @Nested
+    class BracketLikeEscaping {
+
+        @Test
+        void escapeLikeEscapesOpeningBracket() {
+            // The pattern-level contract for the constant contains/startsWith/endsWith forms
+            // AND the hierarchy prefix LIKE (both build their patterns via escapeLike).
+            assertEquals("\\[SEC]", PlanValues.escapeLike("[SEC]"));
+            assertEquals("50\\%\\[a]\\_b", PlanValues.escapeLike("50%[a]_b"));
+            // Backslash is escaped FIRST, so a literal '\[' becomes '\\' + '\['.
+            assertEquals("\\\\\\[", PlanValues.escapeLike("\\["));
+            // ']' is intentionally unescaped: it is only special on SQL Server as the closer
+            // of a character class, and no class can open once every '[' is escaped.
+            assertEquals("]", PlanValues.escapeLike("]"));
+        }
+
+        private ResourceEntity row(String id, String aString) {
+            ResourceEntity r = new ResourceEntity(id);
+            r.setaString(aString);
+            return r;
+        }
+
+        @Test
+        void bracketConstantsMatchLiterallyOnH2() {
+            // '\[' + ESCAPE stays a literal '[': literal-bracket rows keep matching.
+            withResource(row("br-1", "[SEC]ret"), () -> {
+                assertEquals(1, runCount(exprOp("startsWith",
+                        var("request.resource.attr.aString"), sval("[SEC]"))));
+                assertEquals(1, runCount(exprOp("contains",
+                        var("request.resource.attr.aString"), sval("[SEC]"))));
+            });
+            withResource(row("br-2", "a[x]b"), () ->
+                    assertEquals(1, runCount(exprOp("contains",
+                            var("request.resource.attr.aString"), sval("[x]")))));
+            withResource(row("br-3", "tail[end]"), () ->
+                    assertEquals(1, runCount(exprOp("endsWith",
+                            var("request.resource.attr.aString"), sval("[end]")))));
+        }
+
+        @Test
+        void bracketConstantsDoNotMatchClassMembers() {
+            // The SQL Server over-match scenario: 'Secret' starts with a member of the
+            // {S,E,C} class an unescaped '[SEC]' pattern denotes. It must not match on any
+            // dialect (H2 here; PostgreSQL/MySQL via the oracle legs; SQL Server by the
+            // escaped pattern).
+            withResource(row("br-4", "Secret"), () -> {
+                assertEquals(0, runCount(exprOp("startsWith",
+                        var("request.resource.attr.aString"), sval("[SEC]"))));
+                assertEquals(0, runCount(exprOp("contains",
+                        var("request.resource.attr.aString"), sval("[SEC]"))));
             });
         }
     }

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -68,6 +68,18 @@ resourcePolicy:
         match:
           expr: R.attr.aString.endsWith("\\")
 
+    # '[' must be escaped: T-SQL LIKE treats '[...]' as a character class even under an
+    # ESCAPE clause (unescaped '[SEC]%' would match the d2 seed "Secret" and miss the d1
+    # seed "[SEC]ret" on SQL Server). On H2/PostgreSQL/MySQL — the three oracle legs —
+    # '\[' with ESCAPE must stay a literal '[': d1 in, d2 out, proving the escape is a
+    # semantic no-op on those dialects.
+    - actions: ["like-bracket"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: R.attr.aString.startsWith("[SEC]")
+
     # -- case sensitivity: CEL string equality is exact and case-sensitive, so the c1 seed
     # (aString "One") is DENIED here. A case-insensitive database collation (MySQL default
     # utf8mb4_0900_ai_ci, SQL Server *_CI_*) matches it anyway — the differential oracle
@@ -852,6 +864,17 @@ resourcePolicy:
       condition:
         match:
           expr: 'hierarchy(R.attr.scope).ancestorOf(hierarchy("50%.a_b.x"))'
+
+    # '[' in a path segment routes through the prefix-LIKE branch: the pattern must escape
+    # it as '\[' (SQL Server character classes ignore ESCAPE). The d1 scope
+    # ("[env]:prod:eu") is the literal-bracket descendant; d2 ("e:prod:eu") is the row an
+    # unescaped '[env]' class would match one character of on SQL Server.
+    - actions: ["hier-bracket"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hierarchy(R.attr.scope, ":").descendentOf(hierarchy("[env]:prod", ":"))'
 
     # -- timestamp(field) vs constant-instant comparisons (ts-*) --
     # Wire shape (PDP-verified): the planner folds now()-duration arithmetic to a constant


### PR DESCRIPTION
## Problem

T-SQL (SQL Server / Sybase) `LIKE` treats `[...]` as a **character class even when an `ESCAPE` clause is declared**. The adapter's LIKE escaping (`escapeLike` and the field-to-field `REPLACE` chain) only escaped `\`, `%`, and `_`, so any `[` in a plan constant, needle column, or hierarchy path segment reached the pattern raw.

On SQL Server, `R.attr.code.startsWith("[SEC]")` built `code LIKE '[SEC]%' ESCAPE '\'`, which:

- **over-matches**: `[SEC]` denotes "one character from `{S,E,C}`", so rows starting with `S`, `E`, or `C` (e.g. `Secret`) are returned even though the PDP's `check()` denies them — an authorization bypass;
- **under-matches**: rows literally starting with `[SEC]` are NOT matched — permitted rows silently hidden.

`[` reaches plan constants verbatim (e.g. via constant-folded principal attributes), the README claims SQL Server portability for this approach, and all tests ran on H2 where `[` is inert — so nothing caught it.

## Fix

Escape `[` as `\[` at every pattern-construction site:

1. **`PlanValues.escapeLike`** — covers the constant `contains`/`startsWith`/`endsWith` forms *and* `HierarchyTranslator`'s prefix-LIKE construction (`startsWithLiteral`), which calls `escapeLike` directly.
2. **The field-to-field dynamic `REPLACE` chain** (`SpringDataQueryPlanAdapter.fieldToFieldLike`) — gains a fourth `REPLACE(column, '[', '\[')`, mirroring `escapeLike`.

With the `ESCAPE '\'` clause the adapter already declares, `\[` denotes a literal `[` on every targeted dialect. `]` is intentionally left unescaped: it is only special on SQL Server as the *closer* of a character class, and no class can open once every `[` is escaped (documented in the `escapeLike` javadoc and README).

## Cross-dialect no-op evidence (empirical, not documentation)

Probed directly before shipping:

- **PostgreSQL 16**: `'[SEC]ret' LIKE '\[SEC]%' ESCAPE '\'` → true; `'Secret' LIKE '\[SEC]%' ESCAPE '\'` → false; `'x]y' LIKE '%]%'` → true.
- **MySQL 8.4**: same probes built from hex literals (to mimic JDBC bind parameters and sidestep string-literal backslash handling) → identical results.
- **H2**: covered by the new seeded row-behavior unit tests (literal-`[` rows still match, class-member rows don't).

So the escape is a semantic no-op on H2/PostgreSQL/MySQL and only changes behavior on SQL Server — where it makes the pattern correct.

## Tests

- **Pattern assertions** (`BracketLikeEscaping.escapeLikeEscapesOpeningBracket`): pin `escapeLike("[SEC]") == "\[SEC]"`, escape ordering with `\`, and that `]` stays unescaped. **These fail on the old code** (negative control).
- **Row-behavior tests on H2**: constant `startsWith`/`contains`/`endsWith` with `[` constants against seeded literal-`[` rows; a field-to-field case with a `[`-holding needle column; a hierarchy `descendentOf` with a `[env]` path segment (incl. the `e:prod:eu` class-trap sibling). Honest caveat: since `[` is inert on H2, these row tests pass on old *and* new code — they pin the no-op, while the pattern assertions pin the escape. The SQL Server correctness itself rests on documented T-SQL semantics (this repo has no SQL Server test infrastructure — deliberately out of scope).
- **Differential oracle**: new `like-bracket` and `hier-bracket` actions plus `d1` (`"[SEC]ret"` / needle `"[SEC]"` / scope `"[env]:prod:eu"`) and `d2` (`"Secret"` / scope `"e:prod:eu"`) seeds. `d1`'s `aOptionalString` also feeds the existing `f2f-*` actions, exercising the `REPLACE` chain with a bracket needle. Run on all three legs (H2, PostgreSQL 16, MySQL 8.4) against a live PDP `check()` oracle.

## Test results

- H2 leg (`gradle build`): PASS
- PostgreSQL leg (`ADAPTER_TEST_DB=postgres`): PASS
- MySQL leg (`ADAPTER_TEST_DB=mysql`): PASS

## Docs

README: operator-table rows and the field-to-field gotcha now list `[`; new "SQL Server `LIKE` `[` character classes" gotcha alongside the MySQL backslash one, explaining the mechanism and the intentional non-escaping of `]`.

---

Finding 7/28 from an internal adversarial review of the spring-data adapter.

Note: PR #284 is open in the adapter's numericComparison area + README MySQL arithmetic gotcha — this PR touches different code regions; at most a trivial README-adjacent merge conflict is expected.
