### PR TITLE
docs(spring-data): pin test PDP image, harden example, document public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Current supported adapters:
 
 - [Convex](https://github.com/cerbos/query-plan-adapters/tree/main/convex)
 - [Drizzle ORM](https://github.com/cerbos/query-plan-adapters/tree/main/drizzle)
+- [Elasticsearch (Java)](https://github.com/cerbos/query-plan-adapters/tree/main/elasticsearch-java)
 - [LangChain / ChromaDB](https://github.com/cerbos/query-plan-adapters/tree/main/langchain-chromadb)
 - [Mongoose](https://github.com/cerbos/query-plan-adapters/tree/main/mongoose)
 - [Prisma](https://github.com/cerbos/query-plan-adapters/tree/main/prisma)
+- [Spring Data JPA](https://github.com/cerbos/query-plan-adapters/tree/main/spring-data)
 - [SQLAlchemy](https://github.com/cerbos/query-plan-adapters/tree/main/sqlalchemy)

--- a/spring-data/build.gradle.kts
+++ b/spring-data/build.gradle.kts
@@ -5,9 +5,12 @@ plugins {
 group = "dev.cerbos"
 version = "0.1.0-alpha.1"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+// `options.release` (unlike source/targetCompatibility) also constrains the JDK API
+// surface: compiling on JDK 21/25 still resolves against the Java 17 class library, so a
+// stray post-17 API reference fails at compile time instead of with NoSuchMethodError on
+// a JDK 17 runtime.
+tasks.withType<JavaCompile> {
+    options.release = 17
 }
 
 repositories {

--- a/spring-data/example/README.md
+++ b/spring-data/example/README.md
@@ -11,10 +11,16 @@ is the mandatory tenant boundary, composed outside the Cerbos specification so i
 to `KIND_ALWAYS_ALLOWED`. Changing the resource policies under [`policies/`](policies/) changes
 the policy-controlled result sets without changing the app.
 
-> **Demo identity only:** the endpoints accept `user`, `role`, `tenant`, and `groups` query
-> parameters so the smoke harness can switch principals. Never copy that identity handling into
-> production. Derive all of them from authenticated, server-controlled state; otherwise a caller
-> could request `role=admin` or cross a tenant boundary.
+> [!WARNING]
+> **Demo identity only — do not copy this pattern.** The endpoints accept `user`, `role`,
+> `tenant`, and `groups` as unauthenticated query parameters so the smoke harness can switch
+> principals from `curl`. In a real application, **derive the principal from your
+> authentication layer (Spring Security, a verified JWT/OIDC token, mTLS identity), never
+> from request input**. Anything a caller can type is not an identity: here
+> `?role=admin` grants the unconditional-ALLOW admin rule and `?tenant=...` crosses the
+> tenant boundary. The correct shape is to build `Principal.newInstance(...)` from
+> authenticated, server-controlled state (e.g. `SecurityContextHolder` /
+> `Authentication`) and never read identity or roles from parameters, headers, or bodies.
 
 ## What it covers
 
@@ -129,6 +135,23 @@ Or run the complete harness:
 ```bash
 ./scripts/smoke.sh
 ```
+
+### SQL logging
+
+`src/main/resources/application.yaml` ships with the Hibernate SQL loggers commented out:
+
+```yaml
+# org.hibernate.SQL: DEBUG
+# org.hibernate.orm.jdbc.bind: TRACE
+```
+
+Uncomment them locally to watch the SQL each authorization plan turns into. Keep them off
+anywhere logs are collected: the Cerbos planner constant-folds **principal** attributes
+(emails, departments, owner ids — potentially PII) into the plan constants, the adapter
+binds those constants as JDBC parameters, and `org.hibernate.orm.jdbc.bind: TRACE` prints
+every bind value verbatim on every authorized query (e.g.
+`binding parameter [1] as [VARCHAR] - [alice@corp.com]`). The adapter library itself logs
+nothing — this is purely a logging-configuration concern.
 
 The smoke script starts the PDP and app, checks the full scenario matrix, validates both
 pages and totals for a relation-based paginated query, and checks invalid page bounds return

--- a/spring-data/example/build.gradle.kts
+++ b/spring-data/example/build.gradle.kts
@@ -7,9 +7,10 @@ plugins {
 group = "dev.cerbos.example"
 version = "0.0.1"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+// Match the adapter build: `options.release` pins the Java 17 API surface as well as the
+// language level, so newer compile JDKs can't leak post-17 APIs into the bytecode.
+tasks.withType<JavaCompile> {
+    options.release = 17
 }
 
 repositories {

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoController.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoController.java
@@ -47,9 +47,15 @@ public class PhotoController {
     /**
      * GET /photos?user=alice&role=user&action=view
      *
-     * <p>Identity, tenant, and groups are request parameters only to make authorization cases
-     * reproducible in this local harness. Production code must derive them from authenticated,
-     * server-side state.
+     * <p><strong>DEMO ONLY — never copy this identity handling.</strong> Identity, role,
+     * tenant, and groups arrive as unauthenticated query parameters purely so the curl/smoke
+     * harness can switch principals per request. In production, derive the principal from
+     * your authentication layer — Spring Security's {@code Authentication} /
+     * {@code SecurityContextHolder}, a verified JWT/OIDC token, or equivalent — never from
+     * request input (parameters, headers, or bodies). As written, any caller can assert
+     * {@code role=admin} (hitting the unconditional-ALLOW rule in {@code photo.yaml}) or
+     * pick another tenant; an authorization filter built from a caller-asserted principal
+     * authorizes nothing. See the "Demo identity only" warning in the example README.
      */
     @GetMapping
     public List<PhotoView> list(@RequestParam String user,
@@ -66,7 +72,13 @@ public class PhotoController {
                 .toList();
     }
 
-    /** GET /photos/page?user=alice&action=needs-moderation&page=0&size=1 */
+    /**
+     * GET /photos/page?user=alice&action=needs-moderation&page=0&size=1
+     *
+     * <p><strong>DEMO ONLY:</strong> same caveat as {@link #list} — the principal comes from
+     * query parameters for harness reproducibility; production code must derive it from the
+     * authentication layer, never from request input.
+     */
     @GetMapping("/page")
     public Page<PhotoView> page(@RequestParam String user,
                                 @RequestParam(defaultValue = "user") String role,

--- a/spring-data/example/src/main/resources/application.yaml
+++ b/spring-data/example/src/main/resources/application.yaml
@@ -18,6 +18,11 @@ cerbos:
 
 logging:
   level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
+    # LOCAL DEBUGGING ONLY — uncomment to see the SQL each authorization plan produces.
+    # `org.hibernate.orm.jdbc.bind: TRACE` prints every JDBC bind parameter verbatim,
+    # and the Cerbos planner constant-folds PRINCIPAL attributes (emails, departments,
+    # owner ids — potentially PII) into the plan constants the adapter binds. Never
+    # enable these loggers in production; see "SQL logging" in the README.
+    # org.hibernate.SQL: DEBUG
+    # org.hibernate.orm.jdbc.bind: TRACE
     dev.cerbos.example: INFO

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/AttributeMapping.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/AttributeMapping.java
@@ -2,30 +2,143 @@ package dev.cerbos.queryplan.springdata;
 
 import java.util.Map;
 
+/**
+ * Maps one Cerbos attribute reference (the {@code variable} name in a query plan, e.g.
+ * {@code request.resource.attr.ownerId} or {@code request.resource.id}) onto the JPA model,
+ * either as a scalar {@linkplain Field path} or as a collection {@linkplain Relation
+ * relation}. The mapper passed to
+ * {@link SpringDataQueryPlanAdapter#toSpecification(dev.cerbos.sdk.PlanResourcesResult, Map)
+ * toSpecification} is keyed by the full attribute reference:
+ *
+ * <pre>{@code
+ * Map<String, AttributeMapping> MAPPING = Map.of(
+ *     "request.resource.attr.ownerId",    AttributeMapping.field("owner.id"),
+ *     "request.resource.attr.department", AttributeMapping.field("department"),
+ *     "request.resource.attr.tags",       AttributeMapping.relation("tags", Map.of(
+ *         "name", AttributeMapping.field("name"))));
+ * }</pre>
+ *
+ * <p>Choosing a helper:
+ *
+ * <table border="1">
+ *   <caption>Mapping helpers</caption>
+ *   <tr><th>Helper</th><th>Use for</th></tr>
+ *   <tr><td>{@link #field(String) field("aPath")}</td>
+ *       <td>Simple column or {@code @Embedded} dotted path</td></tr>
+ *   <tr><td>{@link #relation(String) relation("tags")}</td>
+ *       <td>{@code @ElementCollection<String>} (bare values)</td></tr>
+ *   <tr><td>{@link #relation(String, String) relation("tags", "name")}</td>
+ *       <td>{@code @OneToMany} collection whose default member field is {@code name}</td></tr>
+ *   <tr><td>{@link #relation(String, Map) relation("tags", Map.of("name", field("name")))}</td>
+ *       <td>{@code @OneToMany<Tag>} with explicit nested field mapping</td></tr>
+ *   <tr><td>{@link #relation(String, String, Map) relation("tags", "name", Map.of(...))}</td>
+ *       <td>Both: a default member field for bare-value operators plus nested mappings for
+ *           lambda bodies</td></tr>
+ * </table>
+ *
+ * <p>Plan variables that are missing from the mapper, or whose mapping cannot be resolved
+ * against the entity model (e.g. a {@code Relation} used where a scalar path is required),
+ * cause translation to throw {@link IllegalArgumentException} — the adapter fails closed
+ * rather than guessing a column.
+ */
 public sealed interface AttributeMapping permits AttributeMapping.Field, AttributeMapping.Relation {
 
+    /**
+     * Maps an attribute to a scalar JPA path on the entity.
+     *
+     * <p>{@code jpaPath} is resolved segment-by-segment via {@code Path.get(...)}, so dotted
+     * paths traverse {@code @Embedded} objects (and to-one associations):
+     * {@code field("details.pixelWidth")}, {@code field("owner.id")}. Use this for any
+     * attribute compared as a single value ({@code eq}/{@code ne}/ordering/LIKE/temporal
+     * comparisons, scalar {@code in}, ...).
+     *
+     * @param jpaPath entity property name, or a dot-separated path through embeddables
+     * @return the scalar mapping
+     */
     static Field field(String jpaPath) {
         return new Field(jpaPath);
     }
 
+    /**
+     * Maps an attribute to a bare-value collection — typically an
+     * {@code @ElementCollection<String>} — whose elements ARE the compared values.
+     *
+     * <p>Collection operators ({@code in}, {@code hasIntersection}, {@code exists}-family
+     * lambdas over the bare element, {@code size(...)}) translate to correlated subqueries
+     * against the collection table, comparing the element itself.
+     *
+     * @param joinAttribute the entity's collection property name
+     * @return the relation mapping
+     */
     static Relation relation(String joinAttribute) {
         return new Relation(joinAttribute, null, Map.of());
     }
 
+    /**
+     * Maps an attribute to an entity collection ({@code @OneToMany}) whose
+     * {@code defaultMemberField} stands in for the member element wherever the policy treats
+     * the collection as a list of bare values.
+     *
+     * <p>Example: with {@code relation("tags", "name")}, the policy expression
+     * {@code "urgent" in R.attr.tags} compares against {@code tag.name} rather than the
+     * {@code Tag} entity itself.
+     *
+     * @param joinAttribute the entity's collection property name
+     * @param defaultMemberField member-entity field used when the policy addresses the
+     *        element as a bare value
+     * @return the relation mapping
+     */
     static Relation relation(String joinAttribute, String defaultMemberField) {
         return new Relation(joinAttribute, defaultMemberField, Map.of());
     }
 
+    /**
+     * Maps an attribute to an entity collection ({@code @OneToMany}) with explicit mappings
+     * for the member fields referenced inside lambda bodies.
+     *
+     * <p>Example: {@code relation("tags", Map.of("name", field("name")))} lets
+     * {@code R.attr.tags.exists(t, t.name == "x")} resolve {@code t.name} on the member
+     * entity. Nested {@code fields} entries may themselves be {@code relation(...)} mappings,
+     * supporting multi-hop chains ({@code R.attr.categories.subCategories...}).
+     *
+     * @param joinAttribute the entity's collection property name
+     * @param fields policy-facing member field name → mapping on the member entity
+     * @return the relation mapping
+     */
     static Relation relation(String joinAttribute, Map<String, AttributeMapping> fields) {
         return new Relation(joinAttribute, null, fields);
     }
 
+    /**
+     * Maps an attribute to an entity collection with both a {@linkplain #relation(String,
+     * String) default member field} (for bare-value operators such as {@code in} /
+     * {@code hasIntersection}) and {@linkplain #relation(String, Map) explicit nested field
+     * mappings} (for lambda bodies).
+     *
+     * @param joinAttribute the entity's collection property name
+     * @param defaultMemberField member-entity field used when the policy addresses the
+     *        element as a bare value
+     * @param fields policy-facing member field name → mapping on the member entity
+     * @return the relation mapping
+     */
     static Relation relation(String joinAttribute, String defaultMemberField, Map<String, AttributeMapping> fields) {
         return new Relation(joinAttribute, defaultMemberField, fields);
     }
 
+    /**
+     * Scalar mapping: {@code jpaPath} is an entity property name or a dot-separated
+     * {@code @Embedded}/to-one path, resolved via {@code Path.get(...)} at translation time.
+     * Create via {@link #field(String)}.
+     */
     record Field(String jpaPath) implements AttributeMapping {}
 
+    /**
+     * Collection mapping: {@code joinAttribute} names the entity's collection property;
+     * {@code defaultMemberField} (nullable) stands in for the element when the policy treats
+     * the collection as bare values; {@code fields} maps policy-facing member field names
+     * used inside lambda bodies. Create via the {@code relation(...)} factory methods, whose
+     * Javadoc describes when each combination applies.
+     */
     record Relation(String joinAttribute, String defaultMemberField, Map<String, AttributeMapping> fields)
             implements AttributeMapping {}
 }

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/Result.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/Result.java
@@ -11,7 +11,7 @@ public sealed interface Result<T> permits Result.AlwaysAllowed, Result.AlwaysDen
      * <ul>
      *   <li>{@link AlwaysAllowed} – {@code null} predicate; Spring Data's
      *       {@code SimpleJpaRepository} treats this as "no restriction" and omits the
-     *       {@code WHERE} clause entirely (matches {@link Specification#unrestricted()}).</li>
+     *       {@code WHERE} clause entirely (matches {@code Specification.unrestricted()}).</li>
      *   <li>{@link AlwaysDenied} – always-false predicate ({@code 1=0}).</li>
      *   <li>{@link Conditional} – the wrapped Specification. The lambda is invoked fresh
      *       for every query (including Spring Data's separate COUNT pass under

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -54,11 +54,58 @@ public final class SpringDataQueryPlanAdapter {
 
     // -- PlanResourcesResult overloads --
 
+    /**
+     * Translates a Cerbos query plan (as returned by the Java SDK's
+     * {@code CerbosBlockingClient.plan(...)}) into a {@link Result} wrapping a Spring Data
+     * JPA Specification, using the default operator translations.
+     *
+     * <p>Equivalent to {@link #toSpecification(PlanResourcesResult, Map, Map)} with no
+     * operator overrides.
+     *
+     * @param <T> the entity type the Specification will be executed against
+     * @param planResult the SDK plan result ({@code KIND_ALWAYS_ALLOWED},
+     *        {@code KIND_ALWAYS_DENIED}, or a conditional plan)
+     * @param mapper maps each plan variable ({@code request.resource.attr.<name>},
+     *        {@code request.resource.id}) to a JPA path or relation — see
+     *        {@link AttributeMapping}
+     * @return {@link Result.AlwaysAllowed}, {@link Result.AlwaysDenied}, or a
+     *         {@link Result.Conditional} wrapping the translated Specification
+     * @throws IllegalArgumentException if the conditional plan carries no condition.
+     *         Translation of the condition itself is deferred: unsupported operators,
+     *         unmapped attributes, and unresolvable paths throw
+     *         {@code IllegalArgumentException} (fail closed) when the Specification is first
+     *         evaluated by the repository, not from this call.
+     */
     public static <T> Result<T> toSpecification(
             PlanResourcesResult planResult, Map<String, AttributeMapping> mapper) {
         return toSpecification(planResult, mapper, Map.of());
     }
 
+    /**
+     * Translates a Cerbos query plan (as returned by the Java SDK's
+     * {@code CerbosBlockingClient.plan(...)}) into a {@link Result} wrapping a Spring Data
+     * JPA Specification, consulting {@code overrides} for scalar leaf translations.
+     *
+     * <p>Prefer this {@link PlanResourcesResult} entry point when using the Cerbos Java SDK
+     * client. The {@link #toSpecification(PlanResourcesResponse, Map, Map)} overloads accept
+     * the raw protobuf response instead — useful when the response was obtained without the
+     * SDK client wrapper (e.g. deserialized, proxied, or hand-built in tests, since
+     * {@code PlanResourcesResult} cannot be constructed outside the SDK package).
+     *
+     * @param <T> the entity type the Specification will be executed against
+     * @param planResult the SDK plan result
+     * @param mapper maps each plan variable to a JPA path or relation — see
+     *        {@link AttributeMapping}
+     * @param overrides per-operator replacement translations, keyed by Cerbos operator name;
+     *        consulted only for resolved scalar (field, value) leaves — see
+     *        {@link OperatorFunction} for exactly which translation sites are (and are not)
+     *        overridable
+     * @return {@link Result.AlwaysAllowed}, {@link Result.AlwaysDenied}, or a
+     *         {@link Result.Conditional} wrapping the translated Specification
+     * @throws IllegalArgumentException if the conditional plan carries no condition; see
+     *         {@link #toSpecification(PlanResourcesResult, Map)} for the deferred
+     *         fail-closed contract covering the translation itself
+     */
     public static <T> Result<T> toSpecification(
             PlanResourcesResult planResult,
             Map<String, AttributeMapping> mapper,
@@ -78,11 +125,50 @@ public final class SpringDataQueryPlanAdapter {
 
     // -- PlanResourcesResponse overloads --
 
+    /**
+     * Translates a raw {@link PlanResourcesResponse} protobuf into a {@link Result} wrapping
+     * a Spring Data JPA Specification, using the default operator translations.
+     *
+     * <p>Equivalent to {@link #toSpecification(PlanResourcesResponse, Map, Map)} with no
+     * operator overrides. Accepts the wire-level protobuf directly, so it works with
+     * responses obtained without the SDK client wrapper; when calling the PDP through the
+     * Cerbos Java SDK, the {@link #toSpecification(PlanResourcesResult, Map)} overloads are
+     * the natural fit.
+     *
+     * @param <T> the entity type the Specification will be executed against
+     * @param response the raw {@code PlanResources} RPC response
+     * @param mapper maps each plan variable to a JPA path or relation — see
+     *        {@link AttributeMapping}
+     * @return {@link Result.AlwaysAllowed}, {@link Result.AlwaysDenied}, or a
+     *         {@link Result.Conditional} wrapping the translated Specification
+     * @throws IllegalArgumentException if the filter kind is unknown or a conditional filter
+     *         carries no condition; see {@link #toSpecification(PlanResourcesResult, Map)}
+     *         for the deferred fail-closed contract covering the translation itself
+     */
     public static <T> Result<T> toSpecification(
             PlanResourcesResponse response, Map<String, AttributeMapping> mapper) {
         return toSpecification(response, mapper, Map.of());
     }
 
+    /**
+     * Translates a raw {@link PlanResourcesResponse} protobuf into a {@link Result} wrapping
+     * a Spring Data JPA Specification, consulting {@code overrides} for scalar leaf
+     * translations.
+     *
+     * @param <T> the entity type the Specification will be executed against
+     * @param response the raw {@code PlanResources} RPC response
+     * @param mapper maps each plan variable to a JPA path or relation — see
+     *        {@link AttributeMapping}
+     * @param overrides per-operator replacement translations, keyed by Cerbos operator name;
+     *        consulted only for resolved scalar (field, value) leaves — see
+     *        {@link OperatorFunction} for exactly which translation sites are (and are not)
+     *        overridable
+     * @return {@link Result.AlwaysAllowed}, {@link Result.AlwaysDenied}, or a
+     *         {@link Result.Conditional} wrapping the translated Specification
+     * @throws IllegalArgumentException if the filter kind is unknown or a conditional filter
+     *         carries no condition; see {@link #toSpecification(PlanResourcesResult, Map)}
+     *         for the deferred fail-closed contract covering the translation itself
+     */
     public static <T> Result<T> toSpecification(
             PlanResourcesResponse response,
             Map<String, AttributeMapping> mapper,

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -308,7 +308,8 @@ class AdversarialConformanceTest {
 
     @BeforeAll
     static void setUp() throws Exception {
-        cerbos = new GenericContainer<>("ghcr.io/cerbos/cerbos:latest")
+        // Pinned PDP image — see CerbosTestImage for the pin rationale and bump policy.
+        cerbos = new GenericContainer<>(CerbosTestImage.IMAGE)
                 .withExposedPorts(3593)
                 .withCommand("server", "--set=storage.disk.directory=/policies")
                 .withEnv("CERBOS_NO_TELEMETRY", "1")
@@ -322,6 +323,8 @@ class AdversarialConformanceTest {
             throw new UncheckedIOException(e);
         }
         cerbos.start();
+        System.out.printf("==> Adversarial-oracle Cerbos PDP image: %s (digest %s)%n",
+                CerbosTestImage.IMAGE, CerbosTestImage.resolvedDigest(cerbos));
         client = new CerbosClientBuilder(cerbos.getHost() + ":" + cerbos.getMappedPort(3593))
                 .withPlaintext().buildBlockingClient();
 
@@ -764,8 +767,10 @@ class AdversarialConformanceTest {
      * <p>This test asserts BOTH halves of the divergence — the plan kind AND the check()
      * denials — so that the moment an upstream image stops folding, the test fails with
      * explicit re-inclusion instructions instead of the coverage hole silently becoming
-     * permanent (the suite tracks {@code cerbos:latest}, so the fix would otherwise flow in
-     * unnoticed with {@code p-has} still excluded).
+     * permanent. NOTE: the suite runs against the pinned image in {@link CerbosTestImage},
+     * so this "fires when upstream fixes the fold" property is dormant between image bumps —
+     * the tripwire is re-evaluated on every deliberate bump of that pin (see the bump policy
+     * in {@code CerbosTestImage}), which is when an upstream fix would surface here.
      *
      * <p>README "Gotchas" documents the policy-author workaround:
      * {@code R.attr.aOptionalString != null} plans as a conditional {@code ne(variable, null)}

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/CerbosTestImage.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/CerbosTestImage.java
@@ -1,0 +1,47 @@
+package dev.cerbos.queryplan.springdata;
+
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.List;
+
+/**
+ * Single source of truth for the Cerbos PDP container image used by the Testcontainers
+ * suites ({@link SpringDataIntegrationTest} and {@link AdversarialConformanceTest}).
+ *
+ * <p><b>Why pinned.</b> Several tests pin planner-shape-dependent behavior (exact
+ * fail-closed error strings for pass-through shapes, the {@code has()} over-grant
+ * tripwire, differential-oracle row sets). A floating {@code :latest} tag makes past
+ * green runs unreproducible once the tag moves and lets upstream planner changes flow
+ * into CI unnoticed. The image is therefore pinned to an explicit release and bumped
+ * deliberately (repo precedent: the shared conformance corpus pins 0.54.0).
+ *
+ * <p><b>Bump policy.</b> Bumping the default below is a deliberate, reviewed change:
+ * update the version, run the full suite, and re-evaluate every upstream-tracking test —
+ * in particular {@code AdversarialConformanceTest.upstreamHasFoldOverGrantTripwire},
+ * whose "fires when upstream fixes the fold" property is dormant between bumps and only
+ * re-checks upstream behavior when the pinned image moves. Override per-run with
+ * {@code -Dcerbos.test.image=ghcr.io/cerbos/cerbos:<tag>} to trial a newer PDP without
+ * editing source.
+ */
+final class CerbosTestImage {
+
+    /** Pinned Cerbos PDP image; override with the {@code cerbos.test.image} system property. */
+    static final String IMAGE =
+            System.getProperty("cerbos.test.image", "ghcr.io/cerbos/cerbos:0.54.0");
+
+    private CerbosTestImage() {}
+
+    /**
+     * Best-effort repo digest of the image backing a started container, so CI logs record
+     * exactly which PDP build produced a run even if the tag is later re-pointed.
+     */
+    static String resolvedDigest(GenericContainer<?> container) {
+        try {
+            List<String> digests = container.getDockerClient()
+                    .inspectImageCmd(container.getDockerImageName()).exec().getRepoDigests();
+            return digests == null || digests.isEmpty() ? "<no digest>" : digests.get(0);
+        } catch (RuntimeException e) {
+            return "<digest unavailable: " + e.getMessage() + ">";
+        }
+    }
+}

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
@@ -58,8 +58,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Two modes:
  * <ul>
- *   <li><b>Self-managed (default)</b>: a {@code ghcr.io/cerbos/cerbos:dev} container is started
- *       by Testcontainers, with the shared {@code /policies/resource.yaml} mounted in.</li>
+ *   <li><b>Self-managed (default)</b>: a Cerbos container (the pinned image in
+ *       {@link CerbosTestImage}) is started by Testcontainers, with the shared
+ *       {@code /policies/resource.yaml} mounted in.</li>
  *   <li><b>External (Prisma-style sidecar)</b>: if {@code CERBOS_HOST} and {@code CERBOS_PORT}
  *       are set in the environment, the suite skips Testcontainers and connects to an
  *       externally-managed PDP. See {@code docker-compose.yml} and {@code scripts/run-e2e.sh}.</li>
@@ -143,7 +144,8 @@ class SpringDataIntegrationTest {
     );
 
     private static GenericContainer<?> createCerbosContainer() {
-        GenericContainer<?> container = new GenericContainer<>("ghcr.io/cerbos/cerbos:latest")
+        // Pinned PDP image — see CerbosTestImage for the pin rationale and bump policy.
+        GenericContainer<?> container = new GenericContainer<>(CerbosTestImage.IMAGE)
                 .withExposedPorts(3593)
                 .withCommand("server",
                         "--set=storage.disk.directory=/policies",
@@ -184,8 +186,8 @@ class SpringDataIntegrationTest {
             host = cerbos.getHost();
             port = cerbos.getMappedPort(3593);
             System.out.printf(
-                    "==> Started Testcontainers-managed Cerbos PDP (ghcr.io/cerbos/cerbos:latest) at %s:%d%n",
-                    host, port);
+                    "==> Started Testcontainers-managed Cerbos PDP (%s, digest %s) at %s:%d%n",
+                    CerbosTestImage.IMAGE, CerbosTestImage.resolvedDigest(cerbos), host, port);
         }
 
         cerbosClient = new CerbosClientBuilder(host + ":" + port)


### PR DESCRIPTION
Combined docs/build/example hardening sweep covering findings 19, 20, 22, 25, 26, and 27 of 28 from an internal adversarial review of the spring-data adapter. No behavior changes to adapter translation code — tests, docs, build flags, and the example app only.

## Findings addressed

| # | Finding | Change |
|---|---------|--------|
| 19 | Testcontainers PDP image unpinned (`cerbos:latest`) while tests pin planner-shape-dependent behavior | Pinned to `ghcr.io/cerbos/cerbos:0.54.0` (current latest release), centralized in a new `CerbosTestImage` test constant (overridable via `-Dcerbos.test.image`) read by both suites, with a documented deliberate-bump policy; fixed the stale `cerbos:dev` javadoc in `SpringDataIntegrationTest`; both suites now log the resolved image digest at startup (CI recorded no digest anywhere before) |
| 20 | Example ships `org.hibernate.orm.jdbc.bind: TRACE`, printing constant-folded principal attributes (potential PII) as bind params | Both Hibernate loggers commented out in `application.yaml` with a local-debug-only warning; new "SQL logging" section in `example/README` explaining the PII mechanism |
| 22 | Example accepts principal identity/role as unauthenticated query params — dangerous as a copied pattern | Standard "derive the principal from your authentication layer, never from request input" caveat: prominent Javadoc blocks on both `PhotoController` endpoints and an upgraded `[!WARNING]` section in `example/README` |
| 25 | `source/targetCompatibility` doesn't constrain the JDK API surface on newer compile JDKs | Replaced with `tasks.withType<JavaCompile> { options.release = 17 }` in both `spring-data/build.gradle.kts` and `example/build.gradle.kts` |
| 26 | Public API entry points lack Javadoc | Full Javadoc on `AttributeMapping` (interface, `field()`, all four `relation()` overloads, `Field`/`Relation` records — mirroring the README mapping table) and the four `toSpecification` overloads (the `PlanResourcesResult` vs `PlanResourcesResponse` distinction and the fail-closed `IllegalArgumentException` contract), matching the `Result`/`OperatorFunction` style; also fixed the one pre-existing javadoc-task error (broken `Specification#unrestricted()` link in `Result`) so `gradle javadoc` now succeeds |
| 27 | Repo-root README omits spring-data and elasticsearch-java | Added both to the adapter list in existing format/order |

## Pinned image verification

Full H2-leg build (all 468 tests, including the `AdversarialConformanceTest` differential oracle and integration suite) run against the pinned `0.54.0` image: **BUILD SUCCESSFUL, 0 failures — no planner drift vs `latest`** (0.54.0 is the current latest release; resolved digest `sha256:211c261f…` now logged in suite output). `gradle -p example build` also passes.

## Notes

- The has()-tripwire test from #289 intentionally tracks upstream planner behavior; its comment now records that pinning makes the "fires when upstream fixes" property dormant between bumps and that the tripwire is re-evaluated on every image bump (see the bump policy in `CerbosTestImage`).
- **Expected trivial conflict with #290**: that PR adds compact constructors inside the `AttributeMapping.Field`/`Relation` record bodies; this PR adds Javadoc immediately above the same record declarations. Whichever merges second resolves a trivial adjacent-context conflict (keep both).
- Merge freeze: do not merge — accumulating as open per current instructions.
