### PR TITLE
test(spring-data): pin the upstream has() ALWAYS_ALLOWED over-grant with a tripwire

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -373,6 +373,40 @@ three-valued logic, including the places where naive translations leak under `NO
   so `!(ternary...)` cannot flip a null-condition row to included.
 - `ne` against an unsolvable string concatenation reduces to `IS NOT NULL`, not `TRUE`.
 
+### `has(...)` over-grants at the planner level — write `!= null` instead
+
+This one is an **upstream Cerbos planner issue, not an adapter bug, and it affects every
+query-plan adapter equally** (no public cerbos/cerbos issue tracks it at the time of
+writing). The planner constant-folds an attribute-presence check like
+
+```
+has(R.attr.aOptionalString)
+```
+
+to `KIND_ALWAYS_ALLOWED` — a plan that admits **every row** — even though the `check()`
+API denies resources that lack the attribute. Any adapter that translates the plan
+faithfully (as this one does) turns a `has()`-based policy into a silent authorization
+over-grant: rows whose column is `NULL` come back from `findAll(spec)` although a
+per-resource `check()` call would deny them.
+`AdversarialConformanceTest#upstreamHasFoldOverGrantTripwire` pins both halves of the
+divergence against the live PDP and fails with re-inclusion instructions the moment an
+upstream image fixes the fold.
+
+**Workaround (PDP-verified):** express presence as a null comparison instead —
+
+```
+R.attr.aOptionalString != null
+```
+
+The planner emits a conditional `ne(variable, null)` plan, which this adapter translates
+to `a_optional_string IS NOT NULL`, and `check()` agrees on every case: attribute missing
+→ deny, explicitly `null` → deny, present → allow. Guarding an existing policy with
+`has(R.attr.x) && R.attr.x != null` produces the identical (correct) plan, so it is a
+safe drop-in edit. The only semantic difference from true `has()` is the
+explicitly-`null` attribute value, which `has()` treats as *present* — for column-backed
+attributes that distinction doesn't exist, because SQL `NULL` is the only representation
+of "not set".
+
 ### Division by a column is guarded with `NULLIF` — zero divisors deny
 
 CEL double division by zero yields ±Infinity (a defined result that a comparison could

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -543,6 +543,9 @@ class AdversarialConformanceTest {
             // unsupportedShapesThrow below. Known divergences excluded from the oracle run:
             //   p-has            — planner folds has(unknown attr) to KIND_ALWAYS_ALLOWED, so the
             //                      adapter returns all rows while check() denies NULL rows.
+            //                      Pinned by upstreamHasFoldOverGrantTripwire below, which fails
+            //                      loudly (with re-inclusion instructions) once upstream fixes
+            //                      the fold — never delete this exclusion without that test.
             // p-double-frac is IN the run: the adapter forces IEEE double space (CAST columns,
             // double bind parameters), so 3*0.1 == 0.3 is false in SQL exactly as in CEL.
             "p-struct", "p-not-exists-empty", "p-not-ternary-null", "p-double-frac",
@@ -639,6 +642,83 @@ class AdversarialConformanceTest {
                         + "META-INF/services FunctionContributor entry intact?)"
                 : "cerbos_ieee_double must not be registered off-MySQL — H2/PostgreSQL "
                         + "keep the cb.toDouble cast path");
+    }
+
+    /**
+     * Tripwire pinning the known UPSTREAM planner over-grant on the {@code has(...)} macro.
+     *
+     * <p>The Cerbos query planner constant-folds {@code has(R.attr.aOptionalString)} (action
+     * {@code p-has}) to {@code KIND_ALWAYS_ALLOWED} — "return every row" — even though the
+     * {@code check()} API denies resources that lack the attribute. The fold happens at the
+     * PLANNER, so every query-plan adapter is affected equally; this adapter translates the
+     * always-allowed plan faithfully. That is why {@code p-has} is excluded from the
+     * {@code adapterMatchesCheckOracle} {@code @ValueSource}: the differential comparison
+     * cannot pass while the planner itself over-grants. (No public cerbos/cerbos issue tracks
+     * the fold at the time of writing — searched 2026-07.)
+     *
+     * <p>This test asserts BOTH halves of the divergence — the plan kind AND the check()
+     * denials — so that the moment an upstream image stops folding, the test fails with
+     * explicit re-inclusion instructions instead of the coverage hole silently becoming
+     * permanent (the suite tracks {@code cerbos:latest}, so the fix would otherwise flow in
+     * unnoticed with {@code p-has} still excluded).
+     *
+     * <p>README "Gotchas" documents the policy-author workaround:
+     * {@code R.attr.aOptionalString != null} plans as a conditional {@code ne(variable, null)}
+     * that this adapter translates to {@code IS NOT NULL} (PDP-verified).
+     */
+    @Test
+    void upstreamHasFoldOverGrantTripwire() {
+        PlanResourcesResult plan =
+                client.plan(principal(), Resource.newInstance("adversarial"), "p-has");
+        List<String> allIds = SEEDS.stream().map(Seed::id).sorted().toList();
+        List<String> oracle = oracleAllowedIds("p-has");
+
+        String upstreamChanged = String.format(
+                """
+
+                UPSTREAM CHANGE DETECTED: the Cerbos planner's has() -> KIND_ALWAYS_ALLOWED \
+                over-grant no longer reproduces on the image under test.
+
+                Until now, has(R.attr.aOptionalString) (action 'p-has') planned as \
+                KIND_ALWAYS_ALLOWED while check() denied rows without the attribute — a known \
+                upstream planner fold this adapter translated faithfully into "return all \
+                rows". 'p-has' is therefore EXCLUDED from the adapterMatchesCheckOracle \
+                @ValueSource. This tripwire exists to keep that exclusion honest.
+
+                The exclusion is no longer justified. Do ALL of the following:
+                  1. Add "p-has" to the adapterMatchesCheckOracle @ValueSource and delete its
+                     exclusion note in the comment above it — the differential oracle then owns
+                     has() semantics and will catch any mistranslation of the new residual
+                     plan shape mechanically.
+                  2. Run the oracle. If the adapter cannot translate the residual shape the
+                     planner now emits for has() (fetch it with: curl -s <pdp>/api/plan/resources
+                     -d '{"principal":{"id":"u1","roles":["USER"]},"resource":{"kind":
+                     "adversarial","attr":{}},"action":"p-has"}'), implement or fail-closed
+                     route that shape before re-including.
+                  3. Update the README "Gotchas" entry on has() (the over-grant caveat and the
+                     != null workaround) to reflect the fixed planner behaviour.
+                  4. Delete this tripwire test.
+
+                Observed on this run:
+                  plan kind for 'p-has': %s (pinned while broken: KIND_ALWAYS_ALLOWED)
+                  check() allowed %d of %d seeded rows: %s
+                """,
+                plan.getRaw().getFilter().getKind(), oracle.size(), allIds.size(), oracle);
+
+        // Pinned fact 1: the planner still folds has(...) to an unconditional allow-all plan.
+        assertTrue(plan.isAlwaysAllowed(), upstreamChanged);
+        // Pinned fact 2: the check() oracle diverges from that plan — at least one seeded row
+        // (a2/a4/a8/c2 hold NULL aOptionalString) is denied while the plan admits everything.
+        assertTrue(oracle.size() < allIds.size(), upstreamChanged);
+        assertTrue(oracle.contains("a1"),
+                "sanity: check() must still allow rows whose aOptionalString is set; oracle="
+                        + oracle);
+
+        // Executable record of the over-grant itself: the adapter translates the always-allowed
+        // plan faithfully, so the filtered set is EVERY row — including the ones check() denies.
+        assertEquals(allIds, adapterFilteredIds("p-has"),
+                "the adapter is expected to translate KIND_ALWAYS_ALLOWED faithfully into all "
+                        + "rows — if this fails the adapter started second-guessing plan kinds");
     }
 
     @Test


### PR DESCRIPTION
Finding 18/28 from an internal adversarial review of the spring-data adapter.

## The upstream fold this pins

The Cerbos query planner constant-folds an attribute-presence check —
`has(R.attr.aOptionalString)` (action `p-has` in `adversarial-policy.yaml`) — to
`KIND_ALWAYS_ALLOWED`, while the `check()` API denies resources that lack the
attribute. The fold happens at the **planner**, so every query-plan adapter is
affected equally; this adapter translates the always-allowed plan faithfully into
"return all rows". Re-verified today against `ghcr.io/cerbos/cerbos:latest`
(`sha256:211c261f6031...`):

- `plan(p-has)` → `{"filter":{"kind":"KIND_ALWAYS_ALLOWED"}}`
- `check(p-has)` on a resource without `aOptionalString` → `EFFECT_DENY`

Until now `p-has` was merely omitted from the oracle `@ValueSource` with a comment:
no executable record of the over-grant, and — since the suite tracks `cerbos:latest`
— an upstream fix would flow in silently with `p-has` still excluded, making the
coverage hole permanent.

## What this PR adds (test + docs only; no translation code touched)

**`AdversarialConformanceTest#upstreamHasFoldOverGrantTripwire`** pins BOTH facts
against the live PDP container the suite already runs:

1. the `p-has` plan is `KIND_ALWAYS_ALLOWED` (`plan.isAlwaysAllowed()`);
2. the `check()` oracle diverges — the NULL-`aOptionalString` seeds (a2/a4/a8/c2)
   are denied while the plan admits everything (oracle allowed 15 of 19 seeds);
   plus an executable record that the adapter faithfully returns all 19 rows.

When an upstream image stops folding, the test fails with explicit instructions:
add `p-has` (and the new residual shape) to the oracle `@ValueSource`, remove the
exclusion note, update the README entry, delete the tripwire. The failure message is
the deliverable — it was verified end-to-end via a negative control (assertion
temporarily pointed at a CONDITIONAL action's plan; the full message rendered in the
JUnit report with the observed plan kind and oracle counts; then reverted).

**README "Gotchas"**: new section "`has(...)` over-grants at the planner level —
write `!= null` instead", stating this is an upstream issue affecting all adapters,
with the PDP-verified workaround: `R.attr.aOptionalString != null` plans as a
conditional `ne(variable, null)` that the adapter translates to `IS NOT NULL`, and
`check()` agrees (missing → deny, explicit null → deny, present → allow).
`has(R.attr.x) && R.attr.x != null` folds to the identical plan, so it's a safe
drop-in guard for existing policies. The explicitly-null-attribute difference
(`has()` treats it as present) is called out; it cannot arise for column-backed
attributes.

## Upstream issue

Searched cerbos/cerbos issues (`has`, `query plan`, `ALWAYS_ALLOWED`, `planner
fold`, `attribute presence`): **no existing public issue tracks this fold**; the
test comment and README say so. None was filed as part of this PR.

## Validation

- Full H2-leg build green in Docker (`gradle build`, JDK 17): 445 tests, 0 failures;
  the tripwire passes against current `cerbos:latest`. Postgres/MySQL legs not run —
  no translation code changed.
- Negative control: with the plan fetch pointed at `optional-ne` (CONDITIONAL), the
  tripwire failed loudly with the full re-inclusion message; change reverted.

## Notes

PRs #287 and #288 are open and also touch `AdversarialConformanceTest` /
`adversarial-policy.yaml`; this PR only appends a distinctly-named test method and
extends the GROUP B exclusion comment, so any conflicts are trivial
(adjacent-line / keep-both).
