### PR TITLE
fix(spring-data): error-message and API-hardening hygiene sweep

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -183,6 +183,7 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | `eq` / `ne`                      | `cb.equal` / `cb.notEqual` (auto `isNull`/`isNotNull` for `null` RHS) |
 | `lt` / `gt` / `le` / `ge`        | `cb.lessThan` / `greaterThan` / `lessThanOrEqualTo` / `greaterThanOrEqualTo` |
 | `in`                             | `path.in(values)` or correlated `EXISTS` for collections            |
+| `in(R.attr.x, R.attr.coll)` (attribute-in-attribute) | Correlated `EXISTS` comparing the collection's member column to the outer scalar column; a `NULL` scalar matches a `NULL` member element (CEL `null in [..., null]` is true) |
 | `contains` / `startsWith` / `endsWith` | `cb.like(...)` with proper `_`/`%`/`\`/`[` escaping (`[` guards SQL Server character classes — see Gotchas) — incl. the constant-receiver form (`"a,b".contains(R.attr.x)`: the constant is the haystack, the column the needle) |
 | `isSet(field, true/false)`       | `cb.isNotNull` / `cb.isNull`                                        |
 | `hasIntersection(coll, [values])` | Correlated `EXISTS` with `IN`                                      |
@@ -201,7 +202,6 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | `exists(coll, lambda)`           | One correlated aggregate scoring subquery (`MAX(CASE WHEN body … WHEN NOT body … ELSE …)`) whose comparison is TRUE/FALSE/UNKNOWN per the CEL truth table — see the nested-macros gotcha |
 | `exists_one(coll, lambda)`       | One correlated strict-count subquery `= 1` (NULL-poisoned when any element body is undetermined) |
 | `all(coll, lambda)`              | Same scoring subquery as `exists`, compared for "no false and no undetermined element" |
-| `except(coll, lambda)`           | Same scoring subquery as `all`, compared for "some element fails the body" |
 | `filter(coll, lambda)`           | Same as `exists` (filter returns a list — treated as "exists matching") |
 | Bare boolean variable            | `cb.equal(path, true)`                                              |
 | `eq(field, add(const1, const2))` | Constant fold then compare: `cb.equal(field, const1 ⊕ const2)`     |
@@ -250,6 +250,7 @@ the construct: rows marked **no** are rejected while resolving an operand,
 | Timestamp comparison on an ambiguous column type | `timestamp(R.attr.createdAt) < now() - duration("24h")` with `createdAt` mapped to `LocalDateTime`/`java.util.Date`/`String` | yes (the comparison operator) | The supported shape (see table above) requires an `Instant` or `OffsetDateTime` column. Other types don't pin the absolute instant they store — a wrong zone/format assumption would silently diverge from `check()`. The override receives the parsed `Instant` and can apply schema-specific knowledge. |
 | Timestamp shapes beyond `timestamp(field) vs constant` | `timestamp(R.attr.a) < timestamp(R.attr.b)`, `timestamp(...)` inside arithmetic | no | Only the leaf comparison shape the planner emits for time-window policies is translated; nested/derived shapes keep their named errors. |
 | `eq`/`ne` against a list constant               | `R.attr.tags == ["a", "b"]`                       | no          | Whole-list equality has no scalar-column translation (the plan arrives as `eq(variable, value-list)` verbatim); rejected before path resolution. Map the attribute as a Relation and use `in`/`hasIntersection`, or compare elements individually. |
+| `except` (list difference)                      | `size(R.attr.tags.except(["archived"])) > 0`      | no          | Cerbos `except(list, list)` is a two-list function (the wire shape is `except(variable, value-list)`, typically inside `size()` — PDP-verified); list difference has no JPA Criteria translation. Rewrite with an equivalent macro: `size(coll.except([...])) > 0` ≡ `coll.exists(x, !(x in [...]))`. |
 
 ## Gotchas
 
@@ -410,7 +411,7 @@ of "not set".
 
 ### Nested collection macros multiply correlated subqueries — depth is bounded
 
-Every collection macro (`exists`/`exists_one`/`all`/`filter`/`except`/
+Every collection macro (`exists`/`exists_one`/`all`/`filter`/
 `size(filter(...))`) translates to a single correlated aggregate subquery, but the
 lambda body inside it is translated once per polarity — positive and negated — because
 Hibernate 6's criteria negation is stateful and a `Predicate` tree cannot be shared
@@ -436,7 +437,7 @@ your policies intentionally nest deeper, raise the limit via a system property:
 ```
 
 The property is read per translation, must be a positive integer, and applies to
-`exists`/`exists_one`/`all`/`filter`/`except` and `size(filter(...))` nesting.
+`exists`/`exists_one`/`all`/`filter` and `size(filter(...))` nesting.
 
 ### Division by a column is guarded with `NULLIF` — zero divisors deny
 

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/AttributeMapping.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/AttributeMapping.java
@@ -1,6 +1,7 @@
 package dev.cerbos.queryplan.springdata;
 
 import java.util.Map;
+import java.util.Objects;
 
 public sealed interface AttributeMapping permits AttributeMapping.Field, AttributeMapping.Relation {
 
@@ -24,8 +25,24 @@ public sealed interface AttributeMapping permits AttributeMapping.Field, Attribu
         return new Relation(joinAttribute, defaultMemberField, fields);
     }
 
-    record Field(String jpaPath) implements AttributeMapping {}
+    record Field(String jpaPath) implements AttributeMapping {
+        public Field {
+            Objects.requireNonNull(jpaPath, "jpaPath");
+        }
+    }
 
+    /**
+     * A collection-valued mapping. {@code defaultMemberField} may be {@code null} (the joined
+     * element itself is the member value); {@code joinAttribute} and {@code fields} must not be.
+     * The {@code fields} map is defensively copied, so later mutation of the caller's map
+     * cannot silently change which columns the authorization filter resolves.
+     */
     record Relation(String joinAttribute, String defaultMemberField, Map<String, AttributeMapping> fields)
-            implements AttributeMapping {}
+            implements AttributeMapping {
+        public Relation {
+            Objects.requireNonNull(joinAttribute, "joinAttribute");
+            Objects.requireNonNull(fields, "fields");
+            fields = Map.copyOf(fields);
+        }
+    }
 }

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/PlanValues.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/PlanValues.java
@@ -55,9 +55,12 @@ final class PlanValues {
         if (left == null || right == null) {
             // Reaching here means the planner emitted `add(null, ...)` or `add(..., null)`
             // — neither side could satisfy any string/number equation, so report the shape
-            // explicitly rather than NPE'ing on `.getClass()` below.
+            // explicitly rather than NPE'ing on `.getClass()` below. Report TYPES only:
+            // plan constants can carry folded principal-attribute values (PII), and every
+            // other error site in the adapter deliberately keeps values out of messages.
             throw new IllegalArgumentException(
-                    "add requires non-null operands, got " + left + " + " + right);
+                    "add requires non-null operands, got " + typeName(left) + " + "
+                            + typeName(right));
         }
         if (left instanceof String || right instanceof String) {
             return String.valueOf(left) + String.valueOf(right);
@@ -69,7 +72,13 @@ final class PlanValues {
             return ln.doubleValue() + rn.doubleValue();
         }
         throw new IllegalArgumentException(
-                "add requires string or numeric operands, got " + left.getClass() + " + " + right.getClass());
+                "add requires string or numeric operands, got " + typeName(left) + " + "
+                        + typeName(right));
+    }
+
+    /** Type-only operand description for error messages — operand VALUES never leak. */
+    private static String typeName(Object o) {
+        return o == null ? "null" : o.getClass().getSimpleName();
     }
 
     /**

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -35,7 +35,7 @@ public final class SpringDataQueryPlanAdapter {
 
     /**
      * System property bounding collection-macro nesting depth
-     * ({@code exists}/{@code exists_one}/{@code all}/{@code filter}/{@code except}/
+     * ({@code exists}/{@code exists_one}/{@code all}/{@code filter}/
      * {@code size(filter(...))}) accepted by the translator. Each nesting level multiplies the
      * number of correlated subqueries in the translated filter (×2 for the {@code exists} family,
      * ×3 for {@code exists_one}/{@code size(filter(...))} — see the collection-macro Javadoc in
@@ -71,9 +71,14 @@ public final class SpringDataQueryPlanAdapter {
         }
         Operand condition = planResult.getCondition()
                 .orElseThrow(() -> new IllegalArgumentException("Conditional plan has no condition"));
+        // Defensive copies: the returned Specification is re-invoked fresh per query execution
+        // (see Result), so capturing the caller's maps by reference would let post-construction
+        // mutation silently change which columns the authorization filter resolves.
+        Map<String, AttributeMapping> mapperCopy = Map.copyOf(mapper);
+        Map<String, OperatorFunction> overridesCopy = Map.copyOf(overrides);
         return new Result.Conditional<>((root, query, cb) ->
-                new Translator(cb, overrides, isSelectInvocation(root, query))
-                        .traverse(condition, Scope.root(root, query, mapper)));
+                new Translator(cb, overridesCopy, isSelectInvocation(root, query))
+                        .traverse(condition, Scope.root(root, query, mapperCopy)));
     }
 
     // -- PlanResourcesResponse overloads --
@@ -96,9 +101,12 @@ public final class SpringDataQueryPlanAdapter {
                 if (cond.getNodeCase() == Operand.NodeCase.NODE_NOT_SET) {
                     throw new IllegalArgumentException("Conditional plan has no condition");
                 }
+                // Defensive copies — same rationale as the PlanResourcesResult overload.
+                Map<String, AttributeMapping> mapperCopy = Map.copyOf(mapper);
+                Map<String, OperatorFunction> overridesCopy = Map.copyOf(overrides);
                 yield new Result.Conditional<T>((root, query, cb) ->
-                        new Translator(cb, overrides, isSelectInvocation(root, query))
-                                .traverse(cond, Scope.root(root, query, mapper)));
+                        new Translator(cb, overridesCopy, isSelectInvocation(root, query))
+                                .traverse(cond, Scope.root(root, query, mapperCopy)));
             }
             default -> throw new IllegalArgumentException("Unknown filter kind: " + filter.getKind());
         };
@@ -196,6 +204,38 @@ public final class SpringDataQueryPlanAdapter {
             return applyLeaf("eq", path, true);
         }
 
+        /**
+         * The shared named error for Cerbos {@code except()} — a two-list function
+         * ({@code list.except(list)}) whose list-difference result has no JPA Criteria
+         * translation. PDP-verified arrival shapes: inside {@code size()}
+         * ({@code gt(size(except(variable, value-list)), 0)}) and as a comparison operand
+         * ({@code eq(except(variable, value-list), value-list)}).
+         */
+        private static IllegalArgumentException exceptUnsupported() {
+            return new IllegalArgumentException(
+                    "except is not supported: Cerbos except(list, list) computes a list "
+                            + "difference, which has no JPA Criteria translation. Rewrite the "
+                            + "policy with a collection macro instead — e.g. "
+                            + "size(R.attr.tags.except([\"x\"])) > 0 is equivalent to "
+                            + "R.attr.tags.exists(t, !(t in [\"x\"])).");
+        }
+
+        /**
+         * Shape-only description of an operand for error messages: node case plus the attribute
+         * name (VARIABLE) or inner operator (EXPRESSION). Constant VALUES report their type
+         * only — never their content — matching the adapter's no-value-leak discipline.
+         */
+        private static String describeOperand(Operand o) {
+            return switch (o.getNodeCase()) {
+                case VARIABLE -> "VARIABLE '" + o.getVariable() + "'";
+                case EXPRESSION -> "EXPRESSION " + o.getExpression().getOperator() + "()";
+                // The protobuf kind, not the converted value: conversion could itself throw on
+                // a malformed VALUE, and this helper must stay safe inside error paths.
+                case VALUE -> "VALUE (" + o.getValue().getKindCase() + ")";
+                default -> o.getNodeCase().toString();
+            };
+        }
+
         private Predicate traverseExpression(PlanResourcesFilter.Expression expression, Scope scope) {
             String op = expression.getOperator();
             List<Operand> operands = expression.getOperandsList();
@@ -211,8 +251,15 @@ public final class SpringDataQueryPlanAdapter {
                     }
                     yield tri.not(traverse(operands.get(0), scope));
                 }
-                case "exists", "exists_one", "all", "except", "filter" ->
+                case "exists", "exists_one", "all", "filter" ->
                         handleCollectionOperator(op, operands, scope);
+                // Cerbos except() is a two-list function — PDP-verified wire shape:
+                // size(R.attr.tags.except(["archived"])) > 0 arrives as
+                // gt(size(except(variable, value-list)), 0). No lambda form exists on the wire
+                // (a previous lambda-except translation here was unreachable from any real
+                // plan), and list difference has no JPA Criteria translation — fail closed
+                // with a named error instead.
+                case "except" -> throw exceptUnsupported();
                 // has_intersection is the deprecated pre-camelCase alias still accepted by the PDP.
                 case "hasIntersection", "has_intersection" -> handleHasIntersection(operands, scope);
                 case "isSet" -> handleIsSet(operands, scope);
@@ -401,15 +448,18 @@ public final class SpringDataQueryPlanAdapter {
                     return ternaryPred;
                 }
                 NormalizedBinary nb = NormalizedBinary.of(op, operands);
-                Predicate sizePred = trySizeComparison(nb.op(), nb.operands(), scope);
-                if (sizePred != null) {
-                    return sizePred;
-                }
                 // Every leaf operator is binary. Extra operands are a malformed plan and must
-                // fail loudly rather than silently dropping one.
+                // fail loudly rather than silently dropping one — BEFORE the size() probe,
+                // whose last-match-wins operand scan would otherwise translate a partial
+                // comparison (e.g. eq(size(coll), variable, value) as COUNT = value, silently
+                // discarding the variable constraint).
                 if (nb.operands().size() != 2) {
                     throw new IllegalArgumentException(
                             nb.op() + " requires exactly 2 operands, got " + nb.operands().size());
+                }
+                Predicate sizePred = trySizeComparison(nb.op(), nb.operands(), scope);
+                if (sizePred != null) {
+                    return sizePred;
                 }
                 return dispatch(nb.op(),
                         resolve(nb.operands().get(0)),
@@ -1014,7 +1064,13 @@ public final class SpringDataQueryPlanAdapter {
                     }
                 }
                 if (otherOperand == null) {
-                    throw new IllegalArgumentException("add comparison requires a second operand");
+                    // Both operands are add() expressions — there IS a second operand, it just
+                    // isn't a scalar to fold against, so say that instead of misreporting arity.
+                    throw new IllegalArgumentException(
+                            op + " between two add() expressions is not supported: got "
+                                    + describeOperand(operands.get(0)) + " and "
+                                    + describeOperand(operands.get(1))
+                                    + "; one operand must be a mapped attribute or constant");
                 }
                 List<Operand> addOperands = addExprOperand.getExpression().getOperandsList();
                 if (addOperands.size() != 2) {
@@ -1061,6 +1117,11 @@ public final class SpringDataQueryPlanAdapter {
                                         "Direct comparison of map(...) to a value is not supported "
                                                 + "(operator: " + op + "). Wrap the map() expression in "
                                                 + "hasIntersection(map(...), [...]) instead.");
+                            }
+                            // eq(except(variable, value-list), value-list) — the comparison
+                            // form of the two-list except() (PDP-verified wire shape).
+                            if ("except".equals(innerOp)) {
+                                throw exceptUnsupported();
                             }
                             throw new IllegalArgumentException(
                                     "Unexpected " + innerOp + "() expression in leaf operand of " + op);
@@ -1530,7 +1591,9 @@ public final class SpringDataQueryPlanAdapter {
                 }
                 List<Operand> sizeOps = sizeExpr.getOperandsList();
                 if (sizeOps.size() != 1) {
-                    throw new IllegalArgumentException("Unsupported size() expression");
+                    throw new IllegalArgumentException(
+                            "Unsupported size() expression: size() takes exactly 1 argument, got "
+                                    + sizeOps.size());
                 }
                 Operand sizeArg = sizeOps.get(0);
                 String var;
@@ -1553,8 +1616,16 @@ public final class SpringDataQueryPlanAdapter {
                             "lambda requires exactly 2 operands");
                     lambdaBody = lambda.body();
                     lambdaVarName = lambda.varName();
+                } else if (sizeArg.getNodeCase() == Operand.NodeCase.EXPRESSION
+                        && "except".equals(sizeArg.getExpression().getOperator())) {
+                    // size(coll.except([...])) — the PDP-verified wire shape of every real
+                    // except() policy. List difference has no JPA translation; the shared
+                    // named error points at the equivalent exists(...) rewrite.
+                    throw exceptUnsupported();
                 } else {
-                    throw new IllegalArgumentException("Unsupported size() expression");
+                    throw new IllegalArgumentException(
+                            "Unsupported size() expression: size() argument must be a collection "
+                                    + "attribute or filter(...), got " + describeOperand(sizeArg));
                 }
                 Scope.ResolvedRelation ref = scope.resolveRelation(var);
                 if (ref == null) {
@@ -1693,7 +1764,10 @@ public final class SpringDataQueryPlanAdapter {
                 }
             }
             if (variable == null || flag == null) {
-                throw new IllegalArgumentException("Invalid isSet operands");
+                throw new IllegalArgumentException(
+                        "Invalid isSet operands: expected one attribute variable and one boolean "
+                                + "value, got " + describeOperand(operands.get(0)) + " / "
+                                + describeOperand(operands.get(1)));
             }
             Path<?> path = scope.resolvePath(variable);
             boolean isSet = flag;
@@ -1722,10 +1796,20 @@ public final class SpringDataQueryPlanAdapter {
             List<Operand> operands = NormalizedBinary.of("in", rawOperands).operands();
             Operand fieldOp = operands.get(0);
             Operand valueOp = operands.get(1);
+            // in(variable, variable) — attribute-in-attribute membership
+            // (`R.attr.createdBy in R.attr.ownedBy` arrives verbatim; PDP-verified). CEL `in`
+            // is receiver-shaped — the member is always FIRST, the list second — and two
+            // VARIABLE operands rank equally so normalization never swaps them: source order
+            // is authoritative here.
+            if (fieldOp.getNodeCase() == Operand.NodeCase.VARIABLE
+                    && valueOp.getNodeCase() == Operand.NodeCase.VARIABLE) {
+                return handleInVariableVariable(fieldOp.getVariable(), valueOp.getVariable(), scope);
+            }
             if (fieldOp.getNodeCase() != Operand.NodeCase.VARIABLE
                     || valueOp.getNodeCase() != Operand.NodeCase.VALUE) {
                 throw new IllegalArgumentException("Unsupported in operand combination: "
-                        + rawOperands.get(0).getNodeCase() + "/" + rawOperands.get(1).getNodeCase());
+                        + describeOperand(rawOperands.get(0)) + " / "
+                        + describeOperand(rawOperands.get(1)));
             }
             String var = fieldOp.getVariable();
             Object val = PlanValues.protoValueToJava(valueOp.getValue());
@@ -1749,6 +1833,62 @@ public final class SpringDataQueryPlanAdapter {
                     return cb.isNull(path);
                 }
                 return cb.equal(path, val);
+            });
+        }
+
+        /**
+         * {@code in(variable, variable)} — a scalar attribute tested for membership of a
+         * collection attribute on the SAME resource ({@code R.attr.createdBy in
+         * R.attr.ownedBy}; PDP-verified the shape arrives verbatim). The member variable must
+         * resolve to a scalar column and the collection variable to a Relation mapping; the
+         * translation is a correlated EXISTS whose body compares the collection's member
+         * column against the outer scalar column:
+         *
+         * <pre>{@code EXISTS (SELECT 1 FROM <relation chain> e
+         *          WHERE e.member = outer.scalar
+         *             OR (e.member IS NULL AND outer.scalar IS NULL))}</pre>
+         *
+         * <p>Null semantics, verified against a live PDP {@code check()} oracle under the
+         * adapter's established column conventions (a NULL scalar column is the
+         * explicitly-null attribute — the {@code eq(x, null) → IS NULL} convention; a NULL
+         * member column is an explicit null list element — the {@code collectionContainsAny}
+         * convention; an empty join is the empty list):
+         * <ul>
+         *   <li>member matches an element → TRUE (row included);</li>
+         *   <li>no match (including the empty collection) → the EXISTS is FALSE, so the row
+         *       is excluded and {@code not(...)} includes it — matching CEL, where a
+         *       non-matching {@code in} is plain FALSE, not an error;</li>
+         *   <li>NULL scalar vs a null element → TRUE ({@code null in [..., null]} is TRUE in
+         *       CEL — the IS NULL conjunct is what matches it, since SQL {@code = NULL} never
+         *       does);</li>
+         *   <li>NULL scalar vs no null element → FALSE (the equality is UNKNOWN and the
+         *       IS NULL conjunct fails on the member side, so no subquery row qualifies).</li>
+         * </ul>
+         * EXISTS itself is two-valued, so {@code tri.not} composes exactly. Like field-to-field
+         * comparisons, there is no (field, value) pair — {@link OperatorFunction} overrides are
+         * not consulted.
+         */
+        private Predicate handleInVariableVariable(String memberVar, String collectionVar,
+                                                   Scope scope) {
+            Scope.ResolvedRelation ref = scope.resolveRelation(collectionVar);
+            if (ref == null) {
+                scope.resolveMapping(collectionVar); // throws "Unknown attribute" when unmapped
+                throw new IllegalArgumentException(
+                        "in(" + memberVar + ", " + collectionVar + ") requires the second "
+                                + "attribute to be mapped as a Relation (collection membership), "
+                                + "but " + collectionVar + " resolves to a scalar Field mapping");
+            }
+            // Resolve the member OUTSIDE the subquery first so an unknown/Relation-valued
+            // member reports its own resolution error rather than a subquery-build failure.
+            scope.resolvePath(memberVar);
+            return existsSubquery(scope, ref, (sub, tailJoin, rebased) -> {
+                Path<?> element = Scope.memberPath(tailJoin, ref.tail(), null);
+                // The outer scalar resolves through the REBASED scope so the produced path is
+                // a legal correlation reference inside the subquery.
+                Path<?> outer = rebased.resolvePath(memberVar);
+                return cb.or(
+                        cb.equal(element, outer),
+                        cb.and(cb.isNull(element), cb.isNull(outer)));
             });
         }
 
@@ -1817,7 +1957,10 @@ public final class SpringDataQueryPlanAdapter {
             }
 
             throw new IllegalArgumentException(
-                    "Unsupported hasIntersection operand shape: " + first.getNodeCase());
+                    "Unsupported hasIntersection operand shape: " + describeOperand(first) + " / "
+                            + describeOperand(second) + ". Supported shapes are "
+                            + "hasIntersection(collection-attribute, [values...]) and "
+                            + "hasIntersection(map(collection, lambda), [values...]).");
         }
 
         /** A parsed CEL lambda operand: its body and the name of its iteration variable. */
@@ -1941,7 +2084,7 @@ public final class SpringDataQueryPlanAdapter {
             });
         }
 
-        // -- exists / exists_one / all / except / filter --
+        // -- exists / exists_one / all / filter --
 
         /**
          * Collection macros translate TRI-STATE to mirror CEL error semantics (per the cel-spec
@@ -1962,10 +2105,10 @@ public final class SpringDataQueryPlanAdapter {
          * correlated aggregate subquery that scores every element into determined-true /
          * determined-false / undetermined and folds the scores into one value whose comparison
          * is TRUE, FALSE, or SQL UNKNOWN exactly per the CEL truth table — see
-         * {@link #macroScoreSubquery} (exists/all/filter/except) and
+         * {@link #macroScoreSubquery} (exists/all/filter) and
          * {@link #strictMatchCountSubquery} (exists_one).
          *
-         * <p>{@code filter}/{@code except} in boolean position are kept consistent with the
+         * <p>{@code filter} in boolean position is kept consistent with the
          * {@code exists} family. Cost note: the unknown machinery is always emitted — the
          * attribute mapping carries no column-nullability metadata, so a NULL-free lambda body
          * cannot be detected statically. The lambda body is translated once per polarity
@@ -2021,10 +2164,6 @@ public final class SpringDataQueryPlanAdapter {
                 // undetermined (max score 1 → NULLIF yields SQL NULL); FALSE otherwise.
                 case "exists", "filter" ->
                         cb.equal(macroScoreSubquery(scope, ref, bodyBuilder, 2, 0), 2);
-                // except is "some element fails the body" — the exists table with the false
-                // witness in the true seat; an UNKNOWN body is UNKNOWN under NOT too.
-                case "except" ->
-                        cb.equal(macroScoreSubquery(scope, ref, bodyBuilder, 0, 2), 2);
                 // all: AND with error absorption — FALSE iff any element is determined-false
                 // (max score 2 absorbs undetermined siblings); UNKNOWN iff none is false but at
                 // least one is undetermined; TRUE otherwise (including the empty collection).
@@ -2041,7 +2180,7 @@ public final class SpringDataQueryPlanAdapter {
 
         /**
          * The single-subquery scoring translation shared by {@code exists}/{@code filter}
-         * (score 2/0), {@code all} and {@code except} (score 0/2). Each element of the relation
+         * (score 2/0) and {@code all} (score 0/2). Each element of the relation
          * chain is scored with a searched CASE:
          *
          * <pre>{@code CASE WHEN body THEN trueScore WHEN NOT body THEN falseScore ELSE 1 END}</pre>
@@ -2054,7 +2193,7 @@ public final class SpringDataQueryPlanAdapter {
          *
          * i.e. the dominant score with the empty collection folded to 0 and the
          * "only undetermined elements dominate" state (max score 1) mapped to SQL NULL. A
-         * two-valued equality against 2 (exists/except) or 0 (all) then yields TRUE / FALSE /
+         * two-valued equality against 2 (exists) or 0 (all) then yields TRUE / FALSE /
          * UNKNOWN exactly per the CEL macro truth tables, and {@code NOT} keeps UNKNOWN rows
          * excluded ({@code NOT(UNKNOWN) = UNKNOWN}).
          *

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -190,7 +190,15 @@ class AdversarialConformanceTest {
             // an UNESCAPED '[SEC]%' would match "Secret" (one character from {S,E,C}); it
             // must never match on any dialect.
             new Seed("d1", true, "[SEC]ret", 13, "[SEC]", List.of(), List.of()),
-            new Seed("d2", false, "Secret", 14, "xSECy", List.of(), List.of())
+            new Seed("d2", false, "Secret", 14, "xSECy", List.of(), List.of()),
+            // in(variable, variable) null-null witness: owner (aOptionalString) is NULL —
+            // an EXPLICIT null on the check side — and the single tag's name column is NULL,
+            // an explicit null element of tagNames. CEL `null in [null]` is TRUE, so the
+            // in-var-var action must INCLUDE this row (EXISTS(member IS NULL AND scalar
+            // IS NULL)); like b5 it also exercises the macro error convention (a NULL tag
+            // name is a missing element attribute for lambda bodies).
+            new Seed("e1", true, "nullowner", 15, null,
+                    List.of(new Tag("te1", null)), List.of())
     );
 
     /**
@@ -686,6 +694,11 @@ class AdversarialConformanceTest {
             "in-null-elem-only", "in-null-elem-only-neg",
             "in-null-elem-rel", "in-null-elem-rel-neg",
             "in-null-elem-hasint",
+            // in(variable, variable): attribute-in-attribute membership via correlated
+            // EXISTS (member column = outer scalar column, NULL-null matching). Witnesses:
+            // a9/b4 match, e1 null-in-[null] (allow), a4/a8 null scalar vs non-null
+            // elements (deny; the negation allows), empty collections under the negation.
+            "in-var-var", "in-var-var-neg",
     })
     void adapterMatchesCheckOracle(String action) {
         List<String> oracle = oracleAllowedIds(action);

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -687,12 +687,48 @@ class SpringDataQueryPlanAdapterTest {
                         exprOp("eq", var("t.name"), sval("public"))))));
     }
 
+    // -- except: a two-list function with no JPA translation — every arrival shape throws --
+    //
+    // PDP-verified wire shapes (Cerbos latest, 2026-07): `size(R.attr.tags.except(["archived"]))
+    // > 0` arrives as gt(size(except(variable, value-list)), 0), and `R.attr.tags.except(
+    // ["archived"]) == []` as eq(except(variable, value-list), value-list). except NEVER
+    // arrives with a lambda operand — a previous lambda-except translation here was
+    // unreachable from any real plan and has been removed.
+
     @Test
-    void exceptOnNestedRelation() {
-        assertEquals(0, runCount(exprOp("except",
-                var("request.resource.attr.tags"),
-                lambda("t",
-                        exprOp("eq", var("t.name"), sval("public"))))));
+    void sizeOfExceptThrowsNamedError() {
+        assertConditionThrows(
+                exprOp("gt",
+                        exprOp("size",
+                                exprOp("except",
+                                        var("request.resource.attr.tags"), listOp("archived"))),
+                        nval(0)),
+                "except is not supported", "except(list, list)", "exists");
+    }
+
+    @Test
+    void exceptComparedToListThrowsNamedError() {
+        assertConditionThrows(
+                exprOp("eq",
+                        exprOp("except",
+                                var("request.resource.attr.tags"), listOp("archived")),
+                        listOp()),
+                "except is not supported", "except(list, list)");
+    }
+
+    @Test
+    void bareExceptThrowsNamedError() {
+        // Top-level except in boolean position — including the old synthetic lambda shape —
+        // must fail closed with the named error, not translate invented semantics.
+        assertConditionThrows(
+                exprOp("except",
+                        var("request.resource.attr.tags"),
+                        lambda("t", exprOp("eq", var("t.name"), sval("public")))),
+                "except is not supported", "except(list, list)");
+        assertConditionThrows(
+                exprOp("except",
+                        var("request.resource.attr.tags"), listOp("archived")),
+                "except is not supported", "except(list, list)");
     }
 
     @Test
@@ -1612,10 +1648,8 @@ class SpringDataQueryPlanAdapterTest {
         }
 
         @Test
-        void filterAndExceptFollowExistsFamilySemantics() {
+        void filterFollowsExistsFamilySemantics() {
             Operand filterPublic = exprOp("filter", var("request.resource.attr.tags"),
-                    lambda("t", exprOp("eq", var("t.name"), sval("public"))));
-            Operand exceptPublic = exprOp("except", var("request.resource.attr.tags"),
                     lambda("t", exprOp("eq", var("t.name"), sval("public"))));
 
             ResourceEntity r = new ResourceEntity("null-elem-fe-1");
@@ -1623,8 +1657,6 @@ class SpringDataQueryPlanAdapterTest {
             withResource(r, () -> {
                 assertEquals(0, runCount(filterPublic));
                 assertEquals(0, runCount(exprOp("not", filterPublic)));
-                assertEquals(0, runCount(exceptPublic));
-                assertEquals(0, runCount(exprOp("not", exceptPublic)));
             });
         }
 
@@ -3165,6 +3197,188 @@ class SpringDataQueryPlanAdapterTest {
         }
     }
 
+    /**
+     * {@code in(variable, variable)} — attribute-in-attribute membership. PDP-verified wire
+     * shape (Cerbos latest, 2026-07): {@code R.attr.createdBy in R.attr.ownedBy} arrives as
+     * {@code in(variable, variable)} verbatim, member first. Translated as a correlated EXISTS
+     * comparing the collection's member column to the outer scalar column, with a NULL scalar
+     * matching a NULL member element (CEL {@code null in [..., null]} is TRUE — check()
+     * verified for every branch below; see the translator Javadoc for the truth table).
+     */
+    @Nested
+    class InVariableVariable {
+
+        private Operand inVarVar() {
+            return exprOp("in",
+                    var("request.resource.attr.createdBy"),
+                    var("request.resource.attr.ownedBy"));
+        }
+
+        @Test
+        void memberMatchingElementIncludesRow() {
+            ResourceEntity r = new ResourceEntity("ivv-1");
+            r.setCreatedBy("alice");
+            r.setOwnedBy(new ArrayList<>(List.of("alice", "bob")));
+            withResource(r, () -> {
+                assertEquals(1, runCount(inVarVar()));
+                assertEquals(0, runCount(exprOp("not", inVarVar())));
+            });
+        }
+
+        @Test
+        void memberNotInCollectionExcludesRowAndNegationIncludesIt() {
+            ResourceEntity r = new ResourceEntity("ivv-2");
+            r.setCreatedBy("carol");
+            r.setOwnedBy(new ArrayList<>(List.of("alice", "bob")));
+            withResource(r, () -> {
+                assertEquals(0, runCount(inVarVar()));
+                assertEquals(1, runCount(exprOp("not", inVarVar())));
+            });
+        }
+
+        @Test
+        void emptyCollectionExcludesRowAndNegationIncludesIt() {
+            // CEL: `x in []` is FALSE (not an error) — check() verified: deny, negation allows.
+            ResourceEntity r = new ResourceEntity("ivv-3");
+            r.setCreatedBy("alice");
+            withResource(r, () -> {
+                assertEquals(0, runCount(inVarVar()));
+                assertEquals(1, runCount(exprOp("not", inVarVar())));
+            });
+        }
+
+        private Operand optInTagNames() {
+            return exprOp("in",
+                    var("request.resource.attr.aOptionalString"),
+                    var("request.resource.attr.tagNames"));
+        }
+
+        @Test
+        void nullScalarMatchesNullElement() {
+            // check() verified: `null in ["a", null]` is TRUE under the explicit-null
+            // conventions the adapter's other null translations already pin.
+            ResourceEntity r = new ResourceEntity("ivv-4");
+            r.setaOptionalString(null);
+            r.addTag("ivv4a", null);
+            r.addTag("ivv4b", "a");
+            withResource(r, () -> {
+                assertEquals(1, runCount(optInTagNames()));
+                assertEquals(0, runCount(exprOp("not", optInTagNames())));
+            });
+        }
+
+        @Test
+        void nullScalarWithoutNullElementExcludesRowAndNegationIncludesIt() {
+            // check() verified: `null in ["a", "b"]` is FALSE (not an error) — deny under
+            // `in`, allow under the negation.
+            ResourceEntity r = new ResourceEntity("ivv-5");
+            r.setaOptionalString(null);
+            r.addTag("ivv5a", "a");
+            withResource(r, () -> {
+                assertEquals(0, runCount(optInTagNames()));
+                assertEquals(1, runCount(exprOp("not", optInTagNames())));
+            });
+        }
+
+        @Test
+        void scalarSecondOperandThrowsNamedError() {
+            assertConditionThrows(
+                    exprOp("in",
+                            var("request.resource.attr.aString"),
+                            var("request.resource.attr.createdBy")),
+                    "request.resource.attr.createdBy", "Relation", "scalar Field mapping");
+        }
+
+        @Test
+        void unknownCollectionAttributeThrows() {
+            assertConditionThrows(
+                    exprOp("in",
+                            var("request.resource.attr.aString"),
+                            var("request.resource.attr.nonexistent")),
+                    "Unknown attribute");
+        }
+    }
+
+    /**
+     * Defensive copies (API hardening): {@code AttributeMapping} records validate and copy at
+     * construction, and {@code toSpecification} captures copies of the caller's maps — so
+     * post-construction mutation cannot silently change which columns the authorization filter
+     * resolves.
+     */
+    @Nested
+    class DefensiveCopies {
+
+        @Test
+        void nullConstructorArgumentsThrowNamedNpe() {
+            NullPointerException f = assertThrows(NullPointerException.class,
+                    () -> AttributeMapping.field(null));
+            assertTrue(f.getMessage().contains("jpaPath"), "message: " + f.getMessage());
+
+            NullPointerException j = assertThrows(NullPointerException.class,
+                    () -> new AttributeMapping.Relation(null, null, Map.of()));
+            assertTrue(j.getMessage().contains("joinAttribute"), "message: " + j.getMessage());
+
+            NullPointerException fields = assertThrows(NullPointerException.class,
+                    () -> new AttributeMapping.Relation("tags", null, null));
+            assertTrue(fields.getMessage().contains("fields"), "message: " + fields.getMessage());
+        }
+
+        @Test
+        void relationFieldsMapIsCopiedAndImmutable() {
+            java.util.HashMap<String, AttributeMapping> fields = new java.util.HashMap<>();
+            fields.put("name", AttributeMapping.field("name"));
+            AttributeMapping.Relation rel = AttributeMapping.relation("tags", fields);
+
+            fields.put("name", AttributeMapping.field("id"));
+            assertEquals(AttributeMapping.field("name"), rel.fields().get("name"),
+                    "mutating the caller's fields map must not affect the Relation");
+            assertThrows(UnsupportedOperationException.class,
+                    () -> rel.fields().put("x", AttributeMapping.field("x")));
+        }
+
+        @Test
+        void mutatingCallerMapperAfterToSpecificationDoesNotAffectSpecification() {
+            // aString and aOptionalString hold different values, so a re-resolved column
+            // is observable as a changed row set.
+            ResourceEntity r = new ResourceEntity("copy-1");
+            r.setaString("match");
+            r.setaOptionalString("other");
+            withResource(r, () -> {
+                java.util.HashMap<String, AttributeMapping> mapper = new java.util.HashMap<>();
+                mapper.put("request.resource.attr.aString", AttributeMapping.field("aString"));
+                Operand cond = exprOp("eq", var("request.resource.attr.aString"), sval("match"));
+                PlanResourcesResponse resp =
+                        buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, cond);
+                Result<ResourceEntity> result =
+                        SpringDataQueryPlanAdapter.toSpecification(resp, mapper);
+                Specification<ResourceEntity> spec =
+                        ((Result.Conditional<ResourceEntity>) result).specification();
+
+                assertEquals(1, countWithSpec(spec));
+                // Redirect the attribute at a different column AFTER construction: the
+                // Specification (re-invoked fresh per execution) must keep the original mapping.
+                mapper.put("request.resource.attr.aString", AttributeMapping.field("aOptionalString"));
+                assertEquals(1, countWithSpec(spec),
+                        "post-construction mapper mutation changed the captured Specification");
+            });
+        }
+
+        private int countWithSpec(Specification<ResourceEntity> spec) {
+            EntityManager em = emf.createEntityManager();
+            try {
+                CriteriaBuilder cb = em.getCriteriaBuilder();
+                CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+                Root<ResourceEntity> root = cq.from(ResourceEntity.class);
+                cq.select(cb.count(root));
+                Predicate p = spec.toPredicate(root, cq, cb);
+                if (p != null) cq.where(p);
+                return em.createQuery(cq).getSingleResult().intValue();
+            } finally {
+                em.close();
+            }
+        }
+    }
+
     // -- Leaf operand-count guard: extra operands must fail loudly, not drop silently --
 
     @Test
@@ -3177,6 +3391,117 @@ class SpringDataQueryPlanAdapterTest {
                         var("request.resource.attr.createdBy"),
                         sval("x")),
                 "eq", "2 operands");
+    }
+
+    @Test
+    void sizeComparisonWithExtraOperandThrows() {
+        // The size() probe used to run BEFORE the arity guard and scan operands
+        // last-match-wins: a malformed eq(size(tags), variable, value) translated to
+        // COUNT(tags) = value, silently discarding the variable constraint. The guard now
+        // fires first, so the size() path shares the loud-failure contract of plain leaves.
+        assertConditionThrows(
+                exprOp("eq",
+                        exprOp("size", var("request.resource.attr.tags")),
+                        var("request.resource.attr.aString"),
+                        nval(2)),
+                "eq", "2 operands");
+    }
+
+    // -- Error-message context and the no-value-leak discipline --
+
+    @Test
+    void foldAddNullOperandErrorDoesNotLeakConstantValues() {
+        // eq(field, add(null, "<folded principal attr>")) — PDP-reachable when a policy
+        // concatenates principal attributes and one is null: the folded value can carry PII
+        // and consuming apps log translation errors at ERROR. The message must report operand
+        // TYPES only, never the values.
+        Operand cond = exprOp("eq",
+                var("request.resource.attr.aString"),
+                exprOp("add", nullVal(), sval("canary-secret-value")));
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> runCount(cond));
+        assertTrue(ex.getMessage().contains("add requires non-null operands"),
+                "unexpected message: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("null") && ex.getMessage().contains("String"),
+                "expected operand types in message: " + ex.getMessage());
+        assertFalse(ex.getMessage().contains("canary-secret-value"),
+                "constant value leaked into the error message: " + ex.getMessage());
+
+        // Mirrored shape: the null on the right.
+        IllegalArgumentException ex2 = assertThrows(IllegalArgumentException.class,
+                () -> runCount(exprOp("eq",
+                        var("request.resource.attr.aString"),
+                        exprOp("add", sval("canary-secret-value"), nullVal()))));
+        assertFalse(ex2.getMessage().contains("canary-secret-value"),
+                "constant value leaked into the error message: " + ex2.getMessage());
+    }
+
+    @Test
+    void bothOperandsAddExpressionsReportsShapeNotArity() {
+        // contains(add(...), add(...)): there ARE two operands — the old message
+        // ("add comparison requires a second operand") misstated the problem as arity.
+        assertConditionThrows(
+                exprOp("contains",
+                        exprOp("add", sval("a"), sval("b")),
+                        exprOp("add", sval("c"), sval("d"))),
+                "contains", "two add() expressions");
+    }
+
+    @Test
+    void invalidIsSetOperandsReportBothNodeCases() {
+        // Missing boolean flag (two variables): the bare "Invalid isSet operands" gave an
+        // on-call engineer nothing; the message must describe both operands.
+        assertConditionThrows(
+                exprOp("isSet",
+                        var("request.resource.attr.aString"),
+                        var("request.resource.attr.createdBy")),
+                "Invalid isSet operands",
+                "VARIABLE 'request.resource.attr.aString'",
+                "VARIABLE 'request.resource.attr.createdBy'");
+        // Missing variable (two booleans).
+        assertConditionThrows(
+                exprOp("isSet", bval(true), bval(false)),
+                "Invalid isSet operands", "VALUE (BOOL_VALUE)");
+    }
+
+    @Test
+    void hasIntersectionVariableVariableReportsBothOperands() {
+        // The PDP can emit hasIntersection(variable, variable); the error must name BOTH
+        // operands (the old message printed only the first node case — "VARIABLE" — which is
+        // individually a supported shape) and point at the supported shapes.
+        assertConditionThrows(
+                exprOp("hasIntersection",
+                        var("request.resource.attr.tagNames"),
+                        var("request.resource.attr.ownedBy")),
+                "VARIABLE 'request.resource.attr.tagNames'",
+                "VARIABLE 'request.resource.attr.ownedBy'",
+                "Supported shapes");
+    }
+
+    @Test
+    void sizeArityErrorReportsOperandCount() {
+        assertConditionThrows(
+                exprOp("gt",
+                        exprOp("size",
+                                var("request.resource.attr.tags"),
+                                var("request.resource.attr.tagNames")),
+                        nval(0)),
+                "size() takes exactly 1 argument, got 2");
+    }
+
+    @Test
+    void sizeBadArgumentErrorNamesTheOffendingShape() {
+        assertConditionThrows(
+                exprOp("gt", exprOp("size", sval("x")), nval(0)),
+                "size() argument must be a collection attribute or filter(...)",
+                "VALUE (STRING_VALUE)");
+        assertConditionThrows(
+                exprOp("gt",
+                        exprOp("size", exprOp("map",
+                                var("request.resource.attr.tags"), lambda("t", var("t.name")))),
+                        nval(0)),
+                "size() argument must be a collection attribute or filter(...)",
+                "EXPRESSION map()");
     }
 
     // -- Arithmetic (add/sub/mult/div) as a comparison operand --

--- a/spring-data/src/test/resources/adversarial-policy.yaml
+++ b/spring-data/src/test/resources/adversarial-policy.yaml
@@ -1024,6 +1024,28 @@ resourcePolicy:
         match:
           expr: 'hasIntersection(R.attr.tagNames, ["public", null])'
 
+    # ==================== in(variable, variable) ====================
+    # Attribute-in-attribute membership: the planner emits in(variable, variable) VERBATIM,
+    # member first (PDP-verified). `owner` is the explicit-null scalar convention and
+    # `tagNames` projects tags.name with NULL names as explicit null elements, so the seeds
+    # exercise every check()-verified branch: match (a9/b4 "same"/"mirror"), no match, empty
+    # collection (`x in []` is false — negation allows), null scalar vs null element
+    # (e1: `null in [null]` is TRUE), and null scalar without a null element (a4/a8:
+    # false — negation allows).
+    - actions: ["in-var-var"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.owner in R.attr.tagNames'
+
+    - actions: ["in-var-var-neg"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!(R.attr.owner in R.attr.tagNames)'
+
     # ==================== depth-3 nested collection macros ====================
     # Three macro levels (categories → subCategories → labels). Pins that the single-
     # subquery-per-polarity macro translation preserves tri-state semantics through deep


### PR DESCRIPTION
Fixes findings 15, 16, 17, 21, 23, 24 (of 28) from an internal adversarial review of the spring-data adapter — six small, related low-severity items combined into one error/API-hygiene sweep.

## Per-finding summary

| # | Finding | Outcome | What changed | Evidence |
|---|---------|---------|--------------|----------|
| 15 | `in(variable, variable)` (attribute-in-attribute membership) planner-emitted but threw pre-override | **Implemented** | Correlated `EXISTS` comparing the collection member column to the outer scalar column, with a NULL-null match conjunct (CEL `null in [..., null]` is true) | Wire shape + all null/missing edge branches verified against a scratch PDP `check()` oracle (member match / no match / empty list / null-vs-null / null-vs-non-null, both polarities). New differential-oracle actions `in-var-var` / `in-var-var-neg` + null-null seed witness `e1`; 7 new unit tests |
| 16 | `except` implemented only for a lambda shape the planner never emits | **Fixed** (unreachable branch removed, documented unsupported) | PDP-verified: `except` is a two-list function — `size(R.attr.tags.except(["x"])) > 0` arrives as `gt(size(except(variable, value-list)), 0)`, `.except(...) == []` as `eq(except(...), value-list)`. The lambda branch is deleted; every arrival shape (inside `size()`, as a comparison operand, top-level) throws one named error pointing at the equivalent `exists(x, !(x in [...]))` rewrite. Unit tests rebuilt from the real wire shapes; README moved `except` from Supported to Not-yet-supported |
| 17 | `size()` comparisons bypassed the 2-operand arity guard | **Fixed** | Guard moved ahead of the size() probe, whose last-match-wins scan silently discarded extra operands (`eq(size(coll), variable, value)` translated as `COUNT = value`) | `sizeComparisonWithExtraOperandThrows` — fails on old code (old code silently translated) |
| 21 | `foldAdd` error stringified operand VALUES (the one value-leaking exception site; PDP-reachable via folded principal attrs) | **Fixed** | Message reports operand types only (`null + String`), matching every other error site | Canary test asserts the constant value does NOT appear in the message (both operand orders) — fails on old code |
| 23 | `AttributeMapping` records neither validate nor copy; `toSpecification` captured caller maps by reference | **Fixed** | Compact constructors with `Objects.requireNonNull` (named params) + `Map.copyOf` in `Field`/`Relation`; `Map.copyOf` of mapper/overrides in both `toSpecification` overload chains. Signatures unchanged — validation is additive | Tests: post-construction mutation of a caller `HashMap` no longer affects a captured Specification; null args throw NPE naming the parameter; `fields()` immutable |
| 24 | Four low-context error messages | **Fixed** | (1) both-operands-add no longer misreported as missing arity; (2) `hasIntersection` shape error names BOTH operands + supported shapes; (3) `isSet` error describes both operands; (4) both bare `"Unsupported size() expression"` sites now report arity or the offending inner shape. New shared `describeOperand` helper reports node case + attribute name / inner operator — VALUE constants report their protobuf kind only (no value leak) | 5 new message-pinning tests, all failing on old code |

Nothing was found already-resolved by intervening work: all six findings still reproduced on current `main` (re-located by symbol after #287/#288) before fixing.

## Verification

- **Scratch PDP** (throwaway container, removed after): wire shapes for `in(variable, variable)` and both `except` arrival shapes fetched from a live planner; `check()` oracle run for every in-var-var edge case (explicit-null, missing, empty, both polarities) — the implemented SQL truth table matches under the adapter's established null conventions.
- **Builds — all three legs green** (translation behavior changed, so all legs run): H2 (`gradle build`, 489 tests), PostgreSQL (`ADAPTER_TEST_DB=postgres`, 119 conformance tests incl. the new `in-var-var` actions), MySQL 8.4 (`ADAPTER_TEST_DB=mysql`, 119 conformance tests, `cerbos_ieee_double` registration test confirms the genuine MySQL leg). 0 failures everywhere; the differential oracle (the semantic arbiter) passes on all three databases with the new actions and seed included.
- **Negative control**: the new/changed unit tests were run against the old `main` sources — exactly the 20 observable new/changed tests fail (`245 tests completed, 20 failed`), every other test passes, confirming each fix is load-bearing.

## Notes

- `OperatorFunction` overrides are not consulted for `in(variable, variable)` — like field-to-field comparisons there is no `(field, value)` pair; documented in the translator Javadoc.
- README: `in` var-var row added to Supported operators; `except` row added to Not yet supported with the macro rewrite guidance; macro-depth sections updated (except is no longer a macro).
