### PR TITLE
docs(spring-data): reference internal tracking for the has() planner fold

### DIFF
--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -378,8 +378,8 @@ three-valued logic, including the places where naive translations leak under `NO
 ### `has(...)` over-grants at the planner level — write `!= null` instead
 
 This one is an **upstream Cerbos planner issue, not an adapter bug, and it affects every
-query-plan adapter equally** (no public cerbos/cerbos issue tracks it at the time of
-writing). The planner constant-folds an attribute-presence check like
+query-plan adapter equally** (tracked in the Cerbos team's internal issue tracker). The
+planner constant-folds an attribute-presence check like
 
 ```
 has(R.attr.aOptionalString)

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -774,8 +774,8 @@ class AdversarialConformanceTest {
      * PLANNER, so every query-plan adapter is affected equally; this adapter translates the
      * always-allowed plan faithfully. That is why {@code p-has} is excluded from the
      * {@code adapterMatchesCheckOracle} {@code @ValueSource}: the differential comparison
-     * cannot pass while the planner itself over-grants. (No public cerbos/cerbos issue tracks
-     * the fold at the time of writing — searched 2026-07.)
+     * cannot pass while the planner itself over-grants. (Tracked in the Cerbos team's
+     * internal issue tracker as of 2026-07; no public cerbos/cerbos issue exists.)
      *
      * <p>This test asserts BOTH halves of the divergence — the plan kind AND the check()
      * denials — so that the moment an upstream image stops folding, the test fails with


### PR DESCRIPTION
Follow-up to #289. The README gotcha and the tripwire javadoc stated that no issue tracks the upstream `has()` -> `ALWAYS_ALLOWED` planner fold. The fold is in fact tracked in the Cerbos team's internal issue tracker; this softens both statements so they stay accurate without referencing internal URLs from a public repo.

Comment-only change (README + test javadoc). Full spring-data build run locally: BUILD SUCCESSFUL.