### PR TITLE
perf(spring-data): deduplicate macro subquery construction and add depth guard

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -190,7 +190,7 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | `size(coll) > 0` / `>= 1`        | Correlated `EXISTS`                                                 |
 | `size(coll) == 0` / `<= 0` / `< 1`| `NOT EXISTS`                                                       |
 | `size(coll) <op> N`              | Correlated `(SELECT COUNT...) <op> N`                               |
-| `size(coll.filter(x, pred)) <op> N` | Correlated `(SELECT COUNT... WHERE pred) <op> N`                 |
+| `size(coll.filter(x, pred)) <op> N` | Correlated strict-count subquery: counts elements matching `pred`, NULL-poisoned (→ UNKNOWN → excluded) when any element body is undetermined |
 | `size(string)`                   | `cb.length(column)` (see Gotchas for astral-character caveat)       |
 | Field-to-field (`R.attr.a == R.attr.b`) | `cb.equal(pathA, pathB)` and friends for `eq`/`ne`/`lt`/`gt`/`le`/`ge`, incl. inside lambdas |
 | Ternary (`cond ? a : b`)         | Predicate rewrite: `(cond AND cmp(a, v)) OR (NOT cond AND cmp(b, v))` — nested, boolean-position, and value-first forms compose; constant residues fold (see Gotchas for `NULL` semantics) |
@@ -198,10 +198,10 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | Timestamp comparisons (`timestamp(R.attr.createdAt) < now() - duration("24h")`) | Temporal column comparison for all of `eq`/`ne`/`lt`/`gt`/`le`/`ge`, both operand orders (value-first forms mirror). The planner folds `now()`/`now() - duration(...)` to a constant RFC-3339 instant at **plan time**, so the window is fixed per query — re-plan to refresh it. The mapped column must be `java.time.Instant` or `java.time.OffsetDateTime` (both denote an absolute instant; Hibernate 6 stores them UTC-normalized). `LocalDateTime`, `java.util.Date`, and `String` columns throw a named error — they are ambiguous about the absolute instant they store (see Gotchas). A `NULL` column value is excluded, matching `check()` denying on the missing attribute. |
 | Field-to-field `contains`/`startsWith`/`endsWith` | `cb.like` over a `REPLACE`-escaped column-derived pattern (`\`, `%`, `_`, `[`), with an `IS NOT NULL` needle guard |
 | Multi-hop relation chains (`R.attr.categories.subCategories`) | Correlated subquery joining through every hop; `exists`/`in`/`hasIntersection`/`size` all treat the chain as the flattened union of tail elements |
-| `exists(coll, lambda)`           | Correlated `EXISTS` with lambda body                                |
-| `exists_one(coll, lambda)`       | Correlated `(SELECT COUNT...) = 1`                                  |
-| `all(coll, lambda)`              | `NOT EXISTS (... AND NOT(body))`                                    |
-| `except(coll, lambda)`           | Correlated `EXISTS (... AND NOT(body))`                             |
+| `exists(coll, lambda)`           | One correlated aggregate scoring subquery (`MAX(CASE WHEN body … WHEN NOT body … ELSE …)`) whose comparison is TRUE/FALSE/UNKNOWN per the CEL truth table — see the nested-macros gotcha |
+| `exists_one(coll, lambda)`       | One correlated strict-count subquery `= 1` (NULL-poisoned when any element body is undetermined) |
+| `all(coll, lambda)`              | Same scoring subquery as `exists`, compared for "no false and no undetermined element" |
+| `except(coll, lambda)`           | Same scoring subquery as `all`, compared for "some element fails the body" |
 | `filter(coll, lambda)`           | Same as `exists` (filter returns a list — treated as "exists matching") |
 | Bare boolean variable            | `cb.equal(path, true)`                                              |
 | `eq(field, add(const1, const2))` | Constant fold then compare: `cb.equal(field, const1 ⊕ const2)`     |
@@ -368,10 +368,41 @@ three-valued logic, including the places where naive translations leak under `NO
   `qty` is NULL yields UNKNOWN (row excluded under both `all(...)` and `!all(...)`),
   matching CEL's error-absorption rules — `exists` is still true if *any* element
   matches, `all` is still false if *any* element fails, `exists_one` errors on any
-  unknown element. This costs two extra correlated `COUNT` subqueries per macro.
+  unknown element. The tri-state machinery is folded into each macro's single scoring
+  subquery (see the nested-macros gotcha below for the cost model).
 - Ternaries carry a third arm that is UNKNOWN exactly when the condition column is NULL,
   so `!(ternary...)` cannot flip a null-condition row to included.
 - `ne` against an unsolvable string concatenation reduces to `IS NOT NULL`, not `TRUE`.
+
+### Nested collection macros multiply correlated subqueries — depth is bounded
+
+Every collection macro (`exists`/`exists_one`/`all`/`filter`/`except`/
+`size(filter(...))`) translates to a single correlated aggregate subquery, but the
+lambda body inside it is translated once per polarity — positive and negated — because
+Hibernate 6's criteria negation is stateful and a `Predicate` tree cannot be shared
+between polarities. Nesting therefore multiplies: a depth-`d` `exists` chain emits
+`2^d − 1` correlated subqueries (`exists_one` and `size(filter(...))` add a third body
+translation for their match counter, so a chain of those grows at `3^d`). Measured on
+the benchmark suite (`MacroNestingBenchmarkTest`, H2, ~3 000 rows across the chain):
+
+| depth | correlated subqueries | translate | execute |
+|-------|-----------------------|-----------|---------|
+| 1     | 1                     | ~0.2 ms   | ~1.7 ms |
+| 2     | 3                     | ~0.3 ms   | ~2.2 ms |
+| 3     | 7                     | ~0.6 ms   | ~2.8 ms |
+| 4     | 15                    | ~1.3 ms   | ~5.9 ms |
+
+To keep a legal-but-degenerate deeply nested policy from silently timing out on
+production-sized tables, the translator bounds macro nesting depth at **5** by default
+and throws `IllegalArgumentException` beyond it (fail closed, at translation time). If
+your policies intentionally nest deeper, raise the limit via a system property:
+
+```
+-Ddev.cerbos.queryplan.springdata.maxMacroDepth=8
+```
+
+The property is read per translation, must be a positive integer, and applies to
+`exists`/`exists_one`/`all`/`filter`/`except` and `size(filter(...))` nesting.
 
 ### Division by a column is guarded with `NULLIF` — zero divisors deny
 

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -33,6 +33,23 @@ import java.util.function.Supplier;
  */
 public final class SpringDataQueryPlanAdapter {
 
+    /**
+     * System property bounding collection-macro nesting depth
+     * ({@code exists}/{@code exists_one}/{@code all}/{@code filter}/{@code except}/
+     * {@code size(filter(...))}) accepted by the translator. Each nesting level multiplies the
+     * number of correlated subqueries in the translated filter (×2 for the {@code exists} family,
+     * ×3 for {@code exists_one}/{@code size(filter(...))} — see the collection-macro Javadoc in
+     * the translator), so unbounded nesting can silently degrade query latency on large tables.
+     * Plans nested deeper than the limit throw {@link IllegalArgumentException} at translation
+     * time (fail closed). Defaults to {@value #DEFAULT_MAX_MACRO_DEPTH}; set the property to a
+     * positive integer to raise or lower the limit.
+     */
+    public static final String MAX_MACRO_DEPTH_PROPERTY =
+            "dev.cerbos.queryplan.springdata.maxMacroDepth";
+
+    /** Default value of {@link #MAX_MACRO_DEPTH_PROPERTY}. */
+    public static final int DEFAULT_MAX_MACRO_DEPTH = 5;
+
     private SpringDataQueryPlanAdapter() {}
 
     // -- PlanResourcesResult overloads --
@@ -110,6 +127,9 @@ public final class SpringDataQueryPlanAdapter {
         private final HierarchyTranslator hierarchy;
         private final ComparisonTranslator comparisons = new ComparisonTranslator();
         private final boolean selectInvocation;
+        private final int maxMacroDepth = readMaxMacroDepth();
+        /** Current collection-macro nesting depth; maintained by {@link #enterMacro}. */
+        private int macroDepth;
 
         Translator(CriteriaBuilder cb, Map<String, OperatorFunction> overrides, boolean selectInvocation) {
             this.cb = cb;
@@ -117,6 +137,50 @@ public final class SpringDataQueryPlanAdapter {
             this.overrides = overrides;
             this.hierarchy = new HierarchyTranslator(cb);
             this.selectInvocation = selectInvocation;
+        }
+
+        private static int readMaxMacroDepth() {
+            String raw = System.getProperty(MAX_MACRO_DEPTH_PROPERTY);
+            if (raw == null) {
+                return DEFAULT_MAX_MACRO_DEPTH;
+            }
+            int value;
+            try {
+                value = Integer.parseInt(raw.trim());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        MAX_MACRO_DEPTH_PROPERTY + " must be a positive integer, got '" + raw + "'", e);
+            }
+            if (value < 1) {
+                throw new IllegalArgumentException(
+                        MAX_MACRO_DEPTH_PROPERTY + " must be a positive integer, got " + value);
+            }
+            return value;
+        }
+
+        /**
+         * Track one collection-macro nesting level around {@code body}, failing closed when the
+         * plan nests deeper than {@link #MAX_MACRO_DEPTH_PROPERTY} allows. Each macro level
+         * multiplies the correlated-subquery count of the translated filter (one subquery per
+         * body polarity), so a runaway-deep policy must throw a clear error at translation time
+         * instead of silently emitting a filter that times out on production-sized tables.
+         */
+        private Predicate enterMacro(String op, Supplier<Predicate> body) {
+            macroDepth++;
+            try {
+                if (macroDepth > maxMacroDepth) {
+                    throw new IllegalArgumentException(
+                            "Collection-macro nesting depth " + macroDepth + " exceeds the maximum of "
+                            + maxMacroDepth + " (reached via operator '" + op + "'). Each nesting "
+                            + "level multiplies the number of correlated subqueries in the "
+                            + "translated filter, so deeply nested macros degrade query latency "
+                            + "sharply. If the policy shape is intentional, raise the limit via "
+                            + "the '" + MAX_MACRO_DEPTH_PROPERTY + "' system property.");
+                }
+                return body.get();
+            } finally {
+                macroDepth--;
+            }
         }
 
         Predicate traverse(Operand operand, Scope scope) {
@@ -1543,50 +1607,54 @@ public final class SpringDataQueryPlanAdapter {
                 }
                 final Operand fBody = lambdaBody;
                 final String fVar = lambdaVarName;
-                SubqueryBodyBuilder bodyBuilder = (sub, tailJoin, rebased) ->
-                        fBody == null ? cb.conjunction()
-                                : traverse(fBody, Scope.lambda(tailJoin, sub, ref.tail(), fVar, rebased));
-
-                Predicate base;
-                if (fractionalCollapse != null) {
-                    // A Relation count is always defined (an empty join is count 0), so the
-                    // fractional eq/ne collapse is unconditional here. Falls through to the
-                    // size(filter(...)) unknown-element guard below so an erroring lambda body
-                    // still denies the row.
-                    base = fractionalCollapse ? cb.conjunction() : cb.disjunction();
-                } else {
+                if (fBody == null) {
+                    // size(collection) counts rows without evaluating a lambda — no element can
+                    // be UNKNOWN, so the plain EXISTS/COUNT comparisons are already exact.
+                    if (fractionalCollapse != null) {
+                        // A Relation count is always defined (an empty join is count 0), so the
+                        // fractional eq/ne collapse is unconditional here.
+                        return fractionalCollapse ? cb.conjunction() : cb.disjunction();
+                    }
                     boolean nonEmpty = ("gt".equals(cmpOp) && numValue == 0L)
                             || ("ge".equals(cmpOp) && numValue == 1L);
                     boolean empty = ("eq".equals(cmpOp) && numValue == 0L)
                             || ("le".equals(cmpOp) && numValue == 0L)
                             || ("lt".equals(cmpOp) && numValue == 1L);
                     if (nonEmpty) {
-                        base = existsSubquery(scope, ref, bodyBuilder);
-                    } else if (empty) {
-                        base = tri.not(existsSubquery(scope, ref, bodyBuilder));
-                    } else {
-                        // Arbitrary N → correlated (SELECT COUNT(...)) <op> N, same shape as
-                        // exists_one. For a multi-hop chain the COUNT joins through every hop, so it
-                        // counts the FLATTENED tail elements — the same element set the EXISTS
-                        // shortcuts range over.
-                        ChainSubquery<Long> cs = countSubquery(scope, ref);
-                        if (fBody != null) {
-                            cs.sub().where(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()));
-                        }
-                        base = compareCount(cs.sub(), cmpOp, numValue);
+                        return existsSubquery(scope, ref, (sub, tailJoin, rebased) -> cb.conjunction());
                     }
+                    if (empty) {
+                        return tri.not(existsSubquery(scope, ref,
+                                (sub, tailJoin, rebased) -> cb.conjunction()));
+                    }
+                    // Arbitrary N → correlated (SELECT COUNT(...)) <op> N. For a multi-hop chain
+                    // the COUNT joins through every hop, so it counts the FLATTENED tail
+                    // elements — the same element set the EXISTS shortcuts range over.
+                    return compareCount(countSubquery(scope, ref).sub(), cmpOp, numValue);
                 }
-                if (fBody == null) {
-                    // size(collection) counts rows without evaluating a lambda — no element can be
-                    // UNKNOWN, so the plain comparison is already exact.
-                    return base;
-                }
-                // size(coll.filter(x, pred)): CEL filter has NO error absorption — any element whose
-                // predicate errors (NULL-derived UNKNOWN body) errors the whole expression (deny),
-                // even when the count comparison would otherwise hold. Same strict table as
-                // exists_one: TriPredicate.baseUnlessUnknown.
-                return tri.baseUnlessUnknown(base,
-                        () -> unknownElementExists(scope, ref, bodyBuilder));
+                // size(coll.filter(x, pred)): CEL filter has NO error absorption — any element
+                // whose predicate errors (NULL-derived UNKNOWN body) errors the whole expression
+                // (deny), even when the count comparison would otherwise hold. Same strict table
+                // as exists_one: strictMatchCount yields SQL NULL whenever any element body is
+                // UNKNOWN, so every comparison against it goes UNKNOWN and the row stays excluded
+                // under both polarities.
+                SubqueryBodyBuilder bodyBuilder = (sub, tailJoin, rebased) ->
+                        traverse(fBody, Scope.lambda(tailJoin, sub, ref.tail(), fVar, rebased));
+                final String finalCmpOp = cmpOp;
+                final long finalNumValue = numValue;
+                final Boolean finalCollapse = fractionalCollapse;
+                return enterMacro("size(filter(...))", () -> {
+                    if (finalCollapse != null) {
+                        // The count comparison itself is statically decided (a COUNT is never
+                        // fractional), but an erroring lambda body must still deny the row: the
+                        // poison term is 0 when every element body is determined and SQL NULL
+                        // otherwise, making the collapse UNKNOWN exactly when CEL errors.
+                        Subquery<Long> poison = undeterminedPoisonSubquery(scope, ref, bodyBuilder);
+                        return finalCollapse ? cb.equal(poison, 0L) : cb.notEqual(poison, 0L);
+                    }
+                    return compareCount(strictMatchCountSubquery(scope, ref, bodyBuilder),
+                            finalCmpOp, finalNumValue);
+                });
             }
 
             /** Compare a numeric size expression (COUNT subquery or LENGTH) against a constant. */
@@ -1830,18 +1898,25 @@ public final class SpringDataQueryPlanAdapter {
          * ERROR maps to SQL UNKNOWN so the row stays excluded under BOTH polarities
          * ({@code NOT(UNKNOWN) = UNKNOWN}). A plain EXISTS is not enough: an element whose body
          * is UNKNOWN silently fails to match, collapsing the error case to FALSE — which
-         * {@code not(...)} flips to TRUE, an authorization leak. Building blocks:
-         * {@code EXISTS(elem WHERE body)} (true witness), {@code EXISTS(elem WHERE NOT body)}
-         * (false witness) and {@link #unknownElementExists} (any UNKNOWN-body element); the
-         * truth tables composing them live in {@link TriPredicate}.
+         * {@code not(...)} flips to TRUE, an authorization leak. Each macro is a SINGLE
+         * correlated aggregate subquery that scores every element into determined-true /
+         * determined-false / undetermined and folds the scores into one value whose comparison
+         * is TRUE, FALSE, or SQL UNKNOWN exactly per the CEL truth table — see
+         * {@link #macroScoreSubquery} (exists/all/filter/except) and
+         * {@link #strictMatchCountSubquery} (exists_one).
          *
          * <p>{@code filter}/{@code except} in boolean position are kept consistent with the
-         * {@code exists} family. Cost note: the unknown machinery is always emitted — each
-         * {@link #unknownElementExists} probe is two correlated COUNT subqueries, and
-         * {@code exists_one} (like the arbitrary-N {@code size(filter(...))} shape) emits the
-         * probe twice, i.e. five correlated subqueries including the base COUNT — the attribute
-         * mapping carries no column-nullability metadata, so a NULL-free lambda body cannot be
-         * detected statically.
+         * {@code exists} family. Cost note: the unknown machinery is always emitted — the
+         * attribute mapping carries no column-nullability metadata, so a NULL-free lambda body
+         * cannot be detected statically. The lambda body is translated once per polarity
+         * (positive and negated — Hibernate 6 negation is stateful, see {@link TriPredicate},
+         * so a Predicate tree cannot be shared between polarities): twice for the
+         * {@code exists} family, three times for {@code exists_one} (which also needs the
+         * positive body inside its match counter). Nested macros therefore multiply — a
+         * depth-d exists chain emits {@code 2^d - 1} correlated subqueries (an exists_one
+         * chain up to {@code (3^d - 1) / 2}) — which is why {@link #enterMacro} bounds the
+         * nesting depth ({@link #MAX_MACRO_DEPTH_PROPERTY}, default
+         * {@value #DEFAULT_MAX_MACRO_DEPTH}).
          */
         private Predicate handleCollectionOperator(String op, List<Operand> operands, Scope scope) {
             if (operands.size() != 2) {
@@ -1879,58 +1954,124 @@ public final class SpringDataQueryPlanAdapter {
             // tree (Hibernate 6 negation is stateful — see TriPredicate.not()).
             SubqueryBodyBuilder bodyBuilder = (sub, tailJoin, rebased) -> traverse(body,
                     Scope.lambda(tailJoin, sub, ref.tail(), lambdaVarName, rebased));
-            SubqueryBodyBuilder negatedBodyBuilder = (sub, tailJoin, rebased) ->
-                    tri.not(bodyBuilder.build(sub, tailJoin, rebased));
 
-            return switch (op) {
-                // exists (and filter): OR with error absorption — TriPredicate.anyTrueOrUnknown.
-                case "exists", "filter" -> tri.anyTrueOrUnknown(
-                        existsSubquery(scope, ref, bodyBuilder),
-                        unknownElementExists(scope, ref, bodyBuilder));
+            return enterMacro(op, () -> switch (op) {
+                // exists (and filter): OR with error absorption — TRUE iff any element is
+                // determined-true (max score 2); UNKNOWN iff none is true but at least one is
+                // undetermined (max score 1 → NULLIF yields SQL NULL); FALSE otherwise.
+                case "exists", "filter" ->
+                        cb.equal(macroScoreSubquery(scope, ref, bodyBuilder, 2, 0), 2);
                 // except is "some element fails the body" — the exists table with the false
-                // witness in the true-witness seat; an UNKNOWN body is UNKNOWN under NOT too.
-                case "except" -> tri.anyTrueOrUnknown(
-                        existsSubquery(scope, ref, negatedBodyBuilder),
-                        unknownElementExists(scope, ref, bodyBuilder));
-                // all: AND with error absorption — TriPredicate.allTrueOrUnknown, with the
-                // false witness EXISTS(elem WHERE NOT body).
-                case "all" -> tri.allTrueOrUnknown(
-                        existsSubquery(scope, ref, negatedBodyBuilder),
-                        unknownElementExists(scope, ref, bodyBuilder));
-                // exists_one: strict — any UNKNOWN element denies, else COUNT(body) = 1 —
-                // TriPredicate.baseUnlessUnknown.
-                case "exists_one" -> {
-                    ChainSubquery<Long> cs = countSubquery(scope, ref);
-                    cs.sub().where(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()));
-                    yield tri.baseUnlessUnknown(cb.equal(cs.sub(), 1L),
-                            () -> unknownElementExists(scope, ref, bodyBuilder));
-                }
+                // witness in the true seat; an UNKNOWN body is UNKNOWN under NOT too.
+                case "except" ->
+                        cb.equal(macroScoreSubquery(scope, ref, bodyBuilder, 0, 2), 2);
+                // all: AND with error absorption — FALSE iff any element is determined-false
+                // (max score 2 absorbs undetermined siblings); UNKNOWN iff none is false but at
+                // least one is undetermined; TRUE otherwise (including the empty collection).
+                case "all" ->
+                        cb.equal(macroScoreSubquery(scope, ref, bodyBuilder, 0, 2), 0);
+                // exists_one: strict — any UNKNOWN element denies, else COUNT(body) = 1. The
+                // strict counter goes SQL NULL when any element is undetermined, so the equality
+                // is UNKNOWN and the row stays excluded under both polarities.
+                case "exists_one" ->
+                        cb.equal(strictMatchCountSubquery(scope, ref, bodyBuilder), 1L);
                 default -> throw new IllegalArgumentException("Unsupported collection operator: " + op);
-            };
+            });
         }
 
         /**
-         * TRUE iff the relation holds at least one element whose lambda body evaluates to SQL
-         * UNKNOWN (NULL-derived). Not expressible as a single EXISTS: inside a subquery WHERE an
-         * UNKNOWN body simply fails to match, so {@code EXISTS(body)} and {@code EXISTS(NOT body)}
-         * both skip exactly the rows to be detected. Counting closes the gap — an element is
-         * <em>determined</em> iff {@code body OR NOT body} matches it, therefore
-         * {@code COUNT(elem) > COUNT(elem WHERE body OR NOT body)} holds iff at least one element
-         * is UNKNOWN, including mixed collections where sibling elements are determined
-         * true/false. Both COUNTs never yield NULL, so the comparison itself is two-valued and
-         * safe to negate through {@link TriPredicate#not}. The body is supplied to
-         * {@link TriPredicate#determined} as a Supplier and translated fresh per occurrence
-         * (stateful negation — see {@link TriPredicate#not}).
+         * The single-subquery scoring translation shared by {@code exists}/{@code filter}
+         * (score 2/0), {@code all} and {@code except} (score 0/2). Each element of the relation
+         * chain is scored with a searched CASE:
+         *
+         * <pre>{@code CASE WHEN body THEN trueScore WHEN NOT body THEN falseScore ELSE 1 END}</pre>
+         *
+         * An UNKNOWN body matches neither WHEN (SQL treats an UNKNOWN condition as not taken),
+         * so undetermined elements land in the ELSE — that is what makes the polarity pair
+         * sufficient to distinguish all three states with a single scan. The subquery selects
+         *
+         * <pre>{@code NULLIF(COALESCE(MAX(score), 0), 1)}</pre>
+         *
+         * i.e. the dominant score with the empty collection folded to 0 and the
+         * "only undetermined elements dominate" state (max score 1) mapped to SQL NULL. A
+         * two-valued equality against 2 (exists/except) or 0 (all) then yields TRUE / FALSE /
+         * UNKNOWN exactly per the CEL macro truth tables, and {@code NOT} keeps UNKNOWN rows
+         * excluded ({@code NOT(UNKNOWN) = UNKNOWN}).
+         *
+         * <p>The body is translated exactly twice — once per polarity, the minimum Hibernate 6's
+         * stateful negation permits (see {@link TriPredicate}) — so nested macros grow at
+         * {@code 2^depth}, not the {@code 3^depth} of the previous
+         * EXISTS-plus-two-COUNT-probes translation.
          */
-        private Predicate unknownElementExists(Scope scope, Scope.ResolvedRelation ref,
-                                               SubqueryBodyBuilder bodyBuilder) {
-            ChainSubquery<Long> total = countSubquery(scope, ref);
+        private Subquery<Integer> macroScoreSubquery(Scope scope, Scope.ResolvedRelation ref,
+                                                     SubqueryBodyBuilder bodyBuilder,
+                                                     int trueScore, int falseScore) {
+            ChainSubquery<Integer> cs = chainSubquery(Integer.class, scope, ref);
+            jakarta.persistence.criteria.Expression<Integer> score = cb.<Integer>selectCase()
+                    .when(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()), trueScore)
+                    .when(tri.not(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter())),
+                            falseScore)
+                    .otherwise(1);
+            cs.sub().select(cb.nullif(cb.coalesce(cb.max(score), 0), 1));
+            return cs.sub();
+        }
 
-            ChainSubquery<Long> determined = countSubquery(scope, ref);
-            determined.sub().where(tri.determined(() -> bodyBuilder.build(
-                    determined.sub(), determined.tailJoin(), determined.rebasedOuter())));
+        /**
+         * The strict counting subquery behind {@code exists_one} and {@code size(filter(...))}:
+         * selects the number of elements whose body is determined-true, poisoned to SQL NULL
+         * when ANY element body is UNKNOWN (CEL's strict macros error if any element errors —
+         * no absorption). Shape:
+         *
+         * <pre>{@code COALESCE(SUM(CASE WHEN body THEN 1 ELSE 0 END), 0) + poisonTerm}</pre>
+         *
+         * where {@code poisonTerm} ({@link #undeterminedPoisonTerm}) is 0 when every element is
+         * determined and NULL otherwise — NULL is absorbing under addition, so any undetermined
+         * element nulls the whole count and every comparison against it goes UNKNOWN (row
+         * excluded under both polarities). The empty collection yields 0 + 0 = 0, matching CEL
+         * ({@code exists_one} over an empty list is false, a zero count compares normally).
+         *
+         * <p>Costs three body translations (one positive in the match counter, one per polarity
+         * in the poison term); see {@link #macroScoreSubquery} for why two is the floor.
+         */
+        private Subquery<Long> strictMatchCountSubquery(Scope scope, Scope.ResolvedRelation ref,
+                                                        SubqueryBodyBuilder bodyBuilder) {
+            ChainSubquery<Long> cs = chainSubquery(Long.class, scope, ref);
+            jakarta.persistence.criteria.Expression<Long> match = cb.<Long>selectCase()
+                    .when(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()), 1L)
+                    .otherwise(0L);
+            cs.sub().select(cb.sum(
+                    cb.coalesce(cb.sum(match), 0L),
+                    undeterminedPoisonTerm(cs, bodyBuilder)));
+            return cs.sub();
+        }
 
-            return cb.greaterThan(total.sub(), determined.sub());
+        /**
+         * A subquery selecting ONLY the poison term: 0 when every element body is determined
+         * (or the collection is empty), SQL NULL when any element body is UNKNOWN. Used by the
+         * statically-collapsed {@code size(filter(...))} comparisons, whose count comparison is
+         * pre-decided but whose error semantics still depend on the lambda body.
+         */
+        private Subquery<Long> undeterminedPoisonSubquery(Scope scope, Scope.ResolvedRelation ref,
+                                                          SubqueryBodyBuilder bodyBuilder) {
+            ChainSubquery<Long> cs = chainSubquery(Long.class, scope, ref);
+            cs.sub().select(undeterminedPoisonTerm(cs, bodyBuilder));
+            return cs.sub();
+        }
+
+        /**
+         * {@code NULLIF(COALESCE(MAX(CASE WHEN body THEN 0 WHEN NOT body THEN 0 ELSE 1 END), 0), 1)}
+         * — 0 when every element body is determined (either WHEN taken; also the empty
+         * collection via COALESCE), SQL NULL when at least one element body is UNKNOWN (both
+         * WHENs skipped → ELSE 1 dominates the MAX → NULLIF). The body is translated once per
+         * polarity (stateful negation — see {@link TriPredicate#not}).
+         */
+        private jakarta.persistence.criteria.Expression<Long> undeterminedPoisonTerm(
+                ChainSubquery<?> cs, SubqueryBodyBuilder bodyBuilder) {
+            jakarta.persistence.criteria.Expression<Long> determined = cb.<Long>selectCase()
+                    .when(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()), 0L)
+                    .when(tri.not(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter())), 0L)
+                    .otherwise(1L);
+            return cb.nullif(cb.coalesce(cb.max(determined), 0L), 1L);
         }
 
         @FunctionalInterface
@@ -1980,10 +2121,11 @@ public final class SpringDataQueryPlanAdapter {
          *       joining only the tail attribute off the anchor would either fail at query-build
          *       time or silently query a same-named collection on the wrong entity.</li>
          * </ul>
-         * EXISTS over the join chain and COUNT over {@code tailJoin} therefore express
-         * exists/in/hasIntersection membership and {@code size()} of the flattened union with
-         * the same element set, so the tri-state unknown-element machinery composes with chains
-         * unchanged (its COUNT subqueries traverse the identical chain).
+         * EXISTS over the join chain, aggregate scoring over {@code tailJoin}
+         * ({@link #macroScoreSubquery}/{@link #strictMatchCountSubquery}) and COUNT over
+         * {@code tailJoin} therefore express exists/in/hasIntersection membership and
+         * {@code size()} of the flattened union with the same element set, so the tri-state
+         * unknown-element machinery composes with chains unchanged.
          */
         private <T> ChainSubquery<T> chainSubquery(Class<T> resultType, Scope scope,
                                                    Scope.ResolvedRelation ref) {

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/TriPredicate.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/TriPredicate.java
@@ -71,8 +71,10 @@ final class TriPredicate {
 
     /**
      * {@code body OR NOT body} — TRUE iff {@code body} is determined (two-valued), UNKNOWN iff
-     * {@code body} is UNKNOWN. This is the determinedness test the unknown-element COUNT probes
-     * filter on. {@code body} is built twice (once per polarity).
+     * {@code body} is UNKNOWN. This is the determinedness test behind the ternary's
+     * unknown-condition arm; the collection macros encode the same polarity pair inside their
+     * scoring CASE expressions (see the adapter's {@code macroScoreSubquery}). {@code body} is
+     * built twice (once per polarity).
      */
     Predicate determined(Supplier<Predicate> body) {
         return cb.or(body.get(), not(body.get()));
@@ -111,39 +113,10 @@ final class TriPredicate {
     }
 
     /**
-     * OR with error absorption — the {@code exists}/{@code filter}/{@code except} table:
-     * {@code trueWitness OR (unknownWitness AND UNKNOWN)}.
-     * <ul>
-     *   <li>witness TRUE → TRUE (a true witness absorbs any unknown sibling)</li>
-     *   <li>witness FALSE, unknown witness TRUE → UNKNOWN (deny)</li>
-     *   <li>witness FALSE, unknown witness FALSE → FALSE</li>
-     * </ul>
-     * Both inputs are consumed once, positively; {@code unknownWitness} must be a two-valued
-     * detector (e.g. an EXISTS or a COUNT comparison).
-     */
-    Predicate anyTrueOrUnknown(Predicate trueWitness, Predicate unknownWitness) {
-        return cb.or(trueWitness, cb.and(unknownWitness, unknown()));
-    }
-
-    /**
-     * AND with error absorption — the {@code all} table:
-     * {@code NOT falseWitness AND (NOT unknownWitness OR UNKNOWN)}.
-     * <ul>
-     *   <li>false witness TRUE → FALSE (a false witness absorbs any unknown sibling)</li>
-     *   <li>false witness FALSE, unknown witness TRUE → UNKNOWN (deny)</li>
-     *   <li>false witness FALSE, unknown witness FALSE → TRUE</li>
-     * </ul>
-     * Both inputs are consumed once, each in a single (negated) polarity; both must be
-     * two-valued detectors.
-     */
-    Predicate allTrueOrUnknown(Predicate falseWitness, Predicate unknownWitness) {
-        return cb.and(not(falseWitness), cb.or(not(unknownWitness), unknown()));
-    }
-
-    /**
-     * Strict guard — the {@code exists_one} / {@code size(filter(...))} /
-     * map-intersection table: {@code (base AND NOT unknownWitness) OR (unknownWitness AND
-     * UNKNOWN)}. No absorption: ANY unknown witness poisons the result.
+     * Strict guard — the map-intersection table (the collection macros encode their strict
+     * variant arithmetically inside a single aggregate subquery — see the adapter's
+     * {@code strictMatchCountSubquery}): {@code (base AND NOT unknownWitness) OR
+     * (unknownWitness AND UNKNOWN)}. No absorption: ANY unknown witness poisons the result.
      * <ul>
      *   <li>unknown witness TRUE → UNKNOWN (deny), even when {@code base} is TRUE</li>
      *   <li>unknown witness FALSE → {@code base}</li>

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -1,6 +1,7 @@
 package dev.cerbos.queryplan.springdata;
 
 import dev.cerbos.queryplan.springdata.testmodel.CategoryEntity;
+import dev.cerbos.queryplan.springdata.testmodel.LabelEntity;
 import dev.cerbos.queryplan.springdata.testmodel.ResourceEntity;
 import dev.cerbos.queryplan.springdata.testmodel.SubCategoryEntity;
 import dev.cerbos.sdk.CerbosBlockingClient;
@@ -92,7 +93,11 @@ class AdversarialConformanceTest {
             Map.entry("request.resource.attr.categories", AttributeMapping.relation("categories", Map.of(
                     "name", AttributeMapping.field("name"),
                     "subCategories", AttributeMapping.relation("subCategories", Map.of(
-                            "name", AttributeMapping.field("name")
+                            "name", AttributeMapping.field("name"),
+                            // Third macro level for the macro-depth3-* actions.
+                            "labels", AttributeMapping.relation("labels", Map.of(
+                                    "name", AttributeMapping.field("name")
+                            ))
                     ))
             ))),
             // Multi-hop chain probe (W1): mainCategory is a SINGLE nested object on the check
@@ -179,6 +184,27 @@ class AdversarialConformanceTest {
             new Seed("d1", true, "[SEC]ret", 13, "[SEC]", List.of(), List.of()),
             new Seed("d2", false, "Secret", 14, "xSECy", List.of(), List.of())
     );
+
+    /**
+     * Deterministic label names per seed for the {@code macro-depth3-*} actions — the third
+     * macro level (categories → subCategories → labels). A {@code null} entry seeds a label
+     * whose {@code name} column is NULL: a missing element attribute on the check side, so the
+     * innermost lambda body touching it is a CEL evaluation error that must propagate up
+     * through BOTH enclosing macro levels (deny) — and SQL UNKNOWN through the nested scoring
+     * subqueries on the adapter side. a1 is the true witness ("gold"), a6 the error witness
+     * (no true sibling to absorb the NULL-name error), a8 the determined-false witness, and
+     * c1 the collation witness ("Gold" vs "gold"). Only consulted for seeds that hold a
+     * category/subCategory chain.
+     */
+    private static List<String> labelsFor(Seed s) {
+        return switch (s.id()) {
+            case "a1" -> java.util.Arrays.asList("gold", "silver");
+            case "a6" -> java.util.Arrays.asList(null, "silver");
+            case "a8" -> List.of("silver");
+            case "c1" -> List.of("Gold");
+            default -> List.of();
+        };
+    }
 
     /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
     private static String isoFor(Seed s) {
@@ -390,6 +416,15 @@ class AdversarialConformanceTest {
             for (String subName : s.subCategoryNames()) {
                 catSeq++;
                 SubCategoryEntity sub = new SubCategoryEntity("adv-sub-" + catSeq, subName);
+                List<LabelEntity> labels = new ArrayList<>();
+                int labSeq = 0;
+                for (String labelName : labelsFor(s)) {
+                    labSeq++;
+                    LabelEntity label = new LabelEntity("adv-lab-" + catSeq + "-" + labSeq, labelName);
+                    em.persist(label);
+                    labels.add(label);
+                }
+                sub.setLabels(labels);
                 em.persist(sub);
                 CategoryEntity cat = new CategoryEntity("adv-cat-" + catSeq, "business");
                 cat.setSubCategories(new ArrayList<>(List.of(sub)));
@@ -429,7 +464,10 @@ class AdversarialConformanceTest {
                                 "name", AttributeValue.stringValue("business"),
                                 "subCategories", AttributeValue.listValue(
                                         AttributeValue.mapValue(Map.of(
-                                                "name", AttributeValue.stringValue(subName)))))))
+                                                "name", AttributeValue.stringValue(subName),
+                                                "labels", AttributeValue.listValue(labelsFor(s).stream()
+                                                        .map(AdversarialConformanceTest::asLabelAttribute)
+                                                        .toList())))))))
                         .toList()));
         // A DB NULL is a missing attribute on the check side — conditions touching it must
         // deny (CEL error), matching SQL three-valued logic excluding the row.
@@ -463,6 +501,15 @@ class AdversarialConformanceTest {
                             .toList()))));
         }
         return r;
+    }
+
+    /** A NULL label name in the DB is a missing element attribute on the check side. */
+    private static AttributeValue asLabelAttribute(String name) {
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        if (name != null) {
+            attrs.put("name", AttributeValue.stringValue(name));
+        }
+        return AttributeValue.mapValue(attrs);
     }
 
     /** A NULL tag name in the DB is a missing element attribute on the check side. */
@@ -564,6 +611,11 @@ class AdversarialConformanceTest {
             // multi-hop relation chains via DIRECT dotted syntax (W1) and a root relation
             // subquery anchored from inside a lambda body (W2)
             "w1-exists-chain", "w1-size-chain", "w1-in-chain", "w2-outer-relation",
+            // depth-3 nested macros (categories → subCategories → labels): the single-
+            // subquery-per-polarity scoring translation must keep tri-state semantics through
+            // deep nesting — a1 true witness, a6 NULL-name label error propagating up both
+            // levels, a8 determined false, c1 case witness (labelsFor seeds)
+            "macro-depth3-exists", "macro-depth3-not-exists", "macro-depth3-all",
             // hierarchy operators: both operand orders per operator (field-first ancestorOf
             // and constant-first descendentOf route to the strict-prefix IN-list branch;
             // the mirrored orders route to the prefix-LIKE branch) plus LIKE-metacharacter

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/MacroNestingBenchmarkTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/MacroNestingBenchmarkTest.java
@@ -1,0 +1,284 @@
+package dev.cerbos.queryplan.springdata;
+
+import com.google.protobuf.Value;
+import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter;
+import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter.Expression;
+import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter.Expression.Operand;
+import dev.cerbos.api.v1.response.Response.PlanResourcesResponse;
+import dev.cerbos.queryplan.springdata.testmodel.CategoryEntity;
+import dev.cerbos.queryplan.springdata.testmodel.LabelEntity;
+import dev.cerbos.queryplan.springdata.testmodel.ResourceEntity;
+import dev.cerbos.queryplan.springdata.testmodel.SubCategoryEntity;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Measures — and bounds — the cost of nested collection-macro translation.
+ *
+ * <p>Every collection macro emits its tri-state unknown-element machinery alongside the
+ * membership check, and the lambda body is re-translated once per polarity (Hibernate 6
+ * negation is stateful, so a Predicate tree cannot be shared between a positive and a
+ * negated occurrence — see {@link TriPredicate}). That re-translation is multiplicative
+ * through nesting: with a per-macro body multiplier of k, a depth-d chain of macros emits
+ * on the order of k^d correlated subqueries. This suite pins the multiplier by counting
+ * the correlated subqueries in the actual SQL Hibernate generates for exists-chains of
+ * depth 1..4, and records translation/execution wall times against a seeded H2 database
+ * (a few thousand rows across the relation chain).
+ *
+ * <p>The subquery-count assertions are the regression tripwire: they encode the
+ * single-subquery-per-macro translation (per-macro multiplier 2: at most {@code 2^d - 1}
+ * correlated subqueries for a depth-d exists chain). Under the previous
+ * EXISTS-plus-two-COUNT-probes translation the same chains emitted 3/12/39/120
+ * subqueries, so this test fails loudly if that shape ever comes back. Timings are
+ * printed for observability, not asserted (wall-clock assertions flake in CI).
+ *
+ * <p>Runs against plain H2 with hand-built plan operands — no PDP container — so it is
+ * cheap enough to stay in the default build.
+ */
+class MacroNestingBenchmarkTest {
+
+    /** Captures the SQL of every statement executed through this suite's EMF. */
+    public static final class BenchSqlCapture
+            implements org.hibernate.resource.jdbc.spi.StatementInspector {
+        static final List<String> STATEMENTS =
+                java.util.Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public String inspect(String sql) {
+            STATEMENTS.add(sql);
+            return sql;
+        }
+    }
+
+    private static final int RESOURCES = 300;
+    private static final int CATEGORIES = 15;
+    private static final int SUBCATEGORIES = 45;
+    private static final int LABELS = 135;
+
+    private static final Map<String, AttributeMapping> MAPPING = Map.of(
+            "request.resource.attr.categories", AttributeMapping.relation("categories", Map.of(
+                    "name", AttributeMapping.field("name"),
+                    "subCategories", AttributeMapping.relation("subCategories", Map.of(
+                            "name", AttributeMapping.field("name"),
+                            "labels", AttributeMapping.relation("labels", Map.of(
+                                    "name", AttributeMapping.field("name"),
+                                    // labels ↔ subCategories is bidirectional, which gives the
+                                    // benchmark a legal fourth hop without inventing new entities.
+                                    "subCategories", AttributeMapping.relation("subCategories", Map.of(
+                                            "name", AttributeMapping.field("name")
+                                    ))
+                            ))
+                    ))
+            ))
+    );
+
+    private static EntityManagerFactory emf;
+
+    @BeforeAll
+    static void setUp() {
+        // A dedicated in-memory database: the seed volume here must not leak into the other
+        // suites sharing the default test-pu URL.
+        emf = Persistence.createEntityManagerFactory("test-pu", Map.of(
+                "jakarta.persistence.jdbc.url",
+                "jdbc:h2:mem:cerbosbench;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+                "hibernate.session_factory.statement_inspector",
+                BenchSqlCapture.class.getName()));
+        seed();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (emf != null) emf.close();
+    }
+
+    /**
+     * Seeds a shared relation pool — 15 categories × 3 subCategories × 3 labels — and links
+     * every resource to 3 categories. Row counts across the chain: 300 resources, 900
+     * resource↔category links, 45 category↔subCategory links, 135 subCategory↔label links.
+     */
+    private static void seed() {
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction tx = em.getTransaction();
+        tx.begin();
+
+        List<LabelEntity> labels = new ArrayList<>();
+        for (int i = 0; i < LABELS; i++) {
+            LabelEntity l = new LabelEntity("lab-" + i, "lab-" + (i % 9));
+            em.persist(l);
+            labels.add(l);
+        }
+        List<SubCategoryEntity> subs = new ArrayList<>();
+        for (int i = 0; i < SUBCATEGORIES; i++) {
+            SubCategoryEntity s = new SubCategoryEntity("sub-" + i, "sub-" + (i % 5));
+            s.setLabels(new ArrayList<>(List.of(
+                    labels.get((i * 3) % LABELS),
+                    labels.get((i * 3 + 1) % LABELS),
+                    labels.get((i * 3 + 2) % LABELS))));
+            em.persist(s);
+            subs.add(s);
+        }
+        List<CategoryEntity> cats = new ArrayList<>();
+        for (int i = 0; i < CATEGORIES; i++) {
+            CategoryEntity c = new CategoryEntity("cat-" + i, "cat-" + (i % 4));
+            c.setSubCategories(new ArrayList<>(List.of(
+                    subs.get((i * 3) % SUBCATEGORIES),
+                    subs.get((i * 3 + 1) % SUBCATEGORIES),
+                    subs.get((i * 3 + 2) % SUBCATEGORIES))));
+            em.persist(c);
+            cats.add(c);
+        }
+        for (int i = 0; i < RESOURCES; i++) {
+            ResourceEntity r = new ResourceEntity("res-" + i);
+            r.setCategories(new ArrayList<>(List.of(
+                    cats.get(i % CATEGORIES),
+                    cats.get((i + 5) % CATEGORIES),
+                    cats.get((i + 10) % CATEGORIES))));
+            em.persist(r);
+            if (i % 100 == 99) {
+                em.flush();
+                em.clear();
+            }
+        }
+        tx.commit();
+        em.close();
+    }
+
+    // -- plan-operand builders (hand-built wire shapes, as the unit suite does) --
+
+    private static Operand exprOp(String op, Operand... operands) {
+        Expression.Builder e = Expression.newBuilder().setOperator(op);
+        for (Operand o : operands) e.addOperands(o);
+        return Operand.newBuilder().setExpression(e).build();
+    }
+
+    private static Operand var(String name) {
+        return Operand.newBuilder().setVariable(name).build();
+    }
+
+    private static Operand sval(String v) {
+        return Operand.newBuilder().setValue(Value.newBuilder().setStringValue(v)).build();
+    }
+
+    private static Operand lambda(String varName, Operand body) {
+        return exprOp("lambda", body, var(varName));
+    }
+
+    /** The relation attribute each nesting level iterates, and the leaf constant it matches. */
+    private static final String[] HOPS = {"subCategories", "labels", "subCategories"};
+    private static final String[] LEAF = {"cat-1", "sub-1", "lab-1", "sub-1"};
+
+    /**
+     * Builds {@code categories.exists(v1, v1.subCategories.exists(v2, ... vd.name == LEAF))}
+     * nested to {@code depth} macros.
+     */
+    private static Operand existsChain(int depth) {
+        return existsLevel(1, depth, "request.resource.attr.categories");
+    }
+
+    private static Operand existsLevel(int level, int depth, String collection) {
+        String v = "v" + level;
+        Operand body = level == depth
+                ? exprOp("eq", var(v + ".name"), sval(LEAF[depth - 1]))
+                : existsLevel(level + 1, depth, v + "." + HOPS[level - 1]);
+        return exprOp("exists", var(collection), lambda(v, body));
+    }
+
+    private record Measurement(int depth, int subqueries, long translateMicros,
+                               long executeMicros, int rows) {}
+
+    private Measurement measure(int depth) {
+        PlanResourcesResponse resp = PlanResourcesResponse.newBuilder()
+                .setFilter(PlanResourcesFilter.newBuilder()
+                        .setKind(PlanResourcesFilter.Kind.KIND_CONDITIONAL)
+                        .setCondition(existsChain(depth)))
+                .build();
+        Result<ResourceEntity> result = SpringDataQueryPlanAdapter.toSpecification(resp, MAPPING);
+        assertInstanceOf(Result.Conditional.class, result);
+        Specification<ResourceEntity> spec =
+                ((Result.Conditional<ResourceEntity>) result).specification();
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<String> cq = cb.createQuery(String.class);
+            Root<ResourceEntity> root = cq.from(ResourceEntity.class);
+            cq.select(root.get("id")).distinct(true);
+
+            long t0 = System.nanoTime();
+            Predicate p = spec.toPredicate(root, cq, cb);
+            long translateNanos = System.nanoTime() - t0;
+            cq.where(p);
+
+            BenchSqlCapture.STATEMENTS.clear();
+            long t1 = System.nanoTime();
+            List<String> rows = em.createQuery(cq).getResultList();
+            long executeNanos = System.nanoTime() - t1;
+
+            String sql = BenchSqlCapture.STATEMENTS.stream()
+                    .filter(s -> s.toLowerCase(Locale.ROOT).startsWith("select"))
+                    .reduce("", (a, b) -> a.length() >= b.length() ? a : b)
+                    .toLowerCase(Locale.ROOT);
+            int subqueries = countOccurrences(sql, "select") - 1;
+            return new Measurement(depth, subqueries,
+                    translateNanos / 1_000, executeNanos / 1_000, rows.size());
+        } finally {
+            em.close();
+        }
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + 1)) {
+            count++;
+        }
+        return count;
+    }
+
+    @Test
+    void nestedExistsSubqueryCountStaysSingleSubqueryPerPolarity() {
+        List<Measurement> results = new ArrayList<>();
+        for (int depth = 1; depth <= 4; depth++) {
+            // Warm-up translation once so first-use metamodel initialization doesn't skew
+            // the recorded numbers, then measure.
+            measure(depth);
+            results.add(measure(depth));
+        }
+
+        System.out.println("== nested exists-chain translation cost (H2, "
+                + RESOURCES + " resources, 3x3x3 shared relation pool) ==");
+        System.out.printf("%-6s %-22s %-18s %-16s %s%n",
+                "depth", "correlated subqueries", "translate (us)", "execute (us)", "rows");
+        for (Measurement m : results) {
+            System.out.printf("%-6d %-22d %-18d %-16d %d%n",
+                    m.depth(), m.subqueries(), m.translateMicros(), m.executeMicros(), m.rows());
+        }
+
+        for (Measurement m : results) {
+            int bound = (1 << m.depth()) - 1; // 2^d - 1: one subquery per macro, per polarity
+            assertTrue(m.subqueries() <= bound,
+                    "depth-" + m.depth() + " exists chain emitted " + m.subqueries()
+                            + " correlated subqueries (bound " + bound + ") — the macro "
+                            + "translation has regressed toward the multi-probe shape");
+        }
+    }
+}

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
@@ -757,25 +757,28 @@ class SpringDataIntegrationTest {
         @Test
         void threeLevelNestingIsCorrelatedNotCrossJoined() {
             // categories.exists(c, c.subCategories.exists(s, s.labels.exists(l, l.name == "important")))
-            // — three relation hops, each a correlated EXISTS one level deeper than the last. This pins
-            // the generated SQL shape: a cross/cartesian join would still return rows but would wrongly
-            // pair unrelated subcategories/labels, so we assert directly on the SQL, not just the result.
+            // — three relation hops, each a correlated scoring subquery one level deeper than the
+            // last. This pins the generated SQL shape: a cross/cartesian join would still return
+            // rows but would wrongly pair unrelated subcategories/labels, so we assert directly on
+            // the SQL, not just the result.
             SqlCapture.STATEMENTS.clear();
             assertEquals(List.of("1", "3"),
                     runWithMapping("deep-nested-category-label", CATEGORIES_MAP));
 
             String sql = SqlCapture.STATEMENTS.stream()
-                    .filter(s -> s.toLowerCase().contains("exists"))
+                    .filter(s -> s.toLowerCase().startsWith("select"))
                     .reduce("", (a, b) -> a.length() >= b.length() ? a : b)
                     .toLowerCase();
-            assertFalse(sql.isEmpty(), "expected a SELECT with EXISTS to be captured");
-            // At least one correlated EXISTS per relation hop (categories -> subCategories ->
-            // labels). The tri-state macro translation re-translates each hop's body inside its
-            // unknown-element COUNT subqueries, so the total EXISTS count exceeds three — the
-            // nesting guarantee is the lower bound plus the cross-join ban and the exact result
-            // rows asserted above.
-            assertTrue(countOccurrences(sql, "exists") >= 3,
-                    "expected at least three nested EXISTS subqueries, SQL was:\n" + sql);
+            assertFalse(sql.isEmpty(), "expected the filtered SELECT to be captured");
+            // One correlated aggregate subquery per macro polarity: a depth-3 exists chain emits
+            // at most 2^3 - 1 = 7 subqueries (8 SELECT keywords with the outer query). The lower
+            // bound pins that each relation hop still gets its own correlated subquery; the upper
+            // bound is the regression tripwire against the old per-macro multi-probe translation
+            // (which emitted 39 subqueries for this action).
+            int selects = countOccurrences(sql, "select");
+            assertTrue(selects >= 4 && selects <= 8,
+                    "expected 4..8 SELECTs (three nested correlated subquery levels, one "
+                            + "subquery per polarity), got " + selects + ", SQL was:\n" + sql);
             // Correlated subqueries must not collapse into a cartesian product.
             assertFalse(sql.contains("cross join"),
                     "nested correlation degraded into a cross join, SQL was:\n" + sql);

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -1322,6 +1322,131 @@ class SpringDataQueryPlanAdapterTest {
         }
     }
 
+    // -- collection-macro nesting depth guard --
+    // Each nesting level multiplies the correlated-subquery count of the translated filter, so
+    // plans nested beyond the configured limit must fail loudly at translation time instead of
+    // silently emitting a filter that times out on production-sized tables. The property name is
+    // spelled out literally here (not via the adapter constant) so this suite compiles — and
+    // demonstrably FAILS — against the pre-guard adapter.
+
+    @Nested
+    class MacroDepthGuard {
+
+        private static final String DEPTH_PROPERTY = "dev.cerbos.queryplan.springdata.maxMacroDepth";
+
+        // categories → subCategories → labels → subCategories → labels → subCategories: the
+        // bidirectional many-to-many pair gives arbitrarily deep legal join chains.
+        private static final Map<String, AttributeMapping> DEEP_MAPPER = Map.of(
+                "request.resource.attr.categories", AttributeMapping.relation("categories", Map.of(
+                        "name", AttributeMapping.field("name"),
+                        "subCategories", AttributeMapping.relation("subCategories", Map.of(
+                                "name", AttributeMapping.field("name"),
+                                "labels", AttributeMapping.relation("labels", Map.of(
+                                        "name", AttributeMapping.field("name"),
+                                        "subCategories", AttributeMapping.relation("subCategories", Map.of(
+                                                "name", AttributeMapping.field("name"),
+                                                "labels", AttributeMapping.relation("labels", Map.of(
+                                                        "name", AttributeMapping.field("name"),
+                                                        "subCategories", AttributeMapping.relation(
+                                                                "subCategories", Map.of(
+                                                                        "name", AttributeMapping.field("name")
+                                                                ))
+                                                ))
+                                        ))
+                                ))
+                        ))
+                )));
+
+        private static final String[] HOPS = {"subCategories", "labels", "subCategories",
+                "labels", "subCategories"};
+
+        /** {@code categories.exists(v1, v1.subCategories.exists(v2, ... vd.name == "x"))}. */
+        private Operand existsChain(int depth) {
+            return existsLevel(1, depth, "request.resource.attr.categories");
+        }
+
+        private Operand existsLevel(int level, int depth, String collection) {
+            String v = "v" + level;
+            Operand body = level == depth
+                    ? exprOp("eq", var(v + ".name"), sval("x"))
+                    : existsLevel(level + 1, depth, v + "." + HOPS[level - 1]);
+            return exprOp("exists", var(collection), lambda(v, body));
+        }
+
+        private int runDeep(Operand cond) {
+            return runCount(cond, DEEP_MAPPER, Map.of());
+        }
+
+        @Test
+        void depthAtDefaultLimitTranslates() {
+            assertEquals(0, runDeep(existsChain(5)));
+        }
+
+        @Test
+        void depthBeyondDefaultLimitThrowsNamedError() {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> runDeep(existsChain(6)));
+            assertTrue(ex.getMessage().contains("nesting depth 6 exceeds the maximum of 5")
+                            && ex.getMessage().contains("exists")
+                            && ex.getMessage().contains(DEPTH_PROPERTY),
+                    "unexpected message: " + ex.getMessage());
+        }
+
+        @Test
+        void propertyRaisesAndLowersTheLimit() {
+            System.setProperty(DEPTH_PROPERTY, "2");
+            try {
+                assertEquals(0, runDeep(existsChain(2)));
+                IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                        () -> runDeep(existsChain(3)));
+                assertTrue(ex.getMessage().contains("nesting depth 3 exceeds the maximum of 2"),
+                        "unexpected message: " + ex.getMessage());
+                System.setProperty(DEPTH_PROPERTY, "6");
+                assertEquals(0, runDeep(existsChain(6)));
+            } finally {
+                System.clearProperty(DEPTH_PROPERTY);
+            }
+        }
+
+        @Test
+        void sizeFilterCountsAsAMacroLevel() {
+            // size(categories.filter(v1, v1.subCategories.exists(v2, ...))) — the filter level
+            // plus the exists level is depth 2, over a limit of 1.
+            Operand filtered = exprOp("filter",
+                    var("request.resource.attr.categories"),
+                    lambda("v1", existsLevel(2, 2, "v1.subCategories")));
+            Operand cond = exprOp("gt", exprOp("size", filtered), nval(0));
+            System.setProperty(DEPTH_PROPERTY, "1");
+            try {
+                IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                        () -> runDeep(cond));
+                assertTrue(ex.getMessage().contains("nesting depth 2 exceeds the maximum of 1"),
+                        "unexpected message: " + ex.getMessage());
+            } finally {
+                System.clearProperty(DEPTH_PROPERTY);
+            }
+        }
+
+        @Test
+        void invalidPropertyValuesThrowNamedErrors() {
+            System.setProperty(DEPTH_PROPERTY, "not-a-number");
+            try {
+                IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                        () -> runDeep(existsChain(1)));
+                assertTrue(ex.getMessage().contains(DEPTH_PROPERTY)
+                                && ex.getMessage().contains("positive integer"),
+                        "unexpected message: " + ex.getMessage());
+                System.setProperty(DEPTH_PROPERTY, "0");
+                IllegalArgumentException zero = assertThrows(IllegalArgumentException.class,
+                        () -> runDeep(existsChain(1)));
+                assertTrue(zero.getMessage().contains("positive integer"),
+                        "unexpected message: " + zero.getMessage());
+            } finally {
+                System.clearProperty(DEPTH_PROPERTY);
+            }
+        }
+    }
+
     // -- NULL element columns under collection macros (three-valued lambda bodies) --
     // CEL semantics (cel-spec macro definitions; a NULL element column is a missing attribute,
     // so touching it is an evaluation error → deny):

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/TriPredicateTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/TriPredicateTest.java
@@ -185,52 +185,7 @@ class TriPredicateTest {
                 () -> unknownLeaf(cb, root), () -> knownTrue(cb, root), () -> knownTrue(cb, root))));
     }
 
-    // -- anyTrueOrUnknown(): the exists/filter/except absorption table --
-
-    @Test
-    void anyTrueOrUnknownTruthTable() {
-        // True witness absorbs an unknown sibling → TRUE.
-        assertEquals(1, count((cb, tri, root) ->
-                tri.anyTrueOrUnknown(knownTrue(cb, root), knownTrue(cb, root))));
-        assertEquals(0, countNegated((cb, tri, root) ->
-                tri.anyTrueOrUnknown(knownTrue(cb, root), knownTrue(cb, root))));
-        // No true witness, unknown witness → UNKNOWN (deny) under both polarities.
-        assertEquals(0, count((cb, tri, root) ->
-                tri.anyTrueOrUnknown(knownFalse(cb, root), knownTrue(cb, root))));
-        assertEquals(0, countNegated((cb, tri, root) ->
-                tri.anyTrueOrUnknown(knownFalse(cb, root), knownTrue(cb, root))));
-        // No true witness, no unknown witness → plain FALSE (flips under NOT).
-        assertEquals(0, count((cb, tri, root) ->
-                tri.anyTrueOrUnknown(knownFalse(cb, root), knownFalse(cb, root))));
-        assertEquals(1, countNegated((cb, tri, root) ->
-                tri.anyTrueOrUnknown(knownFalse(cb, root), knownFalse(cb, root))));
-        // True witness, no unknown → plain TRUE.
-        assertEquals(1, count((cb, tri, root) ->
-                tri.anyTrueOrUnknown(knownTrue(cb, root), knownFalse(cb, root))));
-    }
-
-    // -- allTrueOrUnknown(): the all absorption table --
-
-    @Test
-    void allTrueOrUnknownTruthTable() {
-        // False witness absorbs an unknown sibling → FALSE (flips under NOT).
-        assertEquals(0, count((cb, tri, root) ->
-                tri.allTrueOrUnknown(knownTrue(cb, root), knownTrue(cb, root))));
-        assertEquals(1, countNegated((cb, tri, root) ->
-                tri.allTrueOrUnknown(knownTrue(cb, root), knownTrue(cb, root))));
-        // No false witness, unknown witness → UNKNOWN (deny) under both polarities.
-        assertEquals(0, count((cb, tri, root) ->
-                tri.allTrueOrUnknown(knownFalse(cb, root), knownTrue(cb, root))));
-        assertEquals(0, countNegated((cb, tri, root) ->
-                tri.allTrueOrUnknown(knownFalse(cb, root), knownTrue(cb, root))));
-        // No false witness, no unknown witness → TRUE.
-        assertEquals(1, count((cb, tri, root) ->
-                tri.allTrueOrUnknown(knownFalse(cb, root), knownFalse(cb, root))));
-        assertEquals(0, countNegated((cb, tri, root) ->
-                tri.allTrueOrUnknown(knownFalse(cb, root), knownFalse(cb, root))));
-    }
-
-    // -- baseUnlessUnknown(): the exists_one / size(filter) / map-intersection strict table --
+    // -- baseUnlessUnknown(): the map-intersection strict table --
 
     @Test
     void baseUnlessUnknownWithFalseBaseAndUnknownWitnessIsUnknownNotFalse() {

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -952,3 +952,39 @@ resourcePolicy:
       condition:
         match:
           expr: 'timestamp(R.attr.createdAt) != timestamp("2024-06-01T00:00:00Z")'
+
+    # ==================== depth-3 nested collection macros ====================
+    # Three macro levels (categories → subCategories → labels). Pins that the single-
+    # subquery-per-polarity macro translation preserves tri-state semantics through deep
+    # nesting: a1 is the true witness (label "gold"), a6 is the error witness (a label with
+    # NO name — the inner lambda errors, no true sibling absorbs it, and the error must
+    # propagate up through BOTH outer exists levels → deny), a8 has labels but no "gold"
+    # (determined false), c1 is the case witness ("Gold" ≠ "gold": check() denies; a
+    # case-insensitive DB collation would over-include it), and rows without categories are
+    # exists-over-empty → false.
+    - actions: ["macro-depth3-exists"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.categories.exists(c, c.subCategories.exists(s, s.labels.exists(l, l.name == "gold")))'
+
+    # The negation: rows where the depth-3 exists is determined-FALSE must be ALLOWED, while
+    # the a6 error stays an error under NOT (deny) — the leak the tri-state machinery exists
+    # to prevent (NOT(UNKNOWN) must stay UNKNOWN, never flip to TRUE).
+    - actions: ["macro-depth3-not-exists"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!R.attr.categories.exists(c, c.subCategories.exists(s, s.labels.exists(l, l.name == "gold")))'
+
+    # all at the middle level: a6's erroring label makes the inner exists error, all() has no
+    # false witness to absorb it → error → deny; a8's labels hold no "gold", so its inner
+    # exists is determined-false → all() false; a1 is the true witness.
+    - actions: ["macro-depth3-all"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.categories.exists(c, c.subCategories.all(s, s.labels.exists(l, l.name == "gold")))'


### PR DESCRIPTION
Finding 9/28 from an internal adversarial review of the Spring Data adapter: nested collection macros re-translated their lambda bodies 3–5× per level, producing ~3^depth correlated-subquery blowup.

## Measured growth (before, current main)

Each collection macro emitted an `EXISTS` plus two correlated `COUNT` probes (`unknownElementExists`), and `exists_one`/`size(filter(...))` emitted the probe twice. Measured with the new benchmark harness (H2, 300 resources over a categories → subCategories → labels chain, ~3 000 rows across the join tables):

| depth | correlated subqueries | translate | execute |
|-------|----------------------|-----------|---------|
| 1 | 3 | 0.21 ms | 1.6 ms |
| 2 | 12 | 0.52 ms | 2.5 ms |
| 3 | 39 | 2.8 ms | 6.0 ms |
| 4 | 120 | 2.6 ms | 13.1 ms |

Every one of those COUNTs re-joins the whole relation chain per outer row, so on production-sized tables a legal depth-3 policy degrades sharply — and the class Javadoc documented only the per-macro cost, not the exponential composition. No depth guard existed.

## Polarity analysis → dedup shipped

Two hard constraints hold (both re-verified):
- a Hibernate 6 `Predicate` tree cannot be shared between a positive and a negated occurrence (stateful SQM negation — the existing junction-barrier machinery exists precisely for this), and
- criteria nodes are bound to the `From`/`Join` roots of the query they were built in, so a body predicate cannot be reused across different subqueries.

So per-occurrence rebuilds are the floor — but the TRUE/FALSE/UNKNOWN discrimination did **not** need three subqueries. The rewrite folds each macro into a **single correlated aggregate subquery** that scores every element:

```sql
CASE WHEN <body> THEN t WHEN NOT <body> THEN f ELSE 1 END
```

An UNKNOWN body matches neither `WHEN` (SQL skips an UNKNOWN condition), so undetermined elements land in the `ELSE` — the polarity pair suffices to distinguish all three states in one scan. `NULLIF(COALESCE(MAX(score), 0), 1)` folds the verdict into one scalar: dominant score, empty collection → 0, only-undetermined-dominates → SQL NULL. A plain equality against it then yields TRUE / FALSE / UNKNOWN exactly per the CEL macro truth tables, and `NOT` keeps UNKNOWN rows excluded. `exists_one` and `size(filter(...))` use a strict counter (`COALESCE(SUM(match),0) + poison`, where the poison term is 0/NULL) so any erroring element still denies.

Net effect: body built once per polarity — 2× for exists/all/filter/except (was 3×), 3× for exists_one/size(filter) (was 5×).

## Measured growth (after)

| depth | correlated subqueries | translate | execute |
|-------|----------------------|-----------|---------|
| 1 | 1 | 0.22 ms | 1.7 ms |
| 2 | 3 | 0.32 ms | 2.2 ms |
| 3 | 7 | 0.62 ms | 2.8 ms |
| 4 | 15 | 1.3 ms | 5.9 ms |

`2^d − 1` instead of `~3^d`, with **identical result-row sets at every depth**.

## Depth guard

Growth is still exponential (that is inherent to per-polarity rebuilds), so the translator now bounds macro nesting at **5** by default and throws a named `IllegalArgumentException` beyond it — fail closed at translation time, matching the adapter's existing error contract. Configurable via the `dev.cerbos.queryplan.springdata.maxMacroDepth` system property (read per translation; must be a positive integer; invalid values also fail closed with a named error). A system property was chosen over new `toSpecification` overloads to keep the public API surface unchanged.

## Tests

- **Benchmark/regression suite** (`MacroNestingBenchmarkTest`): hand-built plans, no PDP container, seeded H2; prints the table above and asserts the `2^d − 1` bound — fails on the old translation at depth 1 already (3 > 1). Cheap enough to stay in the default build.
- **Guard suite** (`MacroDepthGuard`): depth-at-limit translates, depth-over-limit throws the named error, property raises/lowers the limit, `size(filter(...))` counts as a macro level, invalid property values throw. Negative control: run against the pre-guard adapter, 4/5 fail (the at-limit test passes by design).
- **Differential oracle, depth 3**: new `macro-depth3-exists` / `macro-depth3-not-exists` / `macro-depth3-all` actions over a new third macro level (categories → subCategories → labels), with a NULL-name label error witness proving the CEL error propagates up through BOTH enclosing macro levels — including under negation — plus true/false/collation witnesses. The oracle (per-row `check()` against a live PDP) is the arbiter that the rewrite preserves tri-state semantics.
- Updated the SQL-shape integration pin (`threeLevelNestingIsCorrelatedNotCrossJoined`) to the new bound (4–8 SELECTs; was 40 with the old shape) and kept the cross-join ban.
- `TriPredicate.anyTrueOrUnknown`/`allTrueOrUnknown` became dead code (their truth tables now live in the scoring subqueries) and were removed with their unit tests; `baseUnlessUnknown` stays (map-intersection), `determined`/`not`/`ternary` unchanged.

## Three-leg verification

Full suite (451 tests, including the 109-action differential oracle) green on all three legs:

| leg | result |
|-----|--------|
| H2 (default) | 451 tests, 0 failures |
| PostgreSQL 16 (`ADAPTER_TEST_DB=postgres`) | 451 tests, 0 failures |
| MySQL 8.4, case-sensitive collation, client-side prep stmts (`ADAPTER_TEST_DB=mysql`) | 451 tests, 0 failures |