### PR TITLE
fix(spring-data): keep size() thresholds in long space instead of truncating to int

### DIFF
--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -1476,6 +1476,34 @@ public final class SpringDataQueryPlanAdapter {
                         // IS NOT NULL, never an unconditional 1=1. eq f excludes everything.
                         return fractionalCollapse ? cb.isNotNull(path) : cb.disjunction();
                     }
+                    // cb.length(...) is Expression<Integer>, so the threshold must fit in an
+                    // int. An unguarded narrowing cast wraps thresholds outside int range
+                    // (2147483648 → −2147483648, 4294967296 → 0), silently flipping the
+                    // filter — `size(s) > 4294967296` became `LENGTH(s) > 0` (always-true
+                    // over-inclusion while check() denies every row). No string's length
+                    // leaves int range, so these comparisons fold statically instead —
+                    // CEL-faithfully: the "vacuously true" arms still require IS NOT NULL
+                    // because a NULL column is a missing attribute → CEL error → deny.
+                    if (numValue > Integer.MAX_VALUE) {
+                        // LENGTH(s) < 2^31 for every present string: eq/gt/ge can never
+                        // hold; lt/le/ne always hold for a present string.
+                        return switch (cmpOp) {
+                            case "eq", "gt", "ge" -> cb.disjunction();
+                            case "lt", "le", "ne" -> cb.isNotNull(path);
+                            default -> throw new IllegalArgumentException(
+                                    "Unsupported size comparison operator: " + cmpOp);
+                        };
+                    }
+                    if (numValue < Integer.MIN_VALUE) {
+                        // LENGTH(s) >= 0 > any threshold below int range: gt/ge/ne always
+                        // hold for a present string; eq/lt/le can never hold.
+                        return switch (cmpOp) {
+                            case "gt", "ge", "ne" -> cb.isNotNull(path);
+                            case "eq", "lt", "le" -> cb.disjunction();
+                            default -> throw new IllegalArgumentException(
+                                    "Unsupported size comparison operator: " + cmpOp);
+                        };
+                    }
                     return compareCount(cb.length(path.as(String.class)), cmpOp, (int) numValue);
                 }
                 final Operand fBody = lambdaBody;

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -537,6 +537,10 @@ class AdversarialConformanceTest {
             // arithmetic + size edges: zero column divisor (NaN → deny), fractional count
             // threshold (only ordering ops compile in CEL — int vs double eq/ne does not)
             "cr-div-zero", "cr-size-frac-ge",
+            // size(string) thresholds outside int range: giant constants arrive verbatim;
+            // the old (int) narrowing cast wrapped 4294967296 to 0, so gt returned every
+            // non-empty row (check() denies all) and lt returned nothing (check() allows all)
+            "size-huge-gt", "size-huge-lt",
             // constant NaN / ±Infinity ordering: unfolded div(0,0) → NaN; every NaN
             // ordering is false in CEL/IEEE, while ±Infinity orders normally
             "nan-ord-ternary", "nan-ord-ternary-vf", "nan-ord-le", "nan-ord-inf",

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -534,6 +534,117 @@ class SpringDataQueryPlanAdapterTest {
         }
     }
 
+    // -- size(string) thresholds outside int range: cb.length is Expression<Integer>, so an
+    // unguarded (int) narrowing cast wrapped them (2147483648 → −2147483648, 4294967296 → 0),
+    // silently flipping the filter: `size(s) > 4294967296` became `LENGTH(s) > 0` — always-true
+    // over-inclusion while check() denies every row. No string's length leaves int range, so
+    // these comparisons must fold statically: gt/ge/eq huge → always-false; lt/le/ne huge →
+    // true for a PRESENT string only (NULL column = missing attribute → CEL error → deny).
+
+    @Nested
+    class HugeStringSizeThresholds {
+
+        private static final double TWO_POW_31 = 2147483648.0; // Integer.MAX_VALUE + 1
+        private static final double TWO_POW_32 = 4294967296.0;
+
+        private Operand strSize(String op, double threshold) {
+            return exprOp(op,
+                    exprOp("size", var("request.resource.attr.aOptionalString")),
+                    nval(threshold));
+        }
+
+        private ResourceEntity present() {
+            ResourceEntity r = new ResourceEntity("size-huge-1");
+            r.setaOptionalString("abc");
+            return r;
+        }
+
+        private ResourceEntity emptyString() {
+            ResourceEntity r = new ResourceEntity("size-huge-2");
+            r.setaOptionalString("");
+            return r;
+        }
+
+        private ResourceEntity nullString() {
+            ResourceEntity r = new ResourceEntity("size-huge-3");
+            r.setaOptionalString(null);
+            return r;
+        }
+
+        @Test
+        void gtGeEqAboveIntMaxAreAlwaysFalse() {
+            // No string has >= 2^31 chars, so gt/ge/eq can never hold. The wrap made
+            // gt 2^32 into LENGTH > 0 (matched every non-empty row) and gt 2^31 into
+            // LENGTH > −2^31 (matched every present row).
+            withResource(present(), () -> {
+                assertEquals(0, runCount(strSize("gt", TWO_POW_32)));
+                assertEquals(0, runCount(strSize("gt", TWO_POW_31)));
+                assertEquals(0, runCount(strSize("ge", TWO_POW_32)));
+                assertEquals(0, runCount(strSize("ge", TWO_POW_31)));
+            });
+            // eq 2^32 wrapped to LENGTH = 0, wrongly matching the empty string.
+            withResource(emptyString(), () ->
+                    assertEquals(0, runCount(strSize("eq", TWO_POW_32))));
+        }
+
+        @Test
+        void ltLeAboveIntMaxIncludePresentAndExcludeNull() {
+            // Every present string satisfies lt/le a huge threshold — but a NULL column is
+            // a missing attribute → CEL error → deny. The wrap made lt 2^32 into
+            // LENGTH < 0 (excluded everything).
+            withResource(present(), () -> withResource(nullString(), () -> {
+                assertEquals(1, runCount(strSize("lt", TWO_POW_32)));
+                assertEquals(1, runCount(strSize("le", TWO_POW_32)));
+                assertEquals(1, runCount(strSize("lt", TWO_POW_31)));
+            }));
+        }
+
+        @Test
+        void neAboveIntMaxIncludesEmptyStringAndExcludesNull() {
+            // size("") != 2^32 is TRUE in CEL. The wrap made it LENGTH <> 0, wrongly
+            // excluding the empty string; NULL must stay excluded either way.
+            withResource(emptyString(), () -> withResource(nullString(), () ->
+                    assertEquals(1, runCount(strSize("ne", TWO_POW_32)))));
+        }
+
+        @Test
+        void belowIntMinThresholdsFoldMirrored() {
+            // LENGTH(s) >= 0 > any threshold below int range: gt/ge/ne always hold for a
+            // present string (incl. the empty string — the wrap made gt −2^32 into
+            // LENGTH > 0, wrongly excluding it); eq/lt/le can never hold.
+            withResource(emptyString(), () -> withResource(nullString(), () -> {
+                assertEquals(1, runCount(strSize("gt", -TWO_POW_32)));
+                assertEquals(1, runCount(strSize("ge", -TWO_POW_32)));
+                assertEquals(1, runCount(strSize("ne", -TWO_POW_32)));
+                assertEquals(0, runCount(strSize("lt", -TWO_POW_32)));
+                assertEquals(0, runCount(strSize("le", -TWO_POW_32)));
+                assertEquals(0, runCount(strSize("eq", -TWO_POW_32)));
+            }));
+        }
+
+        @Test
+        void fractionalHugeThresholdRoundsThenFolds() {
+            // ge 2^32 + 0.5 → ceil → 4294967297 → still above int range → always-false;
+            // le → floor → 4294967296 → present strings satisfy it.
+            withResource(present(), () -> {
+                assertEquals(0, runCount(strSize("ge", TWO_POW_32 + 0.5)));
+                assertEquals(1, runCount(strSize("le", TWO_POW_32 + 0.5)));
+            });
+        }
+
+        @Test
+        void boundaryIntegerMaxStillComparesExactly() {
+            // Integer.MAX_VALUE itself is in range and must keep producing a real LENGTH
+            // comparison, not a fold.
+            withResource(present(), () -> {
+                assertEquals(0, runCount(strSize("gt", 2147483647.0)));
+                assertEquals(1, runCount(strSize("lt", 2147483647.0)));
+                assertEquals(1, runCount(strSize("le", 2147483647.0)));
+                assertEquals(0, runCount(strSize("ge", 2147483647.0)));
+            });
+        }
+    }
+
     @Test
     void existsOnNestedRelation() {
         assertEquals(0, runCount(exprOp("exists",

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -734,6 +734,29 @@ resourcePolicy:
         match:
           expr: 'size(R.attr.tags) >= 1.5'
 
+    # ==================== size(string) thresholds outside int range ====================
+    # The planner delivers giant integer constants verbatim (PDP-verified — not folded).
+    # cb.length is Expression<Integer>, so an unguarded (int) narrowing cast wrapped these
+    # (4294967296 → 0), turning `size(aString) > 4294967296` into LENGTH(a_string) > 0 —
+    # every non-empty row returned while check() denies ALL rows (no string has 2^32
+    # chars). The fixed adapter folds statically: gt huge → always-false.
+    - actions: ["size-huge-gt"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'size(R.attr.aString) > 4294967296'
+
+    # The mirror arm: lt huge is true for every PRESENT string (check() allows all seeds —
+    # every seed has aString set, including the empty a8), while the wrapped translation
+    # LENGTH(a_string) < 0 excluded everything.
+    - actions: ["size-huge-lt"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'size(R.attr.aString) < 4294967296'
+
     # ==================== constant NaN / ±Infinity ordering ====================
     # CEL/IEEE define every ordering comparison involving NaN as false. The planner does
     # NOT fold div(0,0): the else arm below arrives as an unfolded div(0,0) subtree, so


### PR DESCRIPTION
## Problem

The Field-mapped string branch of `trySizeComparison` compared `LENGTH(column)` against a plan constant via an unguarded narrowing cast:

```java
compareCount(cb.length(path.as(String.class)), cmpOp, (int) numValue);
```

`numValue` is a `long` parsed from the plan constant, but `cb.length` is `Expression<Integer>`, and the `(int)` cast **wraps** for thresholds outside int range:

- `2147483648` (2^31) → `-2147483648` — `size(aString) > 2147483648` became `LENGTH(a_string) > -2147483648`, i.e. always-true for present strings
- `4294967296` (2^32) → `0` — `size(aString) > 4294967296` became `LENGTH(a_string) > 0`, matching every non-empty row

PDP-verified (re-confirmed against current `ghcr.io/cerbos/cerbos:latest` on a scratch PDP for this PR): `size(request.resource.attr.aString) > 4294967296` is delivered **verbatim** in the wire plan (not folded):

```json
{"operator":"gt","operands":[
  {"expression":{"operator":"size","operands":[{"variable":"request.resource.attr.aString"}]}},
  {"value":4294967296}]}
```

while `check()` DENIES every resource (no string has 2^32 chars). The old adapter silently returned all non-empty rows — an authorization over-inclusion with no exception. The mirrored `lt` direction excluded everything (`LENGTH < 0`), silent under-inclusion. The Relation COUNT branch already keeps `long` and is unaffected (unchanged here).

This is finding 8/28 from an internal adversarial review of the spring-data adapter.

## Approach: static CEL-faithful fold, not a SQL-side long comparison

No real string's length leaves int range, so out-of-range thresholds have statically known truth values. The fix folds them instead of forcing the comparison into long space via `.as(Long.class)`: that would render a dialect-sensitive SQL CAST on every string-size query (the same cast-rendering territory #284 is fixing on MySQL) to buy nothing — the outcome is a constant. The fold changes **zero SQL** for all in-range thresholds.

Semantics, matching `check()` exactly:

| threshold | gt / ge | lt / le | eq | ne |
|---|---|---|---|---|
| `> Integer.MAX_VALUE` | always-false (`cb.disjunction()`) | `IS NOT NULL` | always-false | `IS NOT NULL` |
| `< Integer.MIN_VALUE` | `IS NOT NULL` | always-false | always-false | `IS NOT NULL` |

The "vacuously true" arms are `IS NOT NULL`, never an unconditional `1=1`: a NULL column is a missing attribute → CEL error → `check()` denies, confirmed against the scratch PDP (`huge-lt` on a resource without the attribute → `EFFECT_DENY`). Negative thresholds *within* int range (e.g. `size(x) > -1`) pass through the cast unchanged and were already correct; only the wrap-affected range is folded. Fractional huge thresholds ceil/floor first (existing fractional handling), then fold if still out of range. `Integer.MAX_VALUE` itself still produces a real `LENGTH` comparison (pinned by test).

## Audit for the same finding class

Grepped all of `src/main` (adapter + example) for `(int)`, `intValue()`, `toIntExact`, `(short)`, `(byte)` narrowings of plan-derived values: the `trySizeComparison` site was the **only** occurrence. The Relation COUNT branch compares `Expression<Long>` against the unclamped `long` and needs no change.

## Tests (all fail on the old code — observed, not assumed)

Negative control run with the fix stashed and only the tests applied — 7 failures:

- Unit (`HugeStringSizeThresholds`, 5 of 6 failed on old code):
  - `gtGeEqAboveIntMaxAreAlwaysFalse` — gt/ge 2^31 and 2^32 must return 0 rows (old: returned the seeded row via wrapped always-true / `LENGTH > 0`); eq 2^32 must not match the empty string (old: wrapped to `LENGTH = 0` and matched it)
  - `ltLeAboveIntMaxIncludePresentAndExcludeNull` — present strings included, NULL excluded (old: `LENGTH < 0` excluded everything)
  - `neAboveIntMaxIncludesEmptyStringAndExcludesNull` — `size("") != 2^32` is TRUE in CEL (old: `LENGTH <> 0` wrongly excluded the empty string)
  - `belowIntMinThresholdsFoldMirrored` — mirror arm for thresholds under `Integer.MIN_VALUE` (`-4294967296` wrapped to `0`)
  - `fractionalHugeThresholdRoundsThenFolds` — ceil/floor then fold
  - `boundaryIntegerMaxStillComparesExactly` — passes on old and new code by design (boundary regression guard)
- Differential oracle (2 failed on old code):
  - `size-huge-gt` (`size(R.attr.aString) > 4294967296`): oracle expected `[]`, old adapter returned `[a1, a2, a3, a4, a5, a6, a7, a9, b1, b2, b3, b4, b5, b6, c1, c2]` — every non-empty row
  - `size-huge-lt`: oracle expected all 17 seeds, old adapter returned `[]`

## Three-leg build

All green with the fix, 436 tests / 0 failures per leg:

- H2 (default): `gradle build` — BUILD SUCCESSFUL, 436 tests, 0 failures
- `ADAPTER_TEST_DB=postgres` (PostgreSQL 16 Testcontainer): BUILD SUCCESSFUL, 436 tests, 0 failures
- `ADAPTER_TEST_DB=mysql` (MySQL 8.4 Testcontainer): BUILD SUCCESSFUL, 436 tests, 0 failures

## Merge-order note

#284 and #285 are open in different code regions (`numericComparison`/MySQL leg config; `escapeLike`/`fieldToFieldLike`). No functional overlap with `trySizeComparison`, but all three append actions to `adversarial-policy.yaml` and the `AdversarialConformanceTest` action list — whichever merges last may need a trivial append-conflict resolution there. This PR's oracle actions (`size-huge-*`) and seeds are distinct from theirs (no new seeds added; no `d1`/`d2` ids).
