### PR TITLE
test(spring-data): add edge-case regression scenarios to the example app

### DIFF
--- a/.github/workflows/spring-data.yaml
+++ b/.github/workflows/spring-data.yaml
@@ -106,3 +106,10 @@ jobs:
 
       - name: Run smoke test
         run: ./example/scripts/smoke.sh
+
+      # Full-stack regression tripwire: every scenario pins a historical adapter bug
+      # (PRs #273, #274, #275, #279, #285, #286) that would have returned a different
+      # row set — or an HTTP 500 — before its fix. See "Edge-case regression
+      # scenarios" in example/README.md.
+      - name: Run edge-case regression smoke test
+        run: ./example/scripts/smoke-edge-cases.sh

--- a/spring-data/example/README.md
+++ b/spring-data/example/README.md
@@ -82,6 +82,7 @@ example/
 ├── settings.gradle.kts          # composite-build include of the adapter source
 ├── build.gradle.kts             # Spring Boot 3.5, Spring Data JPA, H2
 ├── scripts/smoke.sh             # live PDP + Boot + HTTP assertions
+├── scripts/smoke-edge-cases.sh  # full-stack regression tripwire (see "Edge-case regression scenarios")
 └── src/main/
     ├── resources/application.yaml
     └── java/dev/cerbos/example/photos/
@@ -102,7 +103,7 @@ example/
         ├── WorkspaceController.java # GET /workspaces
         ├── AccessContext.java    # shared principal/tenant construction
         ├── CerbosClientConfig.java
-        ├── SeedData.java         # nine adversarial photos across two tenants
+        ├── SeedData.java         # nine adversarial photos across two tenants + edge-regression seeds
         └── PhotosApplication.java
 ```
 
@@ -247,3 +248,46 @@ observed resource-kind set must be exactly the three intended kinds. Readiness u
 unmapped route and creates no PDP traffic; after the rejected pagination/filter requests, a valid
 `audit-sentinel` request acts as an audit flush barrier and the complete delta must contain only
 that sentinel.
+
+## Edge-case regression scenarios
+
+`./scripts/smoke-edge-cases.sh` (run in CI after `smoke.sh`) is a full-stack regression
+tripwire rather than a tutorial. Each scenario re-creates, end to end — Spring Boot app,
+live PDP, real `JpaSpecificationExecutor` against H2 — a high-severity adapter bug that has
+been fixed on `main`. Every assertion passes today and would have failed (wrong row set, or
+an HTTP 500) immediately before the corresponding fix, so a regression in any of these code
+paths breaks this harness even if unit-level coverage is ever weakened.
+
+The scenarios are deliberately quarantined from the pedagogical demo: the `edge-*` actions
+live in a clearly-delimited section at the bottom of [`policies/photo.yaml`](policies/photo.yaml),
+their fixtures (`e1`–`e6`) sit in an isolated `edge` tenant so no `smoke.sh` expectation
+changes, and some expressions (`0.0 / 0.0`, `size(title) > 4294967296`) are intentionally
+pathological probes — not policy-writing guidance.
+
+| Scenario | Pins | Historical wrong behavior |
+|---|---|---|
+| `edge-ieee-eq` / `edge-ieee-ne` | [#274](https://github.com/cerbos/query-plan-adapters/pull/274) | `eq`/`ne` over `field + constant` solved algebraically (`0.1 - 0.7`); IEEE addition does not invert, so a PDP-denied row (`score = -0.6`) was included by `eq` and excluded by `ne` |
+| `edge-nan-ordering` | [#275](https://github.com/cerbos/query-plan-adapters/pull/275) | constant `NaN` ordering used `Double.compare`'s total order, so `NaN > 0.5` was true and non-public rows leaked through the ternary's else-arm |
+| `edge-retention` | [#279](https://github.com/cerbos/query-plan-adapters/pull/279) | `timestamp(createdAt) < now() - duration("24h")` — the most common compliance shape — threw for every query (each request a 500) instead of comparing the temporal column |
+| `edge-bracket-title` | [#285](https://github.com/cerbos/query-plan-adapters/pull/285) | LIKE escaping missed SQL Server's `[...]` character class; `startsWith("[SEC]")` matched rows starting with S/E/C and missed literal `[SEC]…` rows |
+| `edge-size-huge` | [#286](https://github.com/cerbos/query-plan-adapters/pull/286) | `size(title) > 4294967296` truncated the threshold with an `(int)` cast to `0`, returning every non-empty title instead of no rows |
+| `DELETE /photos/bulk-unsafe` | [#273](https://github.com/cerbos/query-plan-adapters/pull/273) | `delete(Specification)` with a Relation-mapped predicate deleted 0 photos while silently destroying their collection rows; the adapter now throws before any SQL runs — the endpoint surfaces the guard as HTTP 409 and the harness then proves all rows survived |
+
+`DELETE /photos/bulk-unsafe` is an intentionally-failing demonstration endpoint: a 409 with
+the guard's message is its correct, asserted behavior. The safe deletion pattern is
+`findAll(spec)` followed by `deleteAllById(ids)` — see the `Result` Javadoc in the adapter.
+
+### Dialect-sensitive findings
+
+Two further fixed findings only manifest on real MySQL/SQL Server and cannot be reproduced
+on this example's H2 database, so they are deliberately not contorted into this harness:
+
+- **Collation-blind string matching** ([#272](https://github.com/cerbos/query-plan-adapters/pull/272)):
+  case-/accent-insensitive default collations make SQL match rows the PDP denies. Covered by
+  the adapter's real-database CI legs (`test-database` in `.github/workflows/spring-data.yaml`),
+  which run the differential `check()` oracle on PostgreSQL and MySQL with case-sensitive
+  schema collation; see "Database collation requirements" in the adapter README.
+- **MySQL decimal-literal arithmetic** ([#284](https://github.com/cerbos/query-plan-adapters/pull/284)):
+  Connector/J's client-side prepared statements evaluated the adapter's IEEE double
+  arithmetic in exact decimal. The MySQL CI leg runs in both prepared-statement modes to pin
+  the fix; see "MySQL: keeping arithmetic IEEE-faithful" in the adapter README.

--- a/spring-data/example/policies/photo.yaml
+++ b/spring-data/example/policies/photo.yaml
@@ -193,3 +193,81 @@ resourcePolicy:
         - "no-group-grant-safe"
       effect: EFFECT_ALLOW
       roles: ["admin"]
+
+    # ------------------------------------------------------------------------
+    # Edge-case regression scenarios
+    #
+    # Each `edge-*` action below pins one historical adapter bug at the
+    # full-stack level (Spring Boot app + live PDP + real repository). They are
+    # exercised only by the dedicated "edge"-tenant fixtures in SeedData.java
+    # and asserted by scripts/smoke-edge-cases.sh — see "Edge-case regression
+    # scenarios" in the example README. Some expressions are deliberately
+    # pathological (labeled inline); they are probes, not policy-writing
+    # recommendations.
+    # ------------------------------------------------------------------------
+
+    # Pins PR #274: eq over (field + constant) used an algebraic solve
+    # (0.1 - 0.7 = -0.6) that IEEE addition does not invert. check() denies
+    # score = -0.6 (-0.6 + 0.7 == 0.09999999999999998, not 0.1) but the old
+    # adapter emitted `WHERE score = -0.6` and INCLUDED that row. No double
+    # satisfies this equation, so the correct result set is empty.
+    - actions: ["edge-ieee-eq"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: request.resource.attr.score + 0.7 == 0.1
+
+    # Pins PR #274 (ne direction): the old solve emitted `WHERE score != -0.6`,
+    # wrongly EXCLUDING the score = -0.6 row that check() allows here.
+    - actions: ["edge-ieee-ne"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: request.resource.attr.score + 0.7 != 0.1
+
+    # Pins PR #275: ordering against a constant NaN used Double.compare (a
+    # total order ranking NaN above every number), so the NaN else-arm of this
+    # ternary collapsed to always-true and non-public rows leaked through.
+    # CEL/IEEE define every NaN ordering as false. 0.0/0.0 is a deliberate
+    # NaN-producing probe.
+    - actions: ["edge-nan-ordering"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: '(request.resource.attr.public ? 1.0 : 0.0 / 0.0) > 0.5'
+
+    # Pins PR #279: the most common compliance shape — a retention/time-window
+    # rule. The planner folds `now() - duration(...)` to a constant instant;
+    # before the fix the adapter threw for every query of this action (each
+    # request was a 500 instead of returning the older-than-24h rows).
+    - actions: ["edge-retention"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: timestamp(request.resource.attr.createdAt) < now() - duration("24h")
+
+    # Pins PR #285: LIKE escaping must cover SQL Server's `[...]` character
+    # class. The escaped pattern must keep matching a literal "[SEC]" prefix
+    # (and never match the "Secret..." trap row, whose first character is in
+    # the class {S,E,C}).
+    - actions: ["edge-bracket-title"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: request.resource.attr.title.startsWith("[SEC]")
+
+    # Pins PR #286: size() thresholds >= 2^31 were truncated by an (int) cast —
+    # 4294967296 wrapped to 0 and `LENGTH(title) > 0` returned every non-empty
+    # title. check() denies every row, so the correct result set is empty.
+    # 4294967296 is a deliberately pathological regression probe.
+    - actions: ["edge-size-huge"]
+      effect: EFFECT_ALLOW
+      roles: ["user"]
+      condition:
+        match:
+          expr: size(request.resource.attr.title) > 4294967296

--- a/spring-data/example/scripts/smoke-edge-cases.sh
+++ b/spring-data/example/scripts/smoke-edge-cases.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Edge-case regression smoke test for the cerbos-spring-data example.
+#
+# Companion to smoke.sh (which owns the pedagogical scenario matrix and the PDP
+# audit-log verification). This script is a full-stack regression tripwire: every
+# assertion pins a historical adapter bug that was fixed on main and would have
+# produced a DIFFERENT row set (or an HTTP 500) before its fix. The scenarios run
+# against dedicated fixtures in the isolated "edge" tenant (SeedData.java) and the
+# `edge-*` actions in policies/photo.yaml, so smoke.sh's expectations are untouched.
+#
+# Scenario -> historical bug map (details in the policy file and example README):
+#   edge-ieee-eq / edge-ieee-ne  PR #274  algebraic eq/ne add-solve vs IEEE addition
+#   edge-nan-ordering            PR #275  Double.compare total order vs IEEE NaN
+#   edge-retention               PR #279  timestamp()/now()-duration() threw for every query
+#   edge-bracket-title           PR #285  LIKE escaping missed SQL Server's [ class
+#   edge-size-huge               PR #286  size() threshold >= 2^31 truncated by (int) cast
+#   bulk-unsafe delete           PR #273  delete(Specification) collection-row corruption
+#
+# Pre-reqs: docker, curl, jq, gradle (8.x), JDK 17+.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+GREEN="\033[0;32m"; RED="\033[0;31m"; NC="\033[0m"
+fail() { printf "${RED}FAIL${NC} %s\n" "$*" >&2; exit 1; }
+ok()   { printf "${GREEN}OK${NC}   %s\n" "$*"; }
+
+cleanup() {
+    local status=$?
+    if [[ -n "${APP_PID:-}" ]]; then
+        kill "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+    fi
+    if (( status != 0 )); then
+        echo "==> edge-case smoke test failed (exit $status): Cerbos container logs" >&2
+        docker compose logs --no-color cerbos >&2 || true
+        if [[ -f build/smoke/edge-app.log ]]; then
+            echo "==> edge-case smoke test failed (exit $status): last 200 lines of Spring Boot log" >&2
+            tail -n 200 build/smoke/edge-app.log >&2 || true
+        fi
+    fi
+    docker compose down --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> docker compose up -d"
+docker compose up -d
+
+echo "==> waiting for Cerbos health"
+for i in {1..30}; do
+    if docker compose ps --format json cerbos | grep -q '"Health":"healthy"'; then break; fi
+    sleep 1
+done
+
+echo "==> gradle bootRun (background)"
+mkdir -p build/smoke
+gradle bootRun --no-daemon >build/smoke/edge-app.log 2>&1 &
+APP_PID=$!
+
+echo "==> waiting for Spring Boot on :8080"
+for i in {1..60}; do
+    if curl -sS -o /dev/null "http://localhost:8080/" 2>/dev/null; then break; fi
+    sleep 1
+done
+curl -sS -o /dev/null "http://localhost:8080/" || \
+    { tail -40 build/smoke/edge-app.log; fail "Spring Boot didn't come up"; }
+
+assert_ids() {
+    local label=$1 url=$2 expected=$3
+    local got
+    got=$(curl -fsS "$url" | jq -r '[.[].id] | sort | join(",")')
+    if [[ "$got" == "$expected" ]]; then
+        ok "$label  => ${got:-<empty>}"
+    else
+        fail "$label  expected=${expected:-<empty>}  got=${got:-<empty>}"
+    fi
+}
+
+EDGE="http://localhost:8080/photos?user=edge-user&tenant=edge"
+
+# Edge fixtures (SeedData.java, tenant "edge"):
+#   e1 "[SEC] Quarterly report"  public  score=NULL  createdAt=now-30d
+#   e2 "Secret launch plan"     !public  score=NULL  createdAt=now-1h
+#   e3 "Precision probe"         public  score=-0.6  createdAt=now-1h
+#   e4 "Cold archive shot"      !public  score=2.5   createdAt=now-30d
+#   e5 "Retention candidate"     public  score=NULL  createdAt=now-30d
+#   e6 "Fresh upload"            public  score=NULL  createdAt=now-1h
+
+# PR #274: `score + 0.7 == 0.1` has NO satisfying double (IEEE addition skips 0.1),
+# so check() denies every row. The pre-fix algebraic solve emitted `score = -0.6`
+# and returned e3.
+assert_ids "edge/ieee-eq"      "$EDGE&action=edge-ieee-eq"      ""
+
+# PR #274 (ne): pre-fix `score != -0.6` wrongly EXCLUDED e3; correct result is every
+# non-null score whose IEEE sum differs from 0.1 — e3 AND e4.
+assert_ids "edge/ieee-ne"      "$EDGE&action=edge-ieee-ne"      "e3,e4"
+
+# PR #275: `(public ? 1.0 : 0.0/0.0) > 0.5` — NaN ordering is false in CEL/IEEE, so
+# only public rows qualify. Pre-fix Double.compare made `NaN > 0.5` true and the
+# non-public rows e2 and e4 leaked through.
+assert_ids "edge/nan-ordering" "$EDGE&action=edge-nan-ordering" "e1,e3,e5,e6"
+
+# PR #279: retention window `timestamp(createdAt) < now() - duration("24h")` — the
+# rows older than 24h. Pre-fix this action was an HTTP 500 on every request.
+assert_ids "edge/retention"    "$EDGE&action=edge-retention"    "e1,e4,e5"
+
+# PR #285: startsWith("[SEC]") — the escaped LIKE pattern must literal-match e1 and
+# never match the class-trap row e2 ("Secret..." starts with a character in {S,E,C}).
+assert_ids "edge/bracket"      "$EDGE&action=edge-bracket-title" "e1"
+
+# PR #286: size(title) > 4294967296 — impossible, so zero rows. Pre-fix the (int)
+# cast wrapped the threshold to 0 and every non-empty title matched.
+assert_ids "edge/size-huge"    "$EDGE&action=edge-size-huge"    ""
+
+# PR #273: delete(Specification) with a Relation-mapped predicate must be refused by
+# the adapter's bulk-delete guard (surfaced by the demo endpoint as HTTP 409) instead
+# of silently destroying collection rows while deleting zero photos.
+DELETE_BODY=$(mktemp)
+DELETE_STATUS=$(curl -sS -X DELETE -o "$DELETE_BODY" -w '%{http_code}' \
+    "http://localhost:8080/photos/bulk-unsafe?user=alice&action=comment")
+if [[ "$DELETE_STATUS" != "409" ]]; then
+    cat "$DELETE_BODY" >&2
+    fail "bulk-unsafe delete: expected HTTP 409 from the guard, got HTTP $DELETE_STATUS"
+fi
+if ! grep -q "SELECT-only" "$DELETE_BODY"; then
+    cat "$DELETE_BODY" >&2
+    fail "bulk-unsafe delete: 409 body did not contain the guard's SELECT-only message"
+fi
+rm -f "$DELETE_BODY"
+ok "bulk-unsafe/guard  => HTTP 409 with guard message"
+
+# Integrity check: the guard must have fired BEFORE any SQL ran. The photo rows and —
+# crucially — the tag/label/grant collection rows (the pre-#273 corruption target)
+# must all still produce the same row sets smoke.sh pins.
+assert_ids "bulk-unsafe/photos-intact" \
+    "http://localhost:8080/photos?user=alice&action=comment" "p1,p2,p5,p6,p7,p8"
+assert_ids "bulk-unsafe/grants-intact" \
+    "http://localhost:8080/photos?user=alice&action=group-grant&groups=finance" "p2,p7"
+assert_ids "bulk-unsafe/labels-intact" \
+    "http://localhost:8080/photos?user=alice&action=needs-moderation" "p2,p3"
+
+echo
+ok "all edge-case regression assertions passed"

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/Photo.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/Photo.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -45,6 +46,23 @@ public class Photo {
 
     @Column(name = "rating", nullable = false)
     private int rating;
+
+    /**
+     * Nullable IEEE-double attribute used only by the {@code edge-ieee-*} regression
+     * scenarios (see scripts/smoke-edge-cases.sh). Kept nullable so the regular fixtures
+     * are unaffected: a NULL score is UNKNOWN under SQL three-valued logic and a missing
+     * attribute is a CEL evaluation error at check() time — both sides exclude the row.
+     */
+    @Column(name = "score")
+    private Double score;
+
+    /**
+     * Photo creation instant for the {@code edge-retention} time-window scenario. Mapped as
+     * {@link Instant} because the adapter's {@code timestamp()} support compares folded
+     * RFC-3339 plan constants against {@code Instant}/{@code OffsetDateTime} columns.
+     */
+    @Column(name = "created_at")
+    private Instant createdAt;
 
     @Embedded
     private PhotoDetails details;
@@ -90,6 +108,18 @@ public class Photo {
         return this;
     }
 
+    /** Fluent setter used only by the edge-case regression fixtures. */
+    public Photo withScore(Double score) {
+        this.score = score;
+        return this;
+    }
+
+    /** Fluent setter used only by the edge-case regression fixtures. */
+    public Photo withCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
     public String getId() { return id; }
     public String getTenantId() { return tenantId; }
     public String getOwnerId() { return ownerId; }
@@ -98,6 +128,8 @@ public class Photo {
     public boolean isArchived() { return isArchived; }
     public String getLocation() { return location; }
     public int getRating() { return rating; }
+    public Double getScore() { return score; }
+    public Instant getCreatedAt() { return createdAt; }
     public PhotoDetails getDetails() { return details; }
     public Set<String> getTags() { return tags; }
     public Set<PhotoLabel> getLabels() { return labels; }

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoController.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoController.java
@@ -4,6 +4,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -94,6 +96,39 @@ public class PhotoController {
         return service.listAllowed(
                         context(user, role, tenant, groups, interests), action, minRating, pageRequest)
                 .map(PhotoView::from);
+    }
+
+    /**
+     * DELETE /photos/bulk-unsafe?user=alice&action=comment
+     *
+     * <p><strong>Intentionally-failing demonstration of the adapter's bulk-delete guard —
+     * this endpoint is expected to return 409, not delete anything.</strong> It passes the
+     * Cerbos Specification to {@code JpaSpecificationExecutor.delete(Specification)}, which
+     * the adapter forbids whenever the plan touches a Relation mapping: Hibernate's
+     * multi-table bulk delete would first clear the collection tables the correlated EXISTS
+     * subquery references, silently destroying tag/label/grant rows while deleting zero
+     * photos (PR #273). The adapter detects the bulk-delete invocation context and throws
+     * {@link UnsupportedOperationException} before any SQL runs; this endpoint surfaces that
+     * as HTTP 409 with the guard's message. The smoke harness asserts the 409 and then
+     * proves the photo and collection rows are untouched. The correct deletion pattern is
+     * {@code findAll(spec)} then {@code deleteAllById(ids)}.
+     */
+    @DeleteMapping("/bulk-unsafe")
+    public ResponseEntity<String> bulkUnsafeDelete(@RequestParam String user,
+                                                   @RequestParam(defaultValue = "user") String role,
+                                                   @RequestParam(defaultValue = "comment") String action,
+                                                   @RequestParam(defaultValue = "acme") String tenant,
+                                                   @RequestParam(defaultValue = "") String groups,
+                                                   @RequestParam(defaultValue = "") String interests) {
+        try {
+            long deleted = service.unsafeBulkDelete(
+                    context(user, role, tenant, groups, interests), action);
+            // The guard failing to fire is itself a regression — make it loud.
+            return ResponseEntity.internalServerError()
+                    .body("bulk-delete guard did not fire; rows deleted: " + deleted);
+        } catch (UnsupportedOperationException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+        }
     }
 
     private static AccessContext context(String user, String role, String tenant,

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoService.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/PhotoService.java
@@ -32,6 +32,11 @@ public class PhotoService {
             Map.entry("request.resource.attr.title", AttributeMapping.field("title")),
             Map.entry("request.resource.attr.location", AttributeMapping.field("location")),
             Map.entry("request.resource.attr.rating", AttributeMapping.field("rating")),
+            // Edge-case regression scenarios (scripts/smoke-edge-cases.sh): a nullable
+            // double for the IEEE arithmetic probes and an Instant column for the
+            // timestamp()/retention-window rule.
+            Map.entry("request.resource.attr.score", AttributeMapping.field("score")),
+            Map.entry("request.resource.attr.createdAt", AttributeMapping.field("createdAt")),
             Map.entry("request.resource.attr.metadata.width", AttributeMapping.field("details.pixelWidth")),
             Map.entry("request.resource.attr.tags", AttributeMapping.relation("tags")),
             Map.entry("request.resource.attr.labels", AttributeMapping.relation("labels", Map.of(
@@ -62,6 +67,22 @@ public class PhotoService {
     public Page<Photo> listAllowed(AccessContext context, String action, Integer minRating,
                                    Pageable pageable) {
         return repository.findAll(specification(context, action, minRating), pageable);
+    }
+
+    /**
+     * Deliberately passes the Cerbos Specification to
+     * {@code JpaSpecificationExecutor.delete(Specification)} — the one repository operation
+     * the adapter forbids. Whenever the plan touches a Relation mapping (tags, labels,
+     * grants), the adapter throws {@link UnsupportedOperationException} instead of letting
+     * Hibernate's multi-table bulk delete corrupt the collection tables (PR #273: the bulk
+     * delete first clears the @ElementCollection/join rows the correlated EXISTS references,
+     * so 0 entity rows were deleted while their collection rows were silently destroyed).
+     * Exists only so {@code DELETE /photos/bulk-unsafe} can demonstrate — and the smoke
+     * harness can pin — that guard. Production code should select ids with
+     * {@code findAll(spec)} and delete via {@code deleteAllById(ids)}.
+     */
+    public long unsafeBulkDelete(AccessContext context, String action) {
+        return repository.delete(specification(context, action, null));
     }
 
     private Specification<Photo> specification(AccessContext context, String action,

--- a/spring-data/example/src/main/java/dev/cerbos/example/photos/SeedData.java
+++ b/spring-data/example/src/main/java/dev/cerbos/example/photos/SeedData.java
@@ -3,6 +3,8 @@ package dev.cerbos.example.photos;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
 
@@ -60,6 +62,43 @@ public class SeedData implements CommandLineRunner {
                 new Photo("p9", "globex", "globex-user", "Confidential acquisition",
                         false, true, null, 2, new PhotoDetails(800, 600), Set.of("globex"))
                         .addGrant("globex", "view", null, "globex:finance")
+        ));
+
+        // Adversarial regression seeds — isolated in their own "edge" tenant so the
+        // tenant fence keeps them invisible to every scenario in scripts/smoke.sh.
+        // Each row exists to trigger a historical adapter bug end-to-end; the pinned
+        // expectations live in scripts/smoke-edge-cases.sh and the `edge-*` rules in
+        // policies/photo.yaml.
+        Instant oldEnough = Instant.now().minus(30, ChronoUnit.DAYS);   // outside 24h window
+        Instant tooRecent = Instant.now().minus(1, ChronoUnit.HOURS);   // inside 24h window
+        photoRepository.saveAll(List.of(
+                // e1: literal "[SEC]" title prefix — must MATCH edge-bracket-title (PR #285).
+                new Photo("e1", "edge", "edge-user", "[SEC] Quarterly report", true, false,
+                        null, 3, new PhotoDetails(1000, 800), Set.of())
+                        .withCreatedAt(oldEnough),
+                // e2: class-trap title — 'S' is in the T-SQL class [SEC]; an unescaped
+                // pattern would match it on SQL Server. Must NOT match edge-bracket-title.
+                new Photo("e2", "edge", "edge-user", "Secret launch plan", false, false,
+                        null, 3, new PhotoDetails(1000, 800), Set.of())
+                        .withCreatedAt(tooRecent),
+                // e3: score = -0.6 — the exact value the pre-#274 algebraic solve produced
+                // for `score + 0.7 == 0.1`; check() DENIES it (IEEE sum != 0.1).
+                new Photo("e3", "edge", "edge-user", "Precision probe", true, false,
+                        null, 3, new PhotoDetails(1000, 800), Set.of())
+                        .withScore(-0.6)
+                        .withCreatedAt(tooRecent),
+                // e4: unrelated non-null score; allowed by edge-ieee-ne alongside e3.
+                new Photo("e4", "edge", "edge-user", "Cold archive shot", false, false,
+                        null, 3, new PhotoDetails(1000, 800), Set.of())
+                        .withScore(2.5)
+                        .withCreatedAt(oldEnough),
+                // e5/e6: retention window rows — e5 old enough, e6 too recent (PR #279).
+                new Photo("e5", "edge", "edge-user", "Retention candidate", true, false,
+                        null, 3, new PhotoDetails(1000, 800), Set.of())
+                        .withCreatedAt(oldEnough),
+                new Photo("e6", "edge", "edge-user", "Fresh upload", true, false,
+                        null, 3, new PhotoDetails(1000, 800), Set.of())
+                        .withCreatedAt(tooRecent)
         ));
 
         albumRepository.saveAll(List.of(


### PR DESCRIPTION
Follow-up hardening from the internal adversarial review of the Spring Data adapter: the example app's smoke harness now doubles as a **full-stack regression tripwire** for the high-severity findings fixed in #273–#286. Each new scenario runs end to end — Spring Boot app, live Cerbos PDP, real `JpaSpecificationExecutor` against H2 — passes on current `main`, and demonstrably **failed immediately before its fix** (verified below), so a regression in any of these code paths now breaks the `example` CI job even if unit-level coverage is ever weakened.

The demo stays pedagogically clean: the `edge-*` actions live in a clearly-delimited section at the bottom of `example/policies/photo.yaml` (each with a comment naming the PR it pins and the old wrong behavior), the fixtures (`e1`–`e6`) sit in an isolated `edge` tenant so **no existing `smoke.sh` assertion changes**, and the new assertions live in a separate `scripts/smoke-edge-cases.sh` wired into the CI `example` job after `smoke.sh`.

### Scenarios

| Scenario | Pins | Old (pre-fix) behavior |
|---|---|---|
| `edge-ieee-eq` / `edge-ieee-ne` | #274 | `score + 0.7 == 0.1` solved algebraically to `score = -0.6`; the PDP-denied `-0.6` row was included by `eq` and excluded by `ne` (no double satisfies the equation — IEEE addition skips 0.1) |
| `edge-nan-ordering` | #275 | `(public ? 1.0 : 0.0/0.0) > 0.5` — `Double.compare` made `NaN > 0.5` true; non-public rows leaked |
| `edge-retention` | #279 | `timestamp(createdAt) < now() - duration("24h")` threw for every query (HTTP 500); now asserts exactly the older-than-24h rows (`Photo` gained an `Instant createdAt` for this — also the most common real compliance shape) |
| `edge-bracket-title` | #285 | `startsWith("[SEC]")` — asserts the escaped LIKE pattern literal-matches the `[SEC]…` row and never the `Secret…` class-trap row |
| `edge-size-huge` | #286 | `size(title) > 4294967296` — the `(int)` cast wrapped the threshold to 0 and every non-empty title matched; asserts zero rows (labeled as a deliberately pathological probe) |
| `DELETE /photos/bulk-unsafe` | #273 | `delete(Specification)` with a Relation predicate deleted 0 photos while destroying collection rows; the endpoint (clearly documented as an intentionally-failing guard demo) asserts HTTP 409 with the guard's SELECT-only message, then proves photo/tag/label/grant row sets are intact |

Collation (#272) and MySQL decimal arithmetic (#284) only manifest on real MySQL/SQL Server; rather than contort the H2 example, the README's new "Dialect-sensitive findings" note points at the adapter's real-database CI legs that already pin them.

### Tripwire verification (old adapter, new scenarios)

For #274, #275, and #286 I checked out the parent commit of each fix in a scratch worktree, overlaid this branch's example, and ran `smoke-edge-cases.sh` against the OLD adapter via the composite build:

- `dc15bc2^` (pre-#274): `FAIL edge/ieee-eq expected=<empty> got=e3`
- `b4aaa9e^` (pre-#275): `FAIL edge/nan-ordering expected=e1,e3,e5,e6 got=e1,e2,e3,e4,e5,e6`
- `aac88f2^` (pre-#286): `FAIL edge/size-huge expected=<empty> got=e1,e2,e3,e4,e5,e6` (the pre-#286 run also confirms the ieee/nan/retention/bracket assertions pass at that commit, isolating the failure to the size fix)

Not worktree-verified: #279 (pre-fix behavior is an HTTP 500 on every `edge-retention` request — pinned at unit/oracle level and empirically documented in the fix PR), #285 (H2 treats `[` as inert, so the H2 assertion pins that escaping preserves literal matching; the SQL Server divergence is covered by the adapter's unit tests), and #273 (the guard itself is exercised live by the 409 + integrity assertions; the pre-fix corruption is pinned by the adapter's integration test).

### Local verification

- `gradle -p example build` — BUILD SUCCESSFUL
- `./example/scripts/smoke.sh` — all existing assertions pass unchanged (new seeds are tenant-isolated)
- `./example/scripts/smoke-edge-cases.sh` — all 11 assertions pass on `main` + this branch

**Do not merge yet** — merge freeze in effect.
