### PR TITLE
Fold exists/all lambdas over literal value-list collections

### DIFF
--- a/drizzle/src/index.test.ts
+++ b/drizzle/src/index.test.ts
@@ -12,7 +12,7 @@ import {
   PlanResourcesResponse,
 } from "@cerbos/core";
 import { GRPC as Cerbos } from "@cerbos/grpc";
-import type { ValidationError } from "@cerbos/core";
+import type { ValidationError, Value } from "@cerbos/core";
 import Database from "better-sqlite3";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -1227,5 +1227,214 @@ describe("queryPlanToDrizzle", () => {
         mapper,
       })
     ).toThrow(/No mapping/);
+  });
+});
+
+describe("known-value collections (planner unroll cliff)", () => {
+  // The planner unrolls exists/all over a known collection (e.g. a folded
+  // principal attribute) into an or/and chain at <= 10 elements
+  // (cerbos/cerbos#2570, #2817) and emits the lambda with a literal value-list
+  // collection above that. These tests straddle the 10-item cliff so both wire
+  // shapes stay exercised regardless of the PDP version behind the sidecar.
+  describe("live plans across the 10-item threshold", () => {
+    const buildTeams = (size: number): string[] => {
+      const teams = ["string", "string3"];
+      while (teams.length < size) {
+        teams.push(`filler-${teams.length}`);
+      }
+      return teams;
+    };
+
+    const allowedIdsForPrincipal = async (
+      action: string,
+      principal: { id: string; roles: string[]; attr: Record<string, Value> }
+    ): Promise<string[]> => {
+      const response = await cerbos.checkResources({
+        principal,
+        resources: resourceAttributes.map((resource) => ({
+          resource: { kind: "resource", id: resource.id, attr: resource },
+          actions: [action],
+        })),
+      });
+      return response.results
+        .filter((result) => result.isAllowed(action) === true)
+        .map((result) => result.resource.id)
+        .sort();
+    };
+
+    describe.each([9, 10, 11])("with %i-element principal collection", (size) => {
+      test.each(["principal-exists", "principal-all"])(
+        "produces results matching checkResources for %s",
+        async (action) => {
+          const principal = {
+            id: "user1",
+            roles: ["USER"],
+            attr: { teams: buildTeams(size) },
+          };
+          const queryPlan = await cerbos.planResources({
+            principal,
+            resource: { kind: "resource" },
+            action,
+          });
+
+          expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+
+          const result = queryPlanToDrizzle({ queryPlan, mapper });
+          const ids = selectIds(ensureFilter(result));
+          expect(ids).toEqual(await allowedIdsForPrincipal(action, principal));
+          // Sanity-check the oracle itself matched the intended rows.
+          const teams = buildTeams(size);
+          const expected = resourceAttributes
+            .filter((r) =>
+              action === "principal-exists"
+                ? teams.includes(r.aString)
+                : !teams.includes(r.aString)
+            )
+            .map((r) => r.id)
+            .sort();
+          expect(ids).toEqual(expected);
+        }
+      );
+    });
+  });
+
+  describe("value-list lambda fold", () => {
+    const valueListPlan = (
+      operator: string,
+      elements: unknown[],
+      body: PlanExpressionOperand,
+      variable = "t"
+    ): PlanResourcesResponse =>
+      buildPlan({
+        operator,
+        operands: [
+          { value: elements },
+          { operator: "lambda", operands: [body, { name: variable }] },
+        ],
+      } as PlanExpressionOperand);
+
+    test("exists over a value list matches any element", () => {
+      const result = queryPlanToDrizzle({
+        queryPlan: valueListPlan("exists", ["string", "string3"], {
+          operator: "eq",
+          operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+        }),
+        mapper,
+      });
+      expect(selectIds(ensureFilter(result))).toEqual([
+        "resource1",
+        "resource3",
+      ]);
+    });
+
+    test("all over a value list requires every element", () => {
+      const result = queryPlanToDrizzle({
+        queryPlan: valueListPlan("all", ["string2"], {
+          operator: "ne",
+          operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+        }),
+        mapper,
+      });
+      expect(selectIds(ensureFilter(result))).toEqual([
+        "resource1",
+        "resource3",
+      ]);
+    });
+
+    test("empty value list keeps CEL identity semantics", () => {
+      const body: PlanExpressionOperand = {
+        operator: "eq",
+        operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+      };
+
+      // exists over [] is false; all over [] is true.
+      expect(
+        selectIds(
+          ensureFilter(
+            queryPlanToDrizzle({ queryPlan: valueListPlan("exists", [], body), mapper })
+          )
+        )
+      ).toEqual([]);
+      expect(
+        selectIds(
+          ensureFilter(
+            queryPlanToDrizzle({ queryPlan: valueListPlan("all", [], body), mapper })
+          )
+        )
+      ).toEqual(allResourceIds);
+    });
+
+    test("substitutes variable path references into element fields", () => {
+      const result = queryPlanToDrizzle({
+        queryPlan: valueListPlan(
+          "exists",
+          [{ name: "string" }, { name: "string3" }],
+          {
+            operator: "eq",
+            operands: [
+              { name: "request.resource.attr.aString" },
+              { name: "t.name" },
+            ],
+          }
+        ),
+        mapper,
+      });
+      expect(selectIds(ensureFilter(result))).toEqual([
+        "resource1",
+        "resource3",
+      ]);
+    });
+
+    test("throws when a variable path is missing on an element", () => {
+      expect(() =>
+        queryPlanToDrizzle({
+          queryPlan: valueListPlan("exists", [{ name: "alpha" }], {
+            operator: "eq",
+            operands: [
+              { name: "request.resource.attr.aString" },
+              { name: "t.missing" },
+            ],
+          }),
+          mapper,
+        })
+      ).toThrow('Cannot resolve "t.missing"');
+    });
+
+    test("throws for exists_one over a value list", () => {
+      expect(() =>
+        queryPlanToDrizzle({
+          queryPlan: valueListPlan("exists_one", ["a"], {
+            operator: "eq",
+            operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+          }),
+          mapper,
+        })
+      ).toThrow("'exists_one' over a literal collection value is not supported");
+    });
+
+    test("throws for a non-list collection value", () => {
+      const plan = buildPlan({
+        operator: "exists",
+        operands: [
+          { value: "not-a-list" },
+          {
+            operator: "lambda",
+            operands: [
+              {
+                operator: "eq",
+                operands: [
+                  { name: "request.resource.attr.aString" },
+                  { name: "t" },
+                ],
+              },
+              { name: "t" },
+            ],
+          },
+        ],
+      } as PlanExpressionOperand);
+      expect(() => queryPlanToDrizzle({ queryPlan: plan, mapper })).toThrow(
+        "'exists' over a literal collection requires a list value"
+      );
+    });
   });
 });

--- a/drizzle/src/index.test.ts
+++ b/drizzle/src/index.test.ts
@@ -1262,6 +1262,15 @@ describe("known-value collections (planner unroll cliff)", () => {
         .sort();
     };
 
+    // Supported PDPs are >= 0.54, where both macros unroll at <= 10 elements and
+    // ship the value-list lambda above that. Pin the wire shape so each leg
+    // provably exercises its side of the cliff — if a future planner moves the
+    // threshold, this fails loudly instead of silently testing one shape only.
+    const expectedShape: Record<string, { unrolled: string; macro: string }> = {
+      "principal-exists": { unrolled: "or", macro: "exists" },
+      "principal-all": { unrolled: "and", macro: "all" },
+    };
+
     describe.each([9, 10, 11])("with %i-element principal collection", (size) => {
       test.each(["principal-exists", "principal-all"])(
         "produces results matching checkResources for %s",
@@ -1278,6 +1287,13 @@ describe("known-value collections (planner unroll cliff)", () => {
           });
 
           expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+          const condition = (
+            queryPlan as { condition: PlanExpressionOperand }
+          ).condition;
+          const shape = expectedShape[action];
+          expect(
+            "operator" in condition ? condition.operator : undefined
+          ).toEqual(size <= 10 ? shape?.unrolled : shape?.macro);
 
           const result = queryPlanToDrizzle({ queryPlan, mapper });
           const ids = selectIds(ensureFilter(result));

--- a/drizzle/src/index.ts
+++ b/drizzle/src/index.ts
@@ -874,6 +874,154 @@ const buildHasIntersectionFilter = (
 
 type CollectionOperator = "exists" | "exists_one" | "filter" | "all" | "except";
 
+// Operators whose second operand is a lambda that binds an iteration variable.
+const LAMBDA_BINDING_OPERATORS = new Set([
+  "exists",
+  "exists_one",
+  "all",
+  "filter",
+  "map",
+  "except",
+]);
+
+/**
+ * Substitute a lambda iteration variable with a concrete collection element
+ * inside a lambda body. A bare reference to the variable becomes the element
+ * itself; a `variable.path.to.field` reference drills into the element. A
+ * nested collection macro whose lambda rebinds the same variable name shadows
+ * the outer variable, so substitution only descends into its collection
+ * operand.
+ */
+const substituteLambdaVariable = (
+  operand: PlanExpressionOperand,
+  variableName: string,
+  element: Value
+): PlanExpressionOperand => {
+  if (isNameOperand(operand)) {
+    if (operand.name === variableName) {
+      return { value: element };
+    }
+    if (operand.name.startsWith(`${variableName}.`)) {
+      let current: Value = element;
+      for (const segment of operand.name
+        .slice(variableName.length + 1)
+        .split(".")) {
+        if (
+          current === null ||
+          typeof current !== "object" ||
+          Array.isArray(current) ||
+          !(segment in current)
+        ) {
+          throw new Error(
+            `Cannot resolve "${operand.name}": collection element has no field "${segment}"`
+          );
+        }
+        current = current[segment] as Value;
+      }
+      return { value: current };
+    }
+    return operand;
+  }
+
+  if (isExpressionOperand(operand)) {
+    if (
+      LAMBDA_BINDING_OPERATORS.has(operand.operator) &&
+      operand.operands.length === 2
+    ) {
+      const [nestedCollection, nestedLambda] = operand.operands;
+      if (
+        nestedCollection !== undefined &&
+        nestedLambda !== undefined &&
+        isExpressionOperand(nestedLambda) &&
+        nestedLambda.operator === "lambda"
+      ) {
+        const nestedVariable = nestedLambda.operands[1];
+        if (
+          nestedVariable !== undefined &&
+          isNameOperand(nestedVariable) &&
+          nestedVariable.name === variableName
+        ) {
+          // The nested lambda shadows our variable: substitute only in the
+          // collection operand.
+          return {
+            operator: operand.operator,
+            operands: [
+              substituteLambdaVariable(nestedCollection, variableName, element),
+              nestedLambda,
+            ],
+          };
+        }
+      }
+    }
+    return {
+      operator: operand.operator,
+      operands: operand.operands.map((o) =>
+        substituteLambdaVariable(o, variableName, element)
+      ),
+    };
+  }
+
+  return operand;
+};
+
+/**
+ * Fold a collection macro whose collection operand is a literal value list.
+ *
+ * The planner emits this shape when a known-value collection (typically a
+ * folded principal attribute) has more than 10 elements — at 10 or fewer it
+ * unrolls `exists`/`all` into an or/and chain itself (cerbos/cerbos#2570,
+ * cerbos/cerbos#2817; `maxItems = 10` in the planner's struct matcher). Apply
+ * the same fold here so the translated filter does not depend on which side of
+ * that threshold the collection lands: substitute each element into the lambda
+ * body and combine the per-element conditions with OR (`exists`) or AND
+ * (`all`). The empty collection keeps CEL identity semantics: `exists` over
+ * `[]` is false, `all` over `[]` is true.
+ */
+const buildKnownValueCollectionFilter = (
+  operator: CollectionOperator,
+  collectionValue: Value,
+  lambdaOperand: PlanExpressionOperand,
+  mapper: Mapper
+): SQL => {
+  if (operator !== "exists" && operator !== "all") {
+    throw new Error(
+      `'${operator}' over a literal collection value is not supported. ` +
+        "Only exists() and all() can be folded into a flat filter."
+    );
+  }
+
+  if (!Array.isArray(collectionValue)) {
+    throw new Error(
+      `'${operator}' over a literal collection requires a list value`
+    );
+  }
+
+  const { variable: variableOperand, expression: bodyOperand } =
+    extractLambdaComponents(lambdaOperand, `'${operator}' lambda operand`);
+  if (!isNameOperand(variableOperand)) {
+    throw new Error("Lambda variable must have a name operand");
+  }
+
+  if (collectionValue.length === 0) {
+    return operator === "exists" ? FALSE_CONDITION : TRUE_CONDITION;
+  }
+
+  const filters = collectionValue.map((element) =>
+    buildFilterFromExpression(
+      substituteLambdaVariable(bodyOperand, variableOperand.name, element),
+      mapper
+    )
+  );
+
+  const combined = operator === "exists" ? or(...filters) : and(...filters);
+  if (!combined) {
+    throw new Error(
+      `Unable to combine folded '${operator}' collection conditions`
+    );
+  }
+  return combined;
+};
+
 const buildCollectionOperatorFilter = (
   operator: CollectionOperator,
   operands: PlanExpressionOperand[],
@@ -887,6 +1035,17 @@ const buildCollectionOperatorFilter = (
   const lambdaOperand = operands[1];
   if (!collectionOperand || !lambdaOperand) {
     throw new Error(`'${operator}' operator requires collection and lambda operands`);
+  }
+  // A literal value list arrives when the planner could not unroll a macro
+  // over a known collection (more than 10 elements) — fold it here instead of
+  // requiring a relation mapping that cannot exist for a literal.
+  if (isValueOperand(collectionOperand)) {
+    return buildKnownValueCollectionFilter(
+      operator,
+      collectionOperand.value,
+      lambdaOperand,
+      mapper
+    );
   }
   if (!isNameOperand(collectionOperand)) {
     throw new Error("Collection operand must be a field reference");

--- a/policies/resource.yaml
+++ b/policies/resource.yaml
@@ -457,6 +457,29 @@ resourcePolicy:
         match:
           expr: R.attr.tags.all(tag, tag.name == "public")
 
+    # Principal-collection macros: P.attr.* is always folded to a known value at plan
+    # time, so the planner unrolls these to or/and chains when the collection has <= 10
+    # elements (cerbos/cerbos#2570 exists, since 0.45; cerbos/cerbos#2817 all, since
+    # 0.54) and emits the lambda with a literal value-list collection when it has more.
+    # Adapter tests exercise both sides of that 10-item cliff (9/10/11 elements).
+    - actions:
+        - "principal-exists"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: P.attr.teams.exists(t, R.attr.aString == t)
+
+    - actions:
+        - "principal-all"
+      effect: EFFECT_ALLOW
+      roles:
+        - USER
+      condition:
+        match:
+          expr: P.attr.teams.all(t, R.attr.aString != t)
+
     - actions:
         - "filter"
       effect: EFFECT_ALLOW

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -8014,3 +8014,282 @@ describe("Value-First Operand Order", () => {
     );
   });
 });
+
+describe("Known-Value Collections (planner unroll cliff)", () => {
+  // The planner unrolls exists/all over a known collection (e.g. a folded
+  // principal attribute) into an or/and chain at <= 10 elements
+  // (cerbos/cerbos#2570, #2817) and emits the lambda with a literal value-list
+  // collection above that. These tests straddle the 10-item cliff so both wire
+  // shapes stay exercised regardless of the PDP version behind the sidecar.
+  describe("live plans across the 10-item threshold", () => {
+    const buildTeams = (size: number): string[] => {
+      const teams = ["string", "string3"];
+      while (teams.length < size) {
+        teams.push(`filler-${teams.length}`);
+      }
+      return teams;
+    };
+
+    describe.each([9, 10, 11])("with %i-element principal collection", (size) => {
+      test("conditional - principal-exists", async () => {
+        const teams = buildTeams(size);
+        const queryPlan = await cerbos.planResources({
+          principal: { id: "user1", roles: ["USER"], attr: { teams } },
+          resource: { kind: "resource" },
+          action: "principal-exists",
+        });
+
+        expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+
+        const result = queryPlanToPrisma({
+          queryPlan,
+          mapper: {
+            "request.resource.attr.aString": { field: "aString" },
+          },
+        });
+
+        if (result.kind !== PlanKind.CONDITIONAL) {
+          throw new Error("Expected CONDITIONAL result");
+        }
+
+        const query = await prisma.resource.findMany({
+          where: { ...result.filters },
+        });
+        expect(query.map((r) => r.id).sort()).toEqual(
+          fixtureResources
+            .filter((r) => teams.includes(r.aString))
+            .map((r) => r.id)
+            .sort()
+        );
+      });
+
+      test("conditional - principal-all", async () => {
+        const teams = buildTeams(size);
+        const queryPlan = await cerbos.planResources({
+          principal: { id: "user1", roles: ["USER"], attr: { teams } },
+          resource: { kind: "resource" },
+          action: "principal-all",
+        });
+
+        expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+
+        const result = queryPlanToPrisma({
+          queryPlan,
+          mapper: {
+            "request.resource.attr.aString": { field: "aString" },
+          },
+        });
+
+        if (result.kind !== PlanKind.CONDITIONAL) {
+          throw new Error("Expected CONDITIONAL result");
+        }
+
+        const query = await prisma.resource.findMany({
+          where: { ...result.filters },
+        });
+        expect(query.map((r) => r.id).sort()).toEqual(
+          fixtureResources
+            .filter((r) => !teams.includes(r.aString))
+            .map((r) => r.id)
+            .sort()
+        );
+      });
+    });
+  });
+
+  describe("value-list lambda fold", () => {
+    const valueListPlan = (
+      operator: string,
+      elements: unknown[],
+      body: PlanExpressionOperand,
+      variable = "t"
+    ): PlanResourcesConditionalResponse =>
+      createConditionalPlan({
+        operator,
+        operands: [
+          { value: elements },
+          { operator: "lambda", operands: [body, { name: variable }] },
+        ],
+      } as PlanExpressionOperand);
+
+    test("exists over a value list folds to OR of the substituted body", () => {
+      const result = queryPlanToPrisma({
+        queryPlan: valueListPlan("exists", ["a", "b", "c"], {
+          operator: "eq",
+          operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+        }),
+        mapper: { "request.resource.attr.aString": { field: "aString" } },
+      });
+
+      expect(result).toStrictEqual({
+        kind: PlanKind.CONDITIONAL,
+        filters: {
+          OR: [
+            { aString: { equals: "a" } },
+            { aString: { equals: "b" } },
+            { aString: { equals: "c" } },
+          ],
+        },
+      });
+    });
+
+    test("all over a value list folds to AND of the substituted body", () => {
+      const result = queryPlanToPrisma({
+        queryPlan: valueListPlan("all", ["a", "b"], {
+          operator: "ne",
+          operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+        }),
+        mapper: { "request.resource.attr.aString": { field: "aString" } },
+      });
+
+      expect(result).toStrictEqual({
+        kind: PlanKind.CONDITIONAL,
+        filters: {
+          AND: [{ aString: { not: "a" } }, { aString: { not: "b" } }],
+        },
+      });
+    });
+
+    test("substitutes variable path references into element fields", () => {
+      const result = queryPlanToPrisma({
+        queryPlan: valueListPlan(
+          "exists",
+          [{ name: "alpha", meta: { rank: 1 } }, { name: "beta", meta: { rank: 2 } }],
+          {
+            operator: "eq",
+            operands: [{ name: "request.resource.attr.aString" }, { name: "t.name" }],
+          }
+        ),
+        mapper: { "request.resource.attr.aString": { field: "aString" } },
+      });
+
+      expect(result).toStrictEqual({
+        kind: PlanKind.CONDITIONAL,
+        filters: {
+          OR: [{ aString: { equals: "alpha" } }, { aString: { equals: "beta" } }],
+        },
+      });
+    });
+
+    test("empty value list yields CEL identity semantics", () => {
+      const body: PlanExpressionOperand = {
+        operator: "eq",
+        operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+      };
+      const mapper = { "request.resource.attr.aString": { field: "aString" } };
+
+      // exists over [] is false — Prisma matches nothing for OR: []
+      expect(
+        queryPlanToPrisma({ queryPlan: valueListPlan("exists", [], body), mapper })
+      ).toStrictEqual({ kind: PlanKind.CONDITIONAL, filters: { OR: [] } });
+
+      // all over [] is true — Prisma matches everything for AND: []
+      expect(
+        queryPlanToPrisma({ queryPlan: valueListPlan("all", [], body), mapper })
+      ).toStrictEqual({ kind: PlanKind.CONDITIONAL, filters: { AND: [] } });
+    });
+
+    test("nested lambda rebinding the variable shadows the outer substitution", () => {
+      // Outer t is substituted; the inner exists rebinds t over a relation, so
+      // its body must keep referencing the inner variable untouched.
+      const result = queryPlanToPrisma({
+        queryPlan: valueListPlan("exists", ["public", "private"], {
+          operator: "exists",
+          operands: [
+            { name: "request.resource.attr.tags" },
+            {
+              operator: "lambda",
+              operands: [
+                {
+                  operator: "eq",
+                  operands: [{ name: "t.name" }, { value: "fixed" }],
+                },
+                { name: "t" },
+              ],
+            },
+          ],
+        }),
+        mapper: {
+          "request.resource.attr.tags": {
+            relation: { name: "tags", type: "many" },
+          },
+        },
+      });
+
+      expect(result).toStrictEqual({
+        kind: PlanKind.CONDITIONAL,
+        filters: {
+          OR: [
+            { tags: { some: { name: { equals: "fixed" } } } },
+            { tags: { some: { name: { equals: "fixed" } } } },
+          ],
+        },
+      });
+    });
+
+    test("throws when a variable path is missing on an element", () => {
+      expect(() =>
+        queryPlanToPrisma({
+          queryPlan: valueListPlan("exists", [{ name: "alpha" }], {
+            operator: "eq",
+            operands: [
+              { name: "request.resource.attr.aString" },
+              { name: "t.missing" },
+            ],
+          }),
+          mapper: { "request.resource.attr.aString": { field: "aString" } },
+        })
+      ).toThrow('Cannot resolve "t.missing"');
+    });
+
+    test("throws for exists_one over a value list", () => {
+      expect(() =>
+        queryPlanToPrisma({
+          queryPlan: valueListPlan("exists_one", ["a"], {
+            operator: "eq",
+            operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+          }),
+          mapper: { "request.resource.attr.aString": { field: "aString" } },
+        })
+      ).toThrow("exists_one over a literal collection value is not supported");
+    });
+
+    test("throws for a non-list collection value", () => {
+      expect(() =>
+        queryPlanToPrisma({
+          queryPlan: valueListPlan("exists", ["ignored"], {
+            operator: "eq",
+            operands: [{ name: "request.resource.attr.aString" }, { name: "t" }],
+          }),
+          mapper: { "request.resource.attr.aString": { field: "aString" } },
+        })
+      ).not.toThrow();
+
+      const plan = createConditionalPlan({
+        operator: "exists",
+        operands: [
+          { value: { not: "a list" } },
+          {
+            operator: "lambda",
+            operands: [
+              {
+                operator: "eq",
+                operands: [
+                  { name: "request.resource.attr.aString" },
+                  { name: "t" },
+                ],
+              },
+              { name: "t" },
+            ],
+          },
+        ],
+      } as PlanExpressionOperand);
+      expect(() =>
+        queryPlanToPrisma({
+          queryPlan: plan,
+          mapper: { "request.resource.attr.aString": { field: "aString" } },
+        })
+      ).toThrow("exists over a literal collection requires a list value");
+    });
+  });
+});

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -8030,6 +8030,23 @@ describe("Known-Value Collections (planner unroll cliff)", () => {
       return teams;
     };
 
+    // Supported PDPs are >= 0.54, where both macros unroll at <= 10 elements and
+    // ship the value-list lambda above that. Pin the wire shape so each leg
+    // provably exercises its side of the cliff — if a future planner moves the
+    // threshold, this fails loudly instead of silently testing one shape only.
+    const expectShape = (
+      queryPlan: PlanResourcesResponse,
+      size: number,
+      unrolledOperator: string,
+      macroOperator: string
+    ): void => {
+      const condition = (queryPlan as PlanResourcesConditionalResponse)
+        .condition;
+      expect((condition as PlanExpression).operator).toEqual(
+        size <= 10 ? unrolledOperator : macroOperator
+      );
+    };
+
     describe.each([9, 10, 11])("with %i-element principal collection", (size) => {
       test("conditional - principal-exists", async () => {
         const teams = buildTeams(size);
@@ -8040,6 +8057,7 @@ describe("Known-Value Collections (planner unroll cliff)", () => {
         });
 
         expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+        expectShape(queryPlan, size, "or", "exists");
 
         const result = queryPlanToPrisma({
           queryPlan,
@@ -8072,6 +8090,7 @@ describe("Known-Value Collections (planner unroll cliff)", () => {
         });
 
         expect(queryPlan.kind).toEqual(PlanKind.CONDITIONAL);
+        expectShape(queryPlan, size, "and", "all");
 
         const result = queryPlanToPrisma({
           queryPlan,

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -127,6 +127,164 @@ function assertDefined<T>(value: T | undefined, message: string): T {
   return value;
 }
 
+// Operators whose second operand is a lambda that binds an iteration variable.
+const LAMBDA_BINDING_OPERATORS = new Set([
+  "exists",
+  "exists_one",
+  "all",
+  "filter",
+  "map",
+  "except",
+]);
+
+/**
+ * Substitute a lambda iteration variable with a concrete collection element
+ * inside a lambda body. A bare reference to the variable becomes the element
+ * itself; a `variable.path.to.field` reference drills into the element. A
+ * nested collection macro whose lambda rebinds the same variable name shadows
+ * the outer variable, so substitution only descends into its collection
+ * operand.
+ */
+function substituteLambdaVariable(
+  operand: PlanExpressionOperand,
+  variableName: string,
+  element: Value
+): PlanExpressionOperand {
+  if (isNamedOperand(operand)) {
+    if (operand.name === variableName) {
+      return { value: element };
+    }
+    if (operand.name.startsWith(`${variableName}.`)) {
+      let current: Value = element;
+      for (const segment of operand.name
+        .slice(variableName.length + 1)
+        .split(".")) {
+        if (
+          current === null ||
+          typeof current !== "object" ||
+          Array.isArray(current) ||
+          !(segment in current)
+        ) {
+          throw new Error(
+            `Cannot resolve "${operand.name}": collection element has no field "${segment}"`
+          );
+        }
+        current = current[segment] as Value;
+      }
+      return { value: current };
+    }
+    return operand;
+  }
+
+  if (isOperatorOperand(operand)) {
+    if (
+      LAMBDA_BINDING_OPERATORS.has(operand.operator) &&
+      operand.operands.length === 2
+    ) {
+      const [nestedCollection, nestedLambda] = operand.operands;
+      if (
+        nestedCollection !== undefined &&
+        nestedLambda !== undefined &&
+        isOperatorOperand(nestedLambda) &&
+        nestedLambda.operator === "lambda"
+      ) {
+        const nestedVariable = nestedLambda.operands[1];
+        if (
+          nestedVariable !== undefined &&
+          isNamedOperand(nestedVariable) &&
+          nestedVariable.name === variableName
+        ) {
+          // The nested lambda shadows our variable: substitute only in the
+          // collection operand.
+          return {
+            operator: operand.operator,
+            operands: [
+              substituteLambdaVariable(nestedCollection, variableName, element),
+              nestedLambda,
+            ],
+          };
+        }
+      }
+    }
+    return {
+      operator: operand.operator,
+      operands: operand.operands.map((o) =>
+        substituteLambdaVariable(o, variableName, element)
+      ),
+    };
+  }
+
+  return operand;
+}
+
+/**
+ * Fold a collection macro whose collection operand is a literal value list.
+ *
+ * The planner emits this shape when a known-value collection (typically a
+ * folded principal attribute) has more than 10 elements — at 10 or fewer it
+ * unrolls `exists`/`all` into an or/and chain itself (cerbos/cerbos#2570,
+ * cerbos/cerbos#2817; `maxItems = 10` in the planner's struct matcher). Apply
+ * the same fold here so the translated filter does not depend on which side of
+ * that threshold the collection lands: substitute each element into the lambda
+ * body and combine the per-element filters with OR (`exists`) or AND (`all`).
+ *
+ * An empty list yields `{OR: []}` / `{AND: []}`, which Prisma evaluates to
+ * match-nothing / match-everything — exactly CEL's `exists`/`all` semantics
+ * over an empty collection.
+ */
+function handleKnownValueCollectionOperator(
+  operator: string,
+  collection: ValueOperand,
+  lambda: PlanExpressionOperand,
+  mapper: Mapper
+): PrismaFilter {
+  if (operator !== "exists" && operator !== "all") {
+    throw new Error(
+      `${operator} over a literal collection value is not supported. ` +
+        "Only exists() and all() can be folded into a flat filter."
+    );
+  }
+
+  const elements = collection.value;
+  if (!Array.isArray(elements)) {
+    throw new Error(
+      `${operator} over a literal collection requires a list value`
+    );
+  }
+
+  if (!isOperatorOperand(lambda) || lambda.operator !== "lambda") {
+    throw new Error(
+      `Second operand of ${operator} must be a lambda expression`
+    );
+  }
+  if (lambda.operands.length !== 2) {
+    throw new Error(
+      `${operator} over a literal collection supports single-variable lambdas only`
+    );
+  }
+
+  const body = assertDefined(
+    lambda.operands[0],
+    "Lambda expression must provide a condition"
+  );
+  const variable = assertDefined(
+    lambda.operands[1],
+    "Lambda variable must have a name"
+  );
+  if (!isNamedOperand(variable)) {
+    throw new Error("Lambda variable must have a name");
+  }
+
+  const filters = elements.map((element) =>
+    buildPrismaFilterFromCerbosExpression(
+      substituteLambdaVariable(body, variable.name, element),
+      mapper
+    )
+  );
+
+  return operator === "exists" ? { OR: filters } : { AND: filters };
+}
+
 function getLeafField(path: string[]): string {
   const fieldName = path[path.length - 1];
   if (!fieldName) {
@@ -1368,6 +1526,18 @@ function handleCollectionOperator(
     operands[1],
     `${operator} requires a lambda operand`
   );
+
+  // A literal value list arrives when the planner could not unroll a macro
+  // over a known collection (more than 10 elements) — fold it here instead of
+  // requiring a relation mapping that cannot exist for a literal.
+  if (isValueOperand(collection)) {
+    return handleKnownValueCollectionOperator(
+      operator,
+      collection,
+      lambda,
+      mapper
+    );
+  }
 
   if (!isNamedOperand(collection)) {
     throw new Error(

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -2214,6 +2214,16 @@ public final class SpringDataQueryPlanAdapter {
             Operand listOperand = operands.get(0);
             Operand lambdaOperand = operands.get(1);
 
+            // A literal value-list collection arrives when the planner could not unroll a
+            // macro over a known collection: at <= 10 elements it folds exists/all into an
+            // or/and chain itself (cerbos/cerbos#2570, #2817; maxItems = 10 in the planner's
+            // struct matcher), above that the lambda ships with the folded value list as its
+            // collection operand. Apply the same fold here instead of demanding a Relation
+            // mapping that cannot exist for a literal.
+            if (listOperand.getNodeCase() == Operand.NodeCase.VALUE) {
+                return handleKnownValueCollection(op, listOperand.getValue(), lambdaOperand, scope);
+            }
+
             if (listOperand.getNodeCase() != Operand.NodeCase.VARIABLE) {
                 throw new IllegalArgumentException(op + " first operand must be a variable");
             }
@@ -2262,6 +2272,129 @@ public final class SpringDataQueryPlanAdapter {
                         cb.equal(strictMatchCountSubquery(scope, ref, bodyBuilder), 1L);
                 default -> throw new IllegalArgumentException("Unsupported collection operator: " + op);
             });
+        }
+
+        /** Operators whose second operand is a lambda that binds an iteration variable. */
+        private static final Set<String> LAMBDA_BINDING_OPERATORS =
+                Set.of("exists", "exists_one", "all", "filter", "map", "except");
+
+        /**
+         * Fold a collection macro whose collection operand is a literal value list: substitute
+         * each element into the lambda body and combine the per-element expressions with
+         * {@code or} ({@code exists}) or {@code and} ({@code all}), then translate the combined
+         * expression through the normal {@link #traverse} path — the same fold the planner
+         * itself applies to known collections of 10 or fewer elements, so the translated
+         * filter does not depend on which side of that threshold the collection lands.
+         *
+         * <p>The empty collection keeps CEL identity semantics: {@code exists} over {@code []}
+         * is false, {@code all} over {@code []} is true. Element comparisons produced by the
+         * fold flow through the standard comparison translation, so NULL columns keep their
+         * SQL-UNKNOWN (row excluded under both polarities) behavior — matching how a
+         * planner-unrolled chain of the same comparisons translates.
+         */
+        private Predicate handleKnownValueCollection(String op, Value collectionValue,
+                                                     Operand lambdaOperand, Scope scope) {
+            if (!"exists".equals(op) && !"all".equals(op)) {
+                throw new IllegalArgumentException(op
+                        + " over a literal collection value is not supported. "
+                        + "Only exists() and all() can be folded into a flat filter.");
+            }
+            if (collectionValue.getKindCase() != Value.KindCase.LIST_VALUE) {
+                throw new IllegalArgumentException(op
+                        + " over a literal collection requires a list value");
+            }
+            ParsedLambda lambda = parseLambda(lambdaOperand,
+                    op + " second operand must be a lambda",
+                    op + " over a literal collection supports single-variable lambdas only",
+                    "lambda variable must be a variable operand");
+
+            List<Value> elements = collectionValue.getListValue().getValuesList();
+            if (elements.isEmpty()) {
+                return "exists".equals(op) ? cb.disjunction() : cb.conjunction();
+            }
+
+            PlanResourcesFilter.Expression.Builder combined = PlanResourcesFilter.Expression
+                    .newBuilder()
+                    .setOperator("exists".equals(op) ? "or" : "and");
+            for (Value element : elements) {
+                combined.addOperands(
+                        substituteLambdaVariable(lambda.body(), lambda.varName(), element));
+            }
+            return traverse(Operand.newBuilder().setExpression(combined).build(), scope);
+        }
+
+        /**
+         * Substitute a lambda iteration variable with a concrete collection element inside a
+         * lambda body. A bare reference to the variable becomes the element itself; a
+         * {@code variable.path.to.field} reference drills into the element (failing closed
+         * when the path is missing — the CEL evaluation of that element would error). A nested
+         * macro whose lambda rebinds the same variable name shadows the outer variable, so
+         * substitution only descends into its collection operand.
+         */
+        private static Operand substituteLambdaVariable(Operand operand, String varName,
+                                                        Value element) {
+            switch (operand.getNodeCase()) {
+                case VARIABLE -> {
+                    String name = operand.getVariable();
+                    if (name.equals(varName)) {
+                        return Operand.newBuilder().setValue(element).build();
+                    }
+                    if (name.startsWith(varName + ".")) {
+                        return Operand.newBuilder()
+                                .setValue(resolveElementPath(name,
+                                        name.substring(varName.length() + 1), element))
+                                .build();
+                    }
+                    return operand;
+                }
+                case EXPRESSION -> {
+                    PlanResourcesFilter.Expression expr = operand.getExpression();
+                    List<Operand> ops = expr.getOperandsList();
+                    PlanResourcesFilter.Expression.Builder rebuilt = expr.toBuilder();
+                    if (LAMBDA_BINDING_OPERATORS.contains(expr.getOperator()) && ops.size() == 2
+                            && shadowsVariable(ops.get(1), varName)) {
+                        // The nested lambda rebinds our variable: substitute only in the
+                        // collection operand.
+                        rebuilt.setOperands(0,
+                                substituteLambdaVariable(ops.get(0), varName, element));
+                        return Operand.newBuilder().setExpression(rebuilt).build();
+                    }
+                    for (int i = 0; i < ops.size(); i++) {
+                        rebuilt.setOperands(i,
+                                substituteLambdaVariable(ops.get(i), varName, element));
+                    }
+                    return Operand.newBuilder().setExpression(rebuilt).build();
+                }
+                default -> {
+                    return operand;
+                }
+            }
+        }
+
+        /** True when {@code lambdaOperand} is a lambda whose iteration variable is {@code varName}. */
+        private static boolean shadowsVariable(Operand lambdaOperand, String varName) {
+            if (lambdaOperand.getNodeCase() != Operand.NodeCase.EXPRESSION
+                    || !"lambda".equals(lambdaOperand.getExpression().getOperator())) {
+                return false;
+            }
+            List<Operand> ops = lambdaOperand.getExpression().getOperandsList();
+            return ops.size() == 2
+                    && ops.get(1).getNodeCase() == Operand.NodeCase.VARIABLE
+                    && varName.equals(ops.get(1).getVariable());
+        }
+
+        /** Drill a dotted path into a struct element, failing closed on a missing field. */
+        private static Value resolveElementPath(String fullRef, String path, Value element) {
+            Value current = element;
+            for (String segment : path.split("\\.")) {
+                if (current.getKindCase() != Value.KindCase.STRUCT_VALUE
+                        || !current.getStructValue().containsFields(segment)) {
+                    throw new IllegalArgumentException("Cannot resolve \"" + fullRef
+                            + "\": collection element has no field \"" + segment + "\"");
+                }
+                current = current.getStructValue().getFieldsOrThrow(segment);
+            }
+            return current;
         }
 
         /**

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -1533,6 +1535,49 @@ class SpringDataIntegrationTest {
                 cleanup.getTransaction().commit();
                 cleanup.close();
             }
+        }
+    }
+
+    // -- known-value principal collections across the planner's 10-item unroll cliff --
+
+    /**
+     * {@code P.attr.teams} is folded to a known value at plan time, so the planner unrolls
+     * {@code principal-exists}/{@code principal-all} into an or/and chain at <= 10 elements
+     * (cerbos/cerbos#2570, #2817) and ships the lambda with a literal value-list collection
+     * above that. These tests straddle the cliff (9/10/11 elements) so both wire shapes stay
+     * exercised against the pinned PDP — and keep returning identical row sets.
+     */
+    @Nested
+    class KnownValuePrincipalCollections {
+
+        private Principal principalWithTeams(int size) {
+            List<AttributeValue> teams = new java.util.ArrayList<>(
+                    List.of(AttributeValue.stringValue("string"),
+                            AttributeValue.stringValue("anotherString")));
+            while (teams.size() < size) {
+                teams.add(AttributeValue.stringValue("filler-" + teams.size()));
+            }
+            return Principal.newInstance("user1", "USER")
+                    .withAttribute("teams", AttributeValue.listValue(
+                            teams.toArray(AttributeValue[]::new)));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {9, 10, 11})
+        void principalExistsMatchesAnyTeam(int size) {
+            // r1 aString = "string", r3 aString = "anotherString" — both in the teams list.
+            assertEquals(List.of("1", "3"),
+                    runWithPrincipalAndMapping(principalWithTeams(size),
+                            "principal-exists", FIELD_MAP));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {9, 10, 11})
+        void principalAllExcludesEveryTeam(int size) {
+            // r2 aString = "amIAString?" — the only row matching none of the teams.
+            assertEquals(List.of("2"),
+                    runWithPrincipalAndMapping(principalWithTeams(size),
+                            "principal-all", FIELD_MAP));
         }
     }
 }

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
@@ -1562,9 +1562,27 @@ class SpringDataIntegrationTest {
                             teams.toArray(AttributeValue[]::new)));
         }
 
+        /**
+         * Pin the wire shape each leg exercises: supported PDPs are >= 0.54, where both
+         * macros unroll at <= 10 elements ({@code or}/{@code and} chain) and ship the
+         * value-list lambda ({@code exists}/{@code all}) above that. Without this, a
+         * planner that moves the threshold would silently leave one side of the cliff
+         * untested while the row assertions stay green.
+         */
+        private void assertPlanShape(int size, String action,
+                                     String unrolledOperator, String macroOperator) {
+            String operator = plan(principalWithTeams(size), action)
+                    .getCondition()
+                    .orElseThrow(() -> new AssertionError(action + " plan has no condition"))
+                    .getExpression()
+                    .getOperator();
+            assertEquals(size <= 10 ? unrolledOperator : macroOperator, operator);
+        }
+
         @ParameterizedTest
         @ValueSource(ints = {9, 10, 11})
         void principalExistsMatchesAnyTeam(int size) {
+            assertPlanShape(size, "principal-exists", "or", "exists");
             // r1 aString = "string", r3 aString = "anotherString" — both in the teams list.
             assertEquals(List.of("1", "3"),
                     runWithPrincipalAndMapping(principalWithTeams(size),
@@ -1574,6 +1592,7 @@ class SpringDataIntegrationTest {
         @ParameterizedTest
         @ValueSource(ints = {9, 10, 11})
         void principalAllExcludesEveryTeam(int size) {
+            assertPlanShape(size, "principal-all", "and", "all");
             // r2 aString = "amIAString?" — the only row matching none of the teams.
             assertEquals(List.of("2"),
                     runWithPrincipalAndMapping(principalWithTeams(size),

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -1381,6 +1381,132 @@ class SpringDataQueryPlanAdapterTest {
     // spelled out literally here (not via the adapter constant) so this suite compiles — and
     // demonstrably FAILS — against the pre-guard adapter.
 
+    /**
+     * exists/all whose collection operand is a literal value list — the wire shape the planner
+     * emits when a known collection (e.g. a folded principal attribute) exceeds the 10-element
+     * unroll cap of cerbos/cerbos#2570/#2817. The adapter folds the macro into the same or/and
+     * chain the planner produces below the cap, so the translated filter does not depend on
+     * which side of that threshold the collection lands.
+     */
+    @Nested
+    class KnownValueCollections {
+
+        private static Value structElement(String field, String value) {
+            return Value.newBuilder().setStructValue(
+                    Struct.newBuilder().putFields(field,
+                            Value.newBuilder().setStringValue(value).build())).build();
+        }
+
+        private static Operand structListOp(String field, String... values) {
+            ListValue.Builder list = ListValue.newBuilder();
+            for (String v : values) list.addValues(structElement(field, v));
+            return Operand.newBuilder().setValue(Value.newBuilder().setListValue(list)).build();
+        }
+
+        @Test
+        void existsOverValueListMatchesAnyElement() {
+            ResourceEntity r = new ResourceEntity("kvc-exists");
+            r.setaString("alpha");
+            withResource(r, () -> {
+                assertEquals(1, runCount(exprOp("exists", listOp("alpha", "beta"),
+                        lambda("t", exprOp("eq", var("request.resource.attr.aString"), var("t"))))));
+                assertEquals(0, runCount(exprOp("exists", listOp("x", "y"),
+                        lambda("t", exprOp("eq", var("request.resource.attr.aString"), var("t"))))));
+            });
+        }
+
+        @Test
+        void allOverValueListRequiresEveryElement() {
+            ResourceEntity r = new ResourceEntity("kvc-all");
+            r.setaString("alpha");
+            withResource(r, () -> {
+                assertEquals(1, runCount(exprOp("all", listOp("x", "y"),
+                        lambda("t", exprOp("ne", var("request.resource.attr.aString"), var("t"))))));
+                assertEquals(0, runCount(exprOp("all", listOp("alpha", "y"),
+                        lambda("t", exprOp("ne", var("request.resource.attr.aString"), var("t"))))));
+            });
+        }
+
+        @Test
+        void emptyValueListKeepsCelIdentitySemantics() {
+            ResourceEntity r = new ResourceEntity("kvc-empty");
+            r.setaString("alpha");
+            withResource(r, () -> {
+                // exists over [] is false; all over [] is true.
+                assertEquals(0, runCount(exprOp("exists", listOp(),
+                        lambda("t", exprOp("eq", var("request.resource.attr.aString"), var("t"))))));
+                assertEquals(1, runCount(exprOp("all", listOp(),
+                        lambda("t", exprOp("ne", var("request.resource.attr.aString"), var("t"))))));
+            });
+        }
+
+        @Test
+        void structElementPathSubstitution() {
+            ResourceEntity r = new ResourceEntity("kvc-struct");
+            r.setaString("alpha");
+            withResource(r, () -> {
+                assertEquals(1, runCount(exprOp("exists", structListOp("name", "alpha", "beta"),
+                        lambda("t", exprOp("eq",
+                                var("request.resource.attr.aString"), var("t.name"))))));
+                assertEquals(0, runCount(exprOp("exists", structListOp("name", "x"),
+                        lambda("t", exprOp("eq",
+                                var("request.resource.attr.aString"), var("t.name"))))));
+            });
+        }
+
+        /**
+         * NULL columns keep their SQL-UNKNOWN exclusion under the fold — parity with how the
+         * equivalent planner-unrolled comparison chain translates.
+         */
+        @Test
+        void nullColumnStaysExcludedUnderFold() {
+            ResourceEntity r = new ResourceEntity("kvc-null");
+            // aOptionalString stays NULL: NULL <> 'x' and NULL = 'x' are both UNKNOWN.
+            withResource(r, () -> {
+                assertEquals(0, runCount(exprOp("all", listOp("x"),
+                        lambda("t", exprOp("ne",
+                                var("request.resource.attr.aOptionalString"), var("t"))))));
+                assertEquals(0, runCount(exprOp("exists", listOp("x"),
+                        lambda("t", exprOp("eq",
+                                var("request.resource.attr.aOptionalString"), var("t"))))));
+            });
+        }
+
+        /**
+         * A nested lambda rebinding the variable shadows it: the inner {@code t.name} must stay
+         * symbolic. An incorrect substitution would try to drill {@code .name} into the outer
+         * string element and fail translation.
+         */
+        @Test
+        void nestedLambdaShadowsOuterVariable() {
+            assertEquals(0, runCount(exprOp("exists", listOp("outer1", "outer2"),
+                    lambda("t", exprOp("exists", var("request.resource.attr.tags"),
+                            lambda("t", exprOp("eq", var("t.name"), sval("public"))))))));
+        }
+
+        @Test
+        void existsOneOverValueListFailsClosed() {
+            assertConditionThrows(exprOp("exists_one", listOp("a"),
+                    lambda("t", exprOp("eq", var("request.resource.attr.aString"), var("t")))),
+                    "exists_one over a literal collection value is not supported");
+        }
+
+        @Test
+        void nonListCollectionValueFailsClosed() {
+            assertConditionThrows(exprOp("exists", sval("not-a-list"),
+                    lambda("t", exprOp("eq", var("request.resource.attr.aString"), var("t")))),
+                    "exists over a literal collection requires a list value");
+        }
+
+        @Test
+        void missingElementFieldFailsClosed() {
+            assertConditionThrows(exprOp("exists", structListOp("name", "alpha"),
+                    lambda("t", exprOp("eq",
+                            var("request.resource.attr.aString"), var("t.missing")))),
+                    "Cannot resolve \"t.missing\"", "has no field \"missing\"");
+        }
+    }
+
     @Nested
     class MacroDepthGuard {
 


### PR DESCRIPTION
## Problem / Intent

The Cerbos planner unrolls `exists`/`all` macros over known-value collections (typically folded principal attributes) into plain or/and chains — but only up to 10 elements (cerbos/cerbos#2570 for `exists` since 0.45, cerbos/cerbos#2817 for `all` since 0.54; `maxItems = 10` in the planner's struct matcher). Above the cap, the lambda ships over the wire with a literal value list as its collection operand — a shape the prisma, spring-data and drizzle adapters all rejected, because their collection-macro handlers require a field/relation reference.

The result was a data-dependent cliff: a policy like `P.attr.teams.exists(t, R.attr.team == t)` translated fine for a principal with 10 teams and threw for one with 11. Tests seeded with realistic-but-small data never crossed the threshold, so the failure only surfaced in production data shapes.

## Approach

Apply the planner's own fold on the adapter side, with no size cap: when a collection macro's first operand is a literal value list, substitute each element into the lambda body (bare `t` becomes the element, `t.path.to.field` drills into it, a nested lambda rebinding the variable shadows it) and combine the per-element conditions with OR (`exists`) or AND (`all`). The combined expression is translated through each adapter's existing pipeline, so comparison semantics — including spring-data's tri-state NULL handling — are identical to what a planner-unrolled chain of the same comparisons produces. Empty collections keep CEL identity semantics (`exists` → match nothing, `all` → match everything); `exists_one`/`filter` over value lists fail closed with a named error.

New shared policy rules (`principal-exists`, `principal-all`) iterate a principal collection, and every adapter runs a live-PDP matrix at 9/10/11 elements so both wire shapes stay permanently exercised on both sides of the cliff — prisma and drizzle behind the `cerbos run` sidecar, spring-data against the pinned PDP testcontainer, with drizzle additionally checked differentially against `checkResources`.