### PR TITLE
fix(spring-data): translate in-lists containing null per CEL semantics

### DIFF
--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -1635,9 +1635,13 @@ public final class SpringDataQueryPlanAdapter {
 
         // -- in (set membership or collection membership) --
 
-        /** Wrap a scalar plan constant as a single-element list; lists pass through unchanged. */
+        /**
+         * Wrap a scalar plan constant as a single-element list; lists pass through unchanged.
+         * The scalar may be the null constant ({@code null in R.attr.items} is planner-emitted),
+         * so the wrapper must be null-tolerant — {@code List.of} is not.
+         */
         private static List<?> asList(Object val) {
-            return (val instanceof List<?> l) ? l : List.of(val);
+            return (val instanceof List<?> l) ? l : java.util.Collections.singletonList(val);
         }
 
         private Predicate handleIn(List<Operand> rawOperands, Scope scope) {
@@ -1669,10 +1673,38 @@ public final class SpringDataQueryPlanAdapter {
                     if (list.isEmpty()) {
                         return cb.disjunction();
                     }
-                    return path.in(list);
+                    return scalarInWithNullElements(path, list);
+                }
+                // Scalar membership over a Field mapping is equality — and equality against
+                // the null constant is IS NULL, mirroring the eq-null leaf translation.
+                if (val == null) {
+                    return cb.isNull(path);
                 }
                 return cb.equal(path, val);
             });
+        }
+
+        /**
+         * {@code path IN (list)} with CEL null-element semantics. CEL {@code x in [..., null]}
+         * is TRUE for an explicitly-null {@code x} (PDP-verified for both {@code in} and
+         * {@code hasIntersection}; the planner even folds the degenerate {@code x in [null]}
+         * to {@code eq(x, null)}, which this adapter translates as IS NULL) — so a null list
+         * element must become an IS NULL disjunct. Passing it to {@code path.in} instead
+         * renders {@code IN (..., NULL)} (verified on Hibernate 6.6/H2), whose SQL
+         * three-valued semantics silently EXCLUDE null rows — and make the negation UNKNOWN
+         * for every non-matching row, returning nothing. Both disjuncts here are two-valued
+         * for every row (IS NULL absorbs the NULL-column case), so {@code tri.not} composes
+         * cleanly over the OR. Callers guarantee a non-empty list.
+         */
+        private Predicate scalarInWithNullElements(Path<?> path, List<?> list) {
+            List<?> nonNull = list.stream().filter(Objects::nonNull).toList();
+            if (nonNull.size() == list.size()) {
+                return path.in(list);
+            }
+            if (nonNull.isEmpty()) {
+                return cb.isNull(path);
+            }
+            return cb.or(path.in(nonNull), cb.isNull(path));
         }
 
         // -- hasIntersection --
@@ -1703,7 +1735,7 @@ public final class SpringDataQueryPlanAdapter {
                 if (values.isEmpty()) {
                     return cb.disjunction();
                 }
-                return path.in(values);
+                return scalarInWithNullElements(path, values);
             }
 
             if (first.getNodeCase() == Operand.NodeCase.EXPRESSION
@@ -1791,9 +1823,21 @@ public final class SpringDataQueryPlanAdapter {
             // (deny) even when another element would intersect — the strict
             // TriPredicate.baseUnlessUnknown table, with the null-witness EXISTS as the unknown
             // detector (IS NULL itself is two-valued, so both EXISTS legs are safe to compose).
+            //
+            // A null element in the constant list only matches an explicitly-null projection,
+            // which member ACCESS can never yield from the column model: a NULL member column
+            // is the missing-attribute error above (PDP-verified: tags=[{}] denies under BOTH
+            // polarities even with null in the list; tags=[{"name": null}] would allow, but a
+            // column cannot distinguish that case and the error convention wins here). Null
+            // elements are therefore inert — stripped so they don't render as a never-matching
+            // SQL `IN (..., NULL)` literal — while NULL-projection rows stay UNKNOWN.
+            List<?> nonNull = values.stream().filter(Objects::nonNull).toList();
+            Predicate base = nonNull.isEmpty()
+                    ? cb.disjunction()
+                    : existsSubquery(scope, ref, (sub, tailJoin, rebased) ->
+                            Scope.memberPath(tailJoin, ref.tail(), memberField).in(nonNull));
             return tri.baseUnlessUnknown(
-                    existsSubquery(scope, ref, (sub, tailJoin, rebased) ->
-                            Scope.memberPath(tailJoin, ref.tail(), memberField).in(values)),
+                    base,
                     () -> existsSubquery(scope, ref, (sub, tailJoin, rebased) ->
                             cb.isNull(Scope.memberPath(tailJoin, ref.tail(), memberField))));
         }
@@ -1804,12 +1848,28 @@ public final class SpringDataQueryPlanAdapter {
             if (values.isEmpty()) {
                 return cb.disjunction();
             }
+            // CEL membership/intersection with a null constant is satisfied by a collection
+            // element that IS null (PDP-verified for both routes here: `null in R.attr.xs`
+            // with xs=["a", null] allows, and hasIntersection(R.attr.xs, ["public", null])
+            // with xs=[null] allows). A related row whose member column is NULL is exactly
+            // such an element under the scalar-projection (defaultMemberField) view, so the
+            // null constant becomes an IS NULL disjunct inside the EXISTS body —
+            // `member IN (...)`/`member = NULL` never matches it in SQL. (Contrast with
+            // map(t, t.name) member ACCESS, where a NULL column is a MISSING element
+            // attribute → CEL error; see handleMapIntersection.)
+            List<?> nonNull = values.stream().filter(Objects::nonNull).toList();
+            boolean hasNull = nonNull.size() < values.size();
             return existsSubquery(scope, ref, (sub, tailJoin, rebased) -> {
                 Path<?> field = Scope.memberPath(tailJoin, ref.tail(), null);
-                if (values.size() == 1) {
-                    return cb.equal(field, values.get(0));
+                if (!hasNull) {
+                    return values.size() == 1 ? cb.equal(field, values.get(0)) : field.in(values);
                 }
-                return field.in(values);
+                if (nonNull.isEmpty()) {
+                    return cb.isNull(field);
+                }
+                Predicate match = nonNull.size() == 1
+                        ? cb.equal(field, nonNull.get(0)) : field.in(nonNull);
+                return cb.or(match, cb.isNull(field));
             });
         }
 

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -85,6 +85,14 @@ class AdversarialConformanceTest {
             // Instant column for the ts-* timestamp() comparison actions
             Map.entry("request.resource.attr.createdAt", AttributeMapping.field("createdAt")),
             Map.entry("request.resource.attr.obj.inner", AttributeMapping.field("aString")),
+            // in-null-elem-*: same column as aOptionalString, but the oracle sends an
+            // EXPLICIT null attribute for NULL columns (aOptionalString is OMITTED instead)
+            // — pinning the adapter's convention that a DB NULL is the explicitly-null
+            // attribute (eq-null → IS NULL, and `x in [..., null]` → OR IS NULL).
+            Map.entry("request.resource.attr.owner", AttributeMapping.field("aOptionalString")),
+            // Scalar projection of tags (defaultMemberField=name) for `null in R.attr.tagNames`;
+            // NULL name columns become explicit null list elements on the check side.
+            Map.entry("request.resource.attr.tagNames", AttributeMapping.relation("tags", "name")),
             Map.entry("request.resource.attr.tags", AttributeMapping.relation("tags", Map.of(
                     "id", AttributeMapping.field("id"),
                     "name", AttributeMapping.field("name")
@@ -436,6 +444,23 @@ class AdversarialConformanceTest {
         if (s.aOptionalString() != null) {
             r = r.withAttribute("aOptionalString", AttributeValue.stringValue(s.aOptionalString()));
         }
+        // `owner` reads the SAME column under the OTHER null convention: a DB NULL is the
+        // EXPLICITLY-null attribute. This is the convention the adapter's null translations
+        // implement (eq-null → IS NULL; a null in-list element → OR IS NULL), and the two
+        // check() verdicts genuinely differ: `null in ["x", null]` is TRUE (allow) while a
+        // MISSING owner is a CEL error (deny). SQL cannot distinguish the two — the adapter
+        // follows the planner, which itself folds `x in [null]` to eq(x, null).
+        r = r.withAttribute("owner", s.aOptionalString() != null
+                ? AttributeValue.stringValue(s.aOptionalString())
+                : nullAttributeValue());
+        // tagNames: the scalar name projection of tags, with NULL name columns as explicit
+        // null elements — the representation under which `null in R.attr.tagNames` is TRUE
+        // exactly when a related row's member column IS NULL.
+        r = r.withAttribute("tagNames", AttributeValue.listValue(s.tags().stream()
+                .map(t -> t.name() != null
+                        ? AttributeValue.stringValue(t.name())
+                        : nullAttributeValue())
+                .toList()));
         if (doubleFor(s) != null) {
             r = r.withAttribute("aDouble", AttributeValue.doubleValue(doubleFor(s)));
         }
@@ -463,6 +488,24 @@ class AdversarialConformanceTest {
                             .toList()))));
         }
         return r;
+    }
+
+    /**
+     * An explicit protobuf NULL attribute value. The SDK's {@link AttributeValue} exposes no
+     * null factory (string/double/bool/list/map only), so the private constructor is reached
+     * reflectively — the null attribute is exactly what the in-null-elem-* actions exist to
+     * exercise, and check() verdicts differ between an explicit null and a missing attribute.
+     */
+    private static AttributeValue nullAttributeValue() {
+        try {
+            var ctor = AttributeValue.class.getDeclaredConstructor(com.google.protobuf.Value.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(com.google.protobuf.Value.newBuilder()
+                    .setNullValue(com.google.protobuf.NullValue.NULL_VALUE).build());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                    "cerbos-sdk-java AttributeValue no longer has a (Value) constructor", e);
+        }
     }
 
     /** A NULL tag name in the DB is a missing element attribute on the check side. */
@@ -578,6 +621,16 @@ class AdversarialConformanceTest {
             // normalization; ts-ne pins NULL exclusion (a3 has no created_at: check()
             // denies on the missing attribute AND SQL excludes the NULL row).
             "ts-window", "ts-vf", "ts-eq", "ts-eq-offset", "ts-ne",
+            // in-lists containing null: the null element arrives VERBATIM and check()
+            // allows an explicitly-null `owner` (`null in [..., null]` is true) — the
+            // translation must be IN (nonNulls) OR IS NULL, with three-valued-safe
+            // negation; `in [null]` is planner-folded to eq-null; the rel variants pin
+            // EXISTS(member IS NULL); hasint pins the same null-element semantics through
+            // the shared intersection translation.
+            "in-null-elem-mixed", "in-null-elem-neg",
+            "in-null-elem-only", "in-null-elem-only-neg",
+            "in-null-elem-rel", "in-null-elem-rel-neg",
+            "in-null-elem-hasint",
     })
     void adapterMatchesCheckOracle(String action) {
         List<String> oracle = oracleAllowedIds(action);

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -64,7 +64,10 @@ class SpringDataQueryPlanAdapterTest {
             Map.entry("request.resource.attr.tags", AttributeMapping.relation("tags", Map.of(
                     "id", AttributeMapping.field("id"),
                     "name", AttributeMapping.field("name")
-            )))
+            ))),
+            // Scalar projection of the tags relation (defaultMemberField) for the
+            // null-element membership tests: `null in R.attr.tagNames`.
+            Map.entry("request.resource.attr.tagNames", AttributeMapping.relation("tags", "name"))
     );
 
     private static EntityManagerFactory emf;
@@ -114,6 +117,19 @@ class SpringDataQueryPlanAdapterTest {
     private static Operand listOp(String... values) {
         ListValue.Builder list = ListValue.newBuilder();
         for (String v : values) list.addValues(Value.newBuilder().setStringValue(v));
+        return Operand.newBuilder().setValue(Value.newBuilder().setListValue(list)).build();
+    }
+
+    /** Like {@link #listOp} but {@code null} entries become protobuf NULL_VALUE elements. */
+    private static Operand listOpNullable(String... values) {
+        ListValue.Builder list = ListValue.newBuilder();
+        for (String v : values) {
+            if (v == null) {
+                list.addValues(Value.newBuilder().setNullValue(NullValue.NULL_VALUE));
+            } else {
+                list.addValues(Value.newBuilder().setStringValue(v));
+            }
+        }
         return Operand.newBuilder().setValue(Value.newBuilder().setListValue(list)).build();
     }
 
@@ -1511,6 +1527,178 @@ class SpringDataQueryPlanAdapterTest {
                 assertEquals(1, runCount(mapNames));
                 assertEquals(0, runCount(exprOp("not", mapNames)));
             });
+        }
+    }
+
+    /**
+     * {@code in}-lists containing {@code null} — PDP-verified wire facts (Cerbos latest,
+     * 2026-07): {@code R.attr.owner in ["a", null]} compiles and the planner emits
+     * {@code in(variable, value ["a", null])} VERBATIM, and {@code check()} ALLOWS an
+     * explicitly-null attribute (CEL {@code null in ["a", null]} is true). The planner itself
+     * folds the degenerate {@code x in [null]} to {@code eq(x, null)} — which this adapter
+     * already translates as IS NULL — so a null list element must become an IS NULL disjunct:
+     * {@code path IN (nonNulls) OR path IS NULL}. Passing the raw null-bearing list to
+     * {@code path.in} instead produces SQL {@code IN ('a', NULL)}, whose three-valued
+     * semantics silently EXCLUDE null rows check() allows (under-return), and whose negation
+     * is UNKNOWN for every non-matching row (the negated filter returns nothing at all).
+     * The Relation side mirrors this: a null element of a mapped collection is a related row
+     * whose member column IS NULL, so the null needle/element becomes an IS NULL disjunct
+     * inside the membership EXISTS.
+     */
+    @Nested
+    class InListNullElements {
+
+        /** Seed three rows keyed by aOptionalString content: "a", "b", and NULL. */
+        private void withOwnerRows(Runnable body) {
+            ResourceEntity a = new ResourceEntity("in-null-a");
+            a.setaOptionalString("a");
+            ResourceEntity b = new ResourceEntity("in-null-b");
+            b.setaOptionalString("b");
+            ResourceEntity nul = new ResourceEntity("in-null-nul");
+            nul.setaOptionalString(null);
+            withResource(a, () -> withResource(b, () -> withResource(nul, body)));
+        }
+
+        /** Seed rows with tag collections: a null-name member, an "x" member, and no tags. */
+        private void withTagRows(Runnable body) {
+            ResourceEntity withX = new ResourceEntity("in-null-tag-x");
+            withX.addTag("int1", "x");
+            ResourceEntity withNullName = new ResourceEntity("in-null-tag-nul");
+            withNullName.addTag("int2", null);
+            ResourceEntity noTags = new ResourceEntity("in-null-tag-none");
+            withResource(withX, () -> withResource(withNullName, () -> withResource(noTags, body)));
+        }
+
+        /** Translate {@code condition}, run it, and return the matched row IDs. */
+        private Set<String> runIds(Operand condition) {
+            PlanResourcesResponse resp =
+                    buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+            Result<ResourceEntity> result =
+                    SpringDataQueryPlanAdapter.toSpecification(resp, MAPPER, Map.of());
+            assertInstanceOf(Result.Conditional.class, result);
+            Specification<ResourceEntity> spec =
+                    ((Result.Conditional<ResourceEntity>) result).specification();
+            EntityManager em = emf.createEntityManager();
+            try {
+                CriteriaBuilder cb = em.getCriteriaBuilder();
+                CriteriaQuery<String> cq = cb.createQuery(String.class);
+                Root<ResourceEntity> root = cq.from(ResourceEntity.class);
+                cq.select(root.get("id")).distinct(true);
+                Predicate p = spec.toPredicate(root, cq, cb);
+                if (p != null) {
+                    cq.where(p);
+                }
+                return Set.copyOf(em.createQuery(cq).getResultList());
+            } finally {
+                em.close();
+            }
+        }
+
+        @Test
+        void inListWithNullElementIncludesNullRow() {
+            // check() verdicts (scratch PDP): "a" ALLOW, null ALLOW, "b" DENY.
+            Operand cond = exprOp("in",
+                    var("request.resource.attr.aOptionalString"), listOpNullable("a", null));
+            withOwnerRows(() ->
+                    assertEquals(Set.of("in-null-a", "in-null-nul"), runIds(cond)));
+        }
+
+        @Test
+        void notInListWithNullElementReturnsOnlyNonMatchingRows() {
+            // check() verdicts: "b" ALLOW; "a" and null DENY. Three-valued trap: over the old
+            // IN ('a', NULL) the negation was UNKNOWN for "b" too — nothing came back.
+            Operand cond = exprOp("not", exprOp("in",
+                    var("request.resource.attr.aOptionalString"), listOpNullable("a", null)));
+            withOwnerRows(() ->
+                    assertEquals(Set.of("in-null-b"), runIds(cond)));
+        }
+
+        @Test
+        void inAllNullListIsPureIsNull() {
+            // The planner folds `x in [null]` to eq(x, null) in real plans; the unfolded
+            // shape must translate identically (pure IS NULL) for hand-built plans.
+            Operand cond = exprOp("in",
+                    var("request.resource.attr.aOptionalString"), listOpNullable((String) null));
+            withOwnerRows(() -> {
+                assertEquals(Set.of("in-null-nul"), runIds(cond));
+                assertEquals(Set.of("in-null-a", "in-null-b"), runIds(exprOp("not", exprOp("in",
+                        var("request.resource.attr.aOptionalString"),
+                        listOpNullable((String) null)))));
+            });
+        }
+
+        @Test
+        void nullNeedleAgainstScalarFieldIsIsNull() {
+            // `null in R.attr.x` over a Field mapping: scalar membership is equality, and
+            // equality against the null constant is IS NULL (mirrors the eq-null leaf).
+            Operand cond = exprOp("in",
+                    nullVal(), var("request.resource.attr.aOptionalString"));
+            withOwnerRows(() ->
+                    assertEquals(Set.of("in-null-nul"), runIds(cond)));
+        }
+
+        @Test
+        void nullNeedleAgainstRelationMatchesNullMemberRow() {
+            // `null in R.attr.tagNames`: CEL is true iff the collection holds a null element
+            // (PDP-verified: items=["a", null] → ALLOW; ["a"], [] → DENY). A related row with
+            // a NULL member column is exactly such an element → EXISTS(member IS NULL).
+            Operand cond = exprOp("in", nullVal(), var("request.resource.attr.tagNames"));
+            withTagRows(() ->
+                    assertEquals(Set.of("in-null-tag-nul"), runIds(cond)));
+        }
+
+        @Test
+        void notNullNeedleAgainstRelationExcludesNullMemberRow() {
+            // check() verdicts: ["a"] ALLOW, [] ALLOW, ["a", null] DENY.
+            Operand cond = exprOp("not",
+                    exprOp("in", nullVal(), var("request.resource.attr.tagNames")));
+            withTagRows(() ->
+                    assertEquals(Set.of("in-null-tag-x", "in-null-tag-none"), runIds(cond)));
+        }
+
+        @Test
+        void hasIntersectionWithNullElementMatchesNullMemberRow() {
+            // hasIntersection shares collectionContainsAny with `in`, and check() agrees:
+            // hasIntersection(R.attr.xs, ["x", null]) ALLOWS xs=[null] (PDP-verified). A
+            // null element in the constant list intersects exactly the collections holding
+            // a null member.
+            Operand cond = exprOp("hasIntersection",
+                    var("request.resource.attr.tagNames"), listOpNullable("x", null));
+            withTagRows(() -> {
+                assertEquals(Set.of("in-null-tag-x", "in-null-tag-nul"), runIds(cond));
+                assertEquals(Set.of("in-null-tag-none"), runIds(exprOp("not",
+                        exprOp("hasIntersection",
+                                var("request.resource.attr.tagNames"),
+                                listOpNullable("x", null)))));
+            });
+        }
+
+        @Test
+        void mapIntersectionNullElementIsInertAndNullProjectionStaysUnknown() {
+            // For map(t, t.name) member ACCESS — unlike the scalar tagNames projection — a
+            // NULL member column is a MISSING element attribute (CEL error): check() denies
+            // tags=[{}] under BOTH polarities even with a null element in the constant list
+            // (PDP-verified), and only an explicitly-null projection (unrepresentable in the
+            // column model) could match that element. The null element must be inert and the
+            // NULL-projection row must stay UNKNOWN.
+            java.util.function.Supplier<Operand> cond = () -> exprOp("hasIntersection",
+                    exprOp("map", var("request.resource.attr.tags"),
+                            lambda("t", var("t.name"))),
+                    listOpNullable("x", null));
+            withTagRows(() -> {
+                assertEquals(Set.of("in-null-tag-x"), runIds(cond.get()));
+                assertEquals(Set.of("in-null-tag-none"),
+                        runIds(exprOp("not", cond.get())));
+            });
+        }
+
+        @Test
+        void overrideStillOwnsInWithNullElement() {
+            // A registered override must keep receiving the RAW list (nulls included).
+            Operand cond = exprOp("in",
+                    var("request.resource.attr.aOptionalString"), listOpNullable("a", null));
+            assertThrows(OverrideInvoked.class,
+                    () -> runCount(cond, Map.of("in", THROWING_OVERRIDE)));
         }
     }
 

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -952,3 +952,74 @@ resourcePolicy:
       condition:
         match:
           expr: 'timestamp(R.attr.createdAt) != timestamp("2024-06-01T00:00:00Z")'
+
+    # ==================== in-lists containing null ====================
+    # `R.attr.owner in [..., null]` compiles and the planner emits the null element
+    # VERBATIM in the value list; check() ALLOWS an explicitly-null attribute (CEL
+    # `null in [..., null]` is true). `owner` maps to the a_optional_string column, and —
+    # unlike aOptionalString — the oracle sends an EXPLICIT null attribute for NULL columns,
+    # matching the adapter's eq-null → IS NULL convention (the planner itself folds
+    # `x in [null]` to `eq(x, null)`). The null element must become an IS NULL disjunct:
+    # `IN (nonNulls) OR IS NULL`; a raw `IN (..., NULL)` silently excludes null rows and
+    # makes the negation UNKNOWN everywhere.
+
+    # Mixed list: matching ("x" → a3, "one_two" → b1), null (a2/a4/a8/c2), non-matching rest.
+    - actions: ["in-null-elem-mixed"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.owner in ["x", "one_two", null]'
+
+    # Negation: three-valued trap — over `IN (..., NULL)` the negation returned NOTHING.
+    - actions: ["in-null-elem-neg"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!(R.attr.owner in ["x", "one_two", null])'
+
+    # Degenerate all-null list: the planner folds this to eq(owner, null) → pure IS NULL.
+    - actions: ["in-null-elem-only"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.owner in [null]'
+
+    - actions: ["in-null-elem-only-neg"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!(R.attr.owner in [null])'
+
+    # Relation variant: `null in collection` is true iff the collection holds a null
+    # element (tagNames projects tags.name; b5/b6 hold NULL-name tags and the oracle sends
+    # those as explicit null list elements) → EXISTS(member IS NULL).
+    - actions: ["in-null-elem-rel"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'null in R.attr.tagNames'
+
+    # Negation: rows with no null member — including EMPTY collections (`null in []` is
+    # false, so the negation allows them).
+    - actions: ["in-null-elem-rel-neg"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!(null in R.attr.tagNames)'
+
+    # hasIntersection with a null element behaves like `in` (PDP-verified: allows
+    # tagNames=[null]): the null element intersects collections holding a null member,
+    # so the shared EXISTS translation gains the same IS NULL disjunct. b5/b6 (NULL-name
+    # tags) plus the "public"-tagged rows must come back.
+    - actions: ["in-null-elem-hasint"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'hasIntersection(R.attr.tagNames, ["public", null])'


### PR DESCRIPTION
An `in`-list containing `null` — legal CEL that compiles and plans — was translated by passing the raw null into `path.in(...)`, producing SQL whose three-valued semantics silently diverge from `check()`. Finding 13/28 from an internal adversarial review of the spring-data adapter.

## Which Hibernate branch is real

Determined empirically (Hibernate 6.6.x, H2/PostgreSQL/MySQL): Hibernate does **not** reject the null literal at criteria-build time — it renders `IN ('a', NULL)`. So the failure mode is the **silent under-return** branch, not the crash branch:

- `owner IN ('x', 'one_two', NULL)` — NULL rows never match (`NULL = x` is UNKNOWN): rows `check()` ALLOWS are silently dropped.
- Negated, it is worse: `NOT(IN (..., NULL))` is UNKNOWN for **every non-matching row**, so the negated filter returned **zero rows**.
- The Relation-mapped path (`null in R.attr.collection`) did crash — an NPE in `asList` (`List.of(null)`), i.e. every query for that plan threw.

## PDP-verified wire + check() facts (scratch PDP, `ghcr.io/cerbos/cerbos:latest`)

- `R.attr.owner in ["a", null]` **emits verbatim**: `in(variable, value ["a", null])`. The negation wraps it in `not(...)` unchanged.
- The degenerate `R.attr.owner in [null]` is **planner-folded to `eq(owner, null)`** — which this adapter already translates as `IS NULL`. The planner itself equates a null list element with the null equality, forcing the translation below for consistency.
- `null in R.attr.items` (collection membership, null needle) emits verbatim as `in(value null, variable)`.
- `hasIntersection(R.attr.xs, ["public", null])` also emits verbatim, and `check()` ALLOWS `xs=[null]` — a null element intersects a null element.

check() verdict table for `owner in ["a", null]` and its negation:

| owner | `in ["a", null]` | `!(in ["a", null])` |
|---|---|---|
| `"a"` | ALLOW | DENY |
| `null` (explicit) | ALLOW | DENY |
| `"b"` | DENY | ALLOW |
| missing | DENY | DENY |

The SQL translation matches all rows `check()` allows under the explicitly-null-attribute convention (the same convention the adapter's existing `eq(x, null)` → `IS NULL` translation uses; SQL cannot distinguish an explicitly-null attribute from a missing one, and the missing-attr row is only reachable under the positive polarity where the divergence predates this change).

## The fix

`scalarInWithNullElements` (shared by `in` and the flat `hasIntersection` branch):

- list with no nulls → `path.in(list)` (unchanged);
- mixed list → `path.in(nonNulls) OR path IS NULL` — both disjuncts are two-valued for every row (`IS NULL` absorbs the NULL-column case), so `TriPredicate.not`'s junction-barrier negation composes cleanly: the negated filter excludes exactly the matching + null rows and returns the rest;
- all-null list → pure `path IS NULL` (mirrors the planner's own `in [null]` → `eq null` fold);
- scalar null needle over a Field mapping → `IS NULL` (mirrors the eq-null leaf).

## Relation decision

Implemented, not fail-closed — the semantics turned out not to be murky once probed:

- `null in R.attr.collection` (Relation-mapped, `defaultMemberField` scalar projection): CEL is true iff the collection holds a null **element**, and a related row whose member column is NULL is exactly such an element under the scalar-projection view → the null constant becomes an `IS NULL` disjunct inside the membership EXISTS (`collectionContainsAny`). Also fixes the `asList` NPE (`Collections.singletonList` instead of `List.of`).
- **Contrast, deliberately different:** `hasIntersection(map(t, t.name), [..., null])` — member **access** — keeps nulls inert. A NULL member column there is a *missing element attribute* (CEL error): PDP-verified that `tags=[{}]` denies under BOTH polarities even with a null element in the list. Nulls are stripped (so they don't render as a never-matching SQL `IN (..., NULL)` literal) while NULL-projection rows stay UNKNOWN via the existing `baseUnlessUnknown` machinery. Only an explicitly-null projection (`{"name": null}`, unrepresentable in the column model) could match the element; the error convention wins.

## Tests (all fail on the old code — negative control)

Unit (`InListNullElements`, 9 tests, row identities): old-code failures observed as
- mixed list: `expected [in-null-a, in-null-nul] but was [in-null-a]` (null row silently dropped);
- negated mixed list: `expected [in-null-b] but was []` (negation returned nothing);
- all-null list: `expected [in-null-nul] but was []`;
- Relation null needle (both polarities): `NullPointerException` at translation;
- hasIntersection with null element: null-member row dropped.

Differential oracle (`in-null-elem-*` actions — distinct from the existing `p-in-null-*` actions, which cover null *columns* and are untouched): `in-null-elem-mixed`, `-neg`, `-only`, `-only-neg`, `-rel`, `-rel-neg`, `-hasint`, over seeds covering matching / non-matching / NULL-column rows and empty collections. New check-side attributes `owner` (explicit null for NULL columns) and `tagNames` (explicit null list elements for NULL member columns) pin the convention; existing attributes and actions are unchanged. Old-code oracle divergences:

```
in-null-elem-mixed    expected [a2, a3, a4, a8, b1, c2]  but was [a3, b1]
in-null-elem-neg      expected [a1, a5, a6, a7, a9, ...] but was []
in-null-elem-rel      NullPointerException
in-null-elem-rel-neg  NullPointerException
in-null-elem-hasint   expected [..., b5, b6]             but was [..., b6]
```

(`in-null-elem-only`/`-only-neg` pass on old code by design — they pin the planner's eq-null fold.)

## Three-leg build results

| Leg | Command | Result |
|---|---|---|
| H2 | `gradle clean build` | 380 tests, 0 failed |
| PostgreSQL | `ADAPTER_TEST_DB=postgres gradle clean build` | 460 tests, 0 failed |
| MySQL | `ADAPTER_TEST_DB=mysql gradle clean build` | 460 tests, 0 failed |

## Note

#287 also appends actions to `adversarial-policy.yaml` — action names here are distinct (`in-null-elem-*`), so any overlap is a trivial append-order conflict at the end of the file.
