### PR TITLE
Remove dead isSet handlers; pin null checks through the eq/ne path

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -117,7 +117,7 @@ These are part of the shared contract. Do not replace them with adapter-specific
 4. Run `scripts/regenerate-wire-fixtures.sh` and commit the new fixture alongside the policy change.
 5. Every adapter harness picks up the new action automatically from `actions.json` on next run;
    triage any divergence into a per-adapter fix issue rather than special-casing it in the harness.
-6. Each harness pins the corpus size as a tripwire (e.g. `expect(MANIFEST_ACTIONS.size).toBe(122)`
+6. Each harness pins the corpus size as a tripwire (e.g. `expect(MANIFEST_ACTIONS.size).toBe(126)`
    in `prisma/src/adversarial.test.ts`, and the oracle/throwing counts in the convex and
    langchain-chromadb harnesses). Bump them deliberately — that assertion exists so a new action
    cannot slip past an adapter unnoticed.

--- a/conformance/actions.json
+++ b/conformance/actions.json
@@ -41,7 +41,8 @@
     "in-null-elem-mixed", "in-null-elem-neg",
     "in-null-elem-only", "in-null-elem-only-neg",
     "in-null-elem-rel", "in-null-elem-rel-neg", "in-null-elem-hasint",
-    "in-var-var", "in-var-var-neg"
+    "in-var-var", "in-var-var-neg",
+    "null-eq", "null-ne", "vf-null-ne", "null-not-eq"
   ],
   "adapterUnsupported": {
     "prisma": [
@@ -223,7 +224,11 @@
       { "action": "in-null-elem-rel-neg", "reason": "Chroma's $in tests a metadata field against a literal list; it cannot test whether a literal is a member of a list-valued metadata field, and Chroma metadata values are scalars anyway" },
       { "action": "in-null-elem-hasint", "reason": "Chroma metadata values are scalars with no list-intersection operator, so hasIntersection has no Where equivalent" },
       { "action": "in-var-var", "reason": "Chroma Where documents compare a metadata field against a literal only; there is no field-to-field operand, so a comparison of two metadata keys cannot be translated" },
-      { "action": "in-var-var-neg", "reason": "Chroma Where documents compare a metadata field against a literal only; there is no field-to-field operand, so a comparison of two metadata keys cannot be translated" }
+      { "action": "in-var-var-neg", "reason": "Chroma Where documents compare a metadata field against a literal only; there is no field-to-field operand, so a comparison of two metadata keys cannot be translated" },
+      { "action": "null-eq", "reason": "Chroma $eq accepts only a finite number, string or boolean literal, and Chroma metadata has no null value, so an equality against null cannot be represented" },
+      { "action": "null-ne", "reason": "Chroma $ne matches records whose metadata key is absent, unlike Cerbos missing-attribute error semantics, and this field is not declared required" },
+      { "action": "vf-null-ne", "reason": "Value-first form of null-ne; the same $ne absent-key mismatch applies after the planner mirrors the operands" },
+      { "action": "null-not-eq", "reason": "Negating the null equality routes through the same $ne absent-key mismatch as null-ne" }
     ],
     "elasticsearch-java": [
       { "action": "all-on-empty", "reason": "Elasticsearch does not index empty nested arrays, so a positive all predicate cannot distinguish an empty collection (true) from a missing collection (CEL error)" },
@@ -305,7 +310,8 @@
       { "action": "in-null-elem-rel-neg", "reason": "Elasticsearch nested fields do not retain explicit null array elements, so negated null membership cannot be represented faithfully" },
       { "action": "in-null-elem-hasint", "reason": "Elasticsearch nested fields do not retain explicit null array elements, so intersection with null cannot be represented faithfully" },
       { "action": "in-var-var", "reason": "Elasticsearch Query DSL cannot test membership of one document field in another without scripts" },
-      { "action": "in-var-var-neg", "reason": "Elasticsearch Query DSL cannot test negated membership of one document field in another without scripts" }
+      { "action": "in-var-var-neg", "reason": "Elasticsearch Query DSL cannot test negated membership of one document field in another without scripts" },
+      { "action": "null-eq", "reason": "Elasticsearch does not index explicit null scalar values, so positive equality against null cannot distinguish an explicit null attribute (check() allows) from a missing field (CEL error, denies) without an indexed null_value sentinel. The negated forms (null-ne, vf-null-ne, null-not-eq) are expressible as exists and stay in the oracle set" }
     ]
   },
   "adapterSupportedExpected": {

--- a/conformance/policies/adversarial.yaml
+++ b/conformance/policies/adversarial.yaml
@@ -996,6 +996,54 @@ resourcePolicy:
         match:
           expr: 'timestamp(R.attr.createdAt) != timestamp("2024-06-01T00:00:00Z")'
 
+    # ==================== direct null comparisons ====================
+    # The planner has NO existence operator: `R.attr.x != null` arrives as a plain `ne`
+    # with a `{"value": null}` operand, never an `isSet`. Verified against the pinned PDP
+    # (the wire fixtures below are the record) and structurally guaranteed — the wire
+    # operator is the CEL function name, and Cerbos registers no `isSet` function; `has()`
+    # is folded away at plan time to ALWAYS_ALLOWED/DENIED and can never reach the wire.
+    # Six adapters carried dead `isSet` branches until cerbos/query-plan-adapters#261;
+    # these actions pin IS NULL / IS NOT NULL through the eq/ne-null path instead.
+    #
+    # `owner` (not aOptionalString) is deliberate: it is the explicit-null alias, so the
+    # oracle sends `null` rather than omitting the attribute. Under the default
+    # missing-attribute convention `== null` would deny every row at check time while the
+    # adapter's IS NULL returned five, which probes attribute representation rather than
+    # the operator. NULL owners: a2/a4/a8/c2/e1 (5 of 20) — non-degenerate either way.
+
+    - actions: ["null-eq"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.owner == null'
+
+    - actions: ["null-ne"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.owner != null'
+
+    # Value-first: the planner preserves source order, so the null lands in operand 0 and
+    # the column in operand 1. An adapter that assumes variable-first reads the null as the
+    # column and the column as the value — the inversion class of #258/#259.
+    - actions: ["vf-null-ne"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'null != R.attr.owner'
+
+    # Negation over IS NULL. Unlike `NOT (col = x)`, `NOT (col IS NULL)` is never UNKNOWN,
+    # so this must return every non-null row rather than collapsing to the empty set.
+    - actions: ["null-not-eq"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!(R.attr.owner == null)'
+
     # ==================== in-lists containing null ====================
     # `R.attr.owner in [..., null]` compiles and the planner emits the null element
     # VERBATIM in the value list; check() ALLOWS an explicitly-null attribute (CEL

--- a/conformance/wire-fixtures/null-eq.json
+++ b/conformance/wire-fixtures/null-eq.json
@@ -1,0 +1,20 @@
+{
+  "action": "null-eq",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "eq",
+        "operands": [
+          {
+            "variable": "request.resource.attr.owner"
+          },
+          {
+            "value": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/conformance/wire-fixtures/null-ne.json
+++ b/conformance/wire-fixtures/null-ne.json
@@ -1,0 +1,20 @@
+{
+  "action": "null-ne",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "ne",
+        "operands": [
+          {
+            "variable": "request.resource.attr.owner"
+          },
+          {
+            "value": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/conformance/wire-fixtures/null-not-eq.json
+++ b/conformance/wire-fixtures/null-not-eq.json
@@ -1,0 +1,27 @@
+{
+  "action": "null-not-eq",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "not",
+        "operands": [
+          {
+            "expression": {
+              "operator": "eq",
+              "operands": [
+                {
+                  "variable": "request.resource.attr.owner"
+                },
+                {
+                  "value": null
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/conformance/wire-fixtures/vf-null-ne.json
+++ b/conformance/wire-fixtures/vf-null-ne.json
@@ -1,0 +1,20 @@
+{
+  "action": "vf-null-ne",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "ne",
+        "operands": [
+          {
+            "value": null
+          },
+          {
+            "variable": "request.resource.attr.owner"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/convex/README.md
+++ b/convex/README.md
@@ -21,7 +21,7 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 | Logical | `and`, `or`, `not` | Builds `q.and(...)`, `q.or(...)`, `q.not(...)` groups. |
 | Comparisons | `eq`, `ne`, `lt`, `le`, `gt`, `ge` | Emits `q.eq`, `q.neq`, `q.lt`, `q.lte`, `q.gt`, `q.gte` against the mapped field. |
 | Membership | `in` | Composed as `q.or(q.eq(field, v1), q.eq(field, v2), ...)`. |
-| Existence | `isSet` | Uses `q.neq(field, undefined)` for set, `q.eq(field, undefined)` for unset. |
+| Existence | `eq`/`ne` against `null` | Null checks arrive as `eq`/`ne` against a null value — the planner emits no existence operator. |
 
 ### Post-filter operators
 
@@ -72,7 +72,7 @@ const { kind, filter, postFilter } = queryPlanToConvex({
 
 > **Security requirement:** `postFilter` is part of the authorization predicate. Run it in the same trusted Convex/backend function and apply it to every candidate before serialization or return. Never send unfiltered candidates to a browser or other untrusted client for filtering.
 
-If your Cerbos policies only use operators that Convex supports natively (comparisons, `in`, `isSet`, logical combinators), you don't need this flag — `filter` alone will enforce the full policy at the DB level.
+If your Cerbos policies only use operators that Convex supports natively (comparisons, `in`, null checks, logical combinators), you don't need this flag — `filter` alone will enforce the full policy at the DB level.
 
 ## Conformance contract
 
@@ -80,7 +80,7 @@ The adapter is differentially tested with 20 hostile seed documents against Cerb
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | All 118 reference conformance actions, plus `matches()`, list indexing/`get-field`, and `timestamp()` plans that the Spring Data reference adapter rejects (121 actions total) |
+| Oracle-tested | All 122 reference conformance actions, plus `matches()`, list indexing/`get-field`, and `timestamp()` plans that the Spring Data reference adapter rejects (125 actions total) |
 | Fail-closed | No corpus shape when `allowPostFilter: true`; unknown operators and invalid expression structures still throw |
 | Explicit opt-in | Any plan that cannot be represented entirely as a Convex database filter requires `allowPostFilter: true` |
 | Known planner divergence | `has()` on a missing attribute is currently folded by the Cerbos planner to `ALWAYS_ALLOWED`; `checkResource` still denies documents where the attribute is missing. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |

--- a/convex/convex/resources.ts
+++ b/convex/convex/resources.ts
@@ -174,7 +174,9 @@ export const filteredQuery = query({
             ),
           )
           .collect();
-      case "isSet":
+      // Named for the SQL-ish shape, not a Cerbos operator: the planner has no existence
+      // operator, it emits ne(field, null) (cerbos/query-plan-adapters#261).
+      case "notNull":
         return await q
           .filter((f) =>
             f.neq(

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -411,10 +411,10 @@ describe("adversarial conformance corpus", () => {
         ].filter(Boolean).length !== 1,
     );
 
-    expect(allActions.size).toBe(122);
+    expect(allActions.size).toBe(126);
     expect(CONVEX_UNSUPPORTED).toHaveLength(0);
     expect(CONVEX_SUPPORTED_EXPECTED).toHaveLength(3);
-    expect(ORACLE_ACTIONS).toHaveLength(121);
+    expect(ORACLE_ACTIONS).toHaveLength(125);
     expect(THROWING_ACTIONS).toHaveLength(0);
     expect(misclassified).toEqual([]);
   });
@@ -444,7 +444,7 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all"]) {
+    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne"]) {
       const ids = await oracleAllowedIds(action);
       expect(ids.length).toBeGreaterThan(0);
       expect(ids.length).toBeLessThan(seedsFile.seeds.length);

--- a/convex/src/index.test.ts
+++ b/convex/src/index.test.ts
@@ -865,7 +865,7 @@ describe("Bare Boolean Operands", () => {
   });
 });
 
-describe("isSet", () => {
+describe("null existence checks", () => {
   test("conditional - is-set produces ne(field, null)", async () => {
     // #given - Cerbos translates `!= null` to ne(field, null)
     const queryPlan = await cerbos.planResources({
@@ -893,8 +893,12 @@ describe("isSet", () => {
     expect(result.filter!(qMissing)).toBe(true);
   });
 
-  test("isSet operator compares against undefined", () => {
-    // #given - isSet operator checks for field existence (undefined in Convex)
+  test("isSet is rejected rather than translated", () => {
+    // #given - a synthetic isSet plan. The PDP cannot produce this: `isSet` is not a
+    // registered CEL function, so a policy naming it fails to compile and the operator
+    // never reaches the wire (cerbos/query-plan-adapters#261). The adapter carried a
+    // dedicated isSet branch for it anyway; now it must fail closed like any unknown
+    // operator rather than guess at an existence filter.
     const queryPlan = {
       kind: PlanKind.CONDITIONAL,
       condition: {
@@ -906,21 +910,10 @@ describe("isSet", () => {
       },
     } as unknown as PlanResourcesResponse;
 
-    // #when
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-
-    // #then - isSet checks undefined (missing), not null
-    const docWithValue = { aOptionalString: "hello" } as Record<string, unknown>;
-    const docWithNull = { aOptionalString: null } as Record<string, unknown>;
-    const docMissing = {} as Record<string, unknown>;
-
-    const qValue = createMockFilterBuilder(docWithValue);
-    const qNull = createMockFilterBuilder(docWithNull);
-    const qMissing = createMockFilterBuilder(docMissing);
-
-    expect(result.filter!(qValue)).toBe(true);
-    expect(result.filter!(qNull)).toBe(true);
-    expect(result.filter!(qMissing)).toBe(false);
+    // #when / #then
+    expect(() =>
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }),
+    ).toThrow(/Unsupported operator: isSet/);
   });
 });
 

--- a/convex/src/index.ts
+++ b/convex/src/index.ts
@@ -33,7 +33,7 @@ export interface QueryPlanToConvexResult<Q = unknown, R = unknown> {
 }
 
 const DB_PUSHABLE_OPERATORS = new Set([
-  "and", "or", "not", "eq", "ne", "lt", "le", "gt", "ge", "in", "isSet",
+  "and", "or", "not", "eq", "ne", "lt", "le", "gt", "ge", "in",
 ]);
 
 const ALL_KNOWN_OPERATORS = new Set([
@@ -216,11 +216,6 @@ const canPushToDb = (
           !isNullableField(needle.name, mapper),
       );
     }
-    case "isSet": {
-      const [field, expected] = expression.operands;
-      if (!field || !expected) return false;
-      return isVariable(field) && isValue(expected);
-    }
     default:
       return expression.operands.every((operand) =>
         canPushToDb(operand, mapper),
@@ -380,28 +375,6 @@ const translateExpression = (
       return q.or(
         ...values.map((v: unknown) => q.eq(q.field(field), v)),
       );
-    }
-
-    case "isSet": {
-      const fieldOperand = requireOperandMatching(
-        (o) => isVariable(o),
-        "isSet operator requires a field operand",
-      );
-      const valueOperand = requireOperandMatching(
-        (o) => isValue(o),
-        "isSet operator requires a boolean operand",
-      );
-
-      if (!isVariable(fieldOperand) || !isValue(valueOperand)) {
-        throw new Error("isSet operator requires one field and one boolean");
-      }
-
-      const field = resolveField(fieldOperand.name, mapper);
-
-      if (valueOperand.value) {
-        return q.neq(q.field(field), undefined);
-      }
-      return q.eq(q.field(field), undefined);
     }
 
     default:
@@ -769,15 +742,6 @@ const evaluateExpression = (
       }
       if (!Array.isArray(haystack)) return EVALUATION_ERROR;
       return haystack.some((value) => valuesEqual(value, needle));
-    }
-
-    case "isSet": {
-      const fieldValue = resolve(getOperandAt(operands, 0, "isSet field"));
-      const expected = resolve(getOperandAt(operands, 1, "isSet expected"));
-      if (typeof expected !== "boolean") return EVALUATION_ERROR;
-      return expected
-        ? !isEvaluationError(fieldValue)
-        : isEvaluationError(fieldValue);
     }
 
     case "contains": {

--- a/convex/src/integration.test.ts
+++ b/convex/src/integration.test.ts
@@ -226,7 +226,7 @@ describe("Integration: Convex + Cerbos", () => {
     );
   });
 
-  test("isSet filter against real Convex DB", async () => {
+  test("IS NOT NULL filter against real Convex DB", async () => {
     const queryPlan = await cerbos.planResources({
       principal: { id: "user1", roles: ["USER"] },
       resource: { kind: "resource" },
@@ -237,7 +237,7 @@ describe("Integration: Convex + Cerbos", () => {
     expect(result.kind).toBe(PlanKind.CONDITIONAL);
 
     const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "isSet",
+      filterType: "notNull",
       filterField: "aOptionalString",
     });
 

--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -7,7 +7,8 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 - Supports logical operators: `and`, `or`, `not`
 - Supports comparison operators: `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `in`
 - Supports string operators: `contains`, `startsWith`, `endsWith`
-- Supports nullability checks via the `isSet` operator
+- Supports nullability checks: `eq`/`ne` against a null value map to `IS NULL` / `IS NOT NULL`
+  (the planner emits no existence operator)
 - Supports set-aware operators such as `hasIntersection`, `exists`, `exists_one`, and `all`
 - Supports relation-aware mappings, including nested relations and many-to-many joins
 - Works with Drizzle SQLite, PostgreSQL, MySQL and PlanetScale drivers
@@ -18,7 +19,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 116 reference conformance actions |
+| Oracle-tested | 120 reference conformance actions |
 | Fail-closed corpus shapes | Sub-millisecond `now()` thresholds plus regex `matches()`, ordered list indexing/`get-field`, and `timestamp()` over an untyped string field (5 actions) |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -617,7 +617,7 @@ describe("adversarial conformance corpus", () => {
   test("oracle is not degenerate", async () => {
     // Guard the guard: at least one action must produce a non-empty, non-total oracle set,
     // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all"]) {
+    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne"]) {
       const ids = await oracleAllowedIds(action);
       expect(ids.length).toBeGreaterThan(0);
       expect(ids.length).toBeLessThan(SEEDS.length);

--- a/drizzle/src/index.ts
+++ b/drizzle/src/index.ts
@@ -89,8 +89,7 @@ type ComparisonOperator =
   | "in"
   | "contains"
   | "startsWith"
-  | "endsWith"
-  | "isSet";
+  | "endsWith";
 
 type MapperTransform = (args: {
   operator: ComparisonOperator;
@@ -1172,11 +1171,6 @@ const applyComparison = (
         throw new Error(`The '${operator}' operator requires a string value`);
       }
       return buildStringMatchCondition(operator, sql`${column}`, sql`${value}`);
-    case "isSet":
-      if (typeof value !== "boolean") {
-        throw new Error("The 'isSet' operator requires a boolean value");
-      }
-      return value ? not(isNull(column)) : isNull(column);
     default:
       throw new Error(`Unsupported operator: ${operator}`);
   }
@@ -2377,7 +2371,7 @@ const buildFilterFromExpression = (
         const filter = buildVariableMembershipFilter(operands, mapper, options);
         return negated ? not(filter) : filter;
       }
-      // Membership/isSet: whichever side is the name operand is the column — the planner
+      // Membership: whichever side is the name operand is the column — the planner
       // emits both `R.attr.x in [..]` (name, values) and `"v" in R.attr.list`
       // (value, name), and both mean membership against the column.
       const fieldOperand = operands.find(isNameOperand);
@@ -2396,28 +2390,6 @@ const buildFilterFromExpression = (
         entry.collectionValueType === "scalar"
           ? resolveRelationDefaultField(unresolved, fieldOperand.name)
           : unresolved;
-      const comparison = applyComparison(
-        resolved.mapping,
-        operator,
-        valueOperand.value
-      );
-      const filter = resolved.relations.length
-        ? wrapWithRelations(
-            resolved.relations,
-            comparison,
-            fieldOperand.name,
-            options
-          )
-        : comparison;
-      return negated ? not(filter) : filter;
-    }
-    case "isSet": {
-      const fieldOperand = operands.find(isNameOperand);
-      const valueOperand = operands.find(isValueOperand);
-      if (!fieldOperand || !valueOperand) {
-        throw new Error("'isSet' requires field and boolean value operands");
-      }
-      const resolved = resolveFieldReference(fieldOperand.name, mapper);
       const comparison = applyComparison(
         resolved.mapping,
         operator,

--- a/elasticsearch-java/README.md
+++ b/elasticsearch-java/README.md
@@ -9,7 +9,8 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 - Supports string operators: `contains`, `startsWith`, `endsWith`, and the safe
   `matches` subset described below
 - Supports `hasIntersection` for array overlap checks
-- Supports `isSet` for field existence checks
+- Supports field existence checks via `eq`/`ne` against a null value (the planner emits no
+  existence operator)
 - Supports polarity-safe `size` checks for array emptiness
 - Supports polarity-safe collection operators for nested object arrays
 - Supports `hasIntersection` + `map` for projecting and matching nested object fields
@@ -285,7 +286,7 @@ The `OperatorFunction` interface takes a field name and value, and returns a `Ma
 | `matches` | `prefix` for `^literal`; `regexp` with Lucene optional flags disabled for fully anchored patterns in the validated common subset |
 | `timestamp` in comparisons | `term` / `range` against a mapped Elasticsearch `date` field, for millisecond-exact values |
 | `hasIntersection` | `terms` (array overlap) |
-| `isSet` | `exists` (true) / `bool.must_not` + `exists` (false) |
+| `ne`/`eq` against `null` | `exists` (ne) / `bool.must_not` + `exists` (eq) |
 | Positive non-empty `size` checks; negated empty checks | `exists` or `nested` + `match_all` |
 | Positive `exists` (collection) | `nested` + inner query |
 | Negated `all` (collection) | `nested` + a definitely-false inner query |
@@ -357,8 +358,8 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 38 reference conformance actions plus regex and timestamp probes (40 actions) |
-| Fail-closed | 80 reference actions plus ordered list indexing/`get-field` (81 actions total) |
+| Oracle-tested | 41 reference conformance actions plus regex and timestamp probes (43 actions) |
+| Fail-closed | 81 reference actions plus ordered list indexing/`get-field` (82 actions total) |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for indexed attributes instead of `has(R.attr.x)` |
 
 The oracle-tested set covers value-first comparisons, literal-safe wildcard matching, safe

--- a/elasticsearch-java/src/main/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapter.java
+++ b/elasticsearch-java/src/main/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapter.java
@@ -72,12 +72,7 @@ public class ElasticsearchQueryPlanAdapter {
                     Map.of("wildcard", Map.of(field, Map.of("value", "*" + escapeWildcard(value))))),
             Map.entry("matches", ElasticsearchQueryPlanAdapter::matchesQuery),
             Map.entry("hasIntersection", (field, value) ->
-                    Map.of("terms", Map.of(field, value instanceof List<?> l ? l : List.of(value)))),
-            Map.entry("isSet", (field, value) ->
-                    Boolean.TRUE.equals(value)
-                            ? Map.of("exists", Map.of("field", field))
-                            : Map.of("bool", Map.of("must_not", List.of(
-                                    Map.of("exists", Map.of("field", field))))))
+                    Map.of("terms", Map.of(field, value instanceof List<?> l ? l : List.of(value))))
     );
 
     /** Operators whose second operand is a lambda that binds an iteration variable. */
@@ -936,7 +931,6 @@ public class ElasticsearchQueryPlanAdapter {
             case "ge" -> range(field, "lt", value);
             case "in", "contains", "startsWith", "endsWith", "matches" ->
                     definedAndNot(field, positive);
-            case "isSet" -> Boolean.TRUE.equals(value) ? notExists(field) : exists(field);
             default -> throw new IllegalArgumentException(
                     "Cannot safely negate operator without scripts: " + normalizedOperator);
         };

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -178,7 +178,7 @@ class ElasticsearchAdversarialConformanceTest {
                 "adapterUnsupported.elasticsearch-java contains non-conformance actions");
         assertTrue(expected.containsAll(supportedExpected),
                 "adapterSupportedExpected.elasticsearch-java contains non-expected actions");
-        assertEquals(80, unsupported.size(),
+        assertEquals(81, unsupported.size(),
                 "Elasticsearch unsupported coverage changed without updating the ledger assertion");
         assertEquals(2, supportedExpected.size(),
                 "Elasticsearch supported-expected coverage changed without updating the ledger assertion");
@@ -203,9 +203,9 @@ class ElasticsearchAdversarialConformanceTest {
         manifest.addAll(conformance);
         manifest.addAll(expected);
         manifest.addAll(divergences);
-        assertEquals(40, oracleActions.size());
-        assertEquals(81, throwingActions.size());
-        assertEquals(122, classified.size());
+        assertEquals(43, oracleActions.size());
+        assertEquals(82, throwingActions.size());
+        assertEquals(126, classified.size());
         assertEquals(manifest, classified, "every manifest action must be classified locally");
     }
 
@@ -464,7 +464,7 @@ class ElasticsearchAdversarialConformanceTest {
 
     @Test
     void oracleIsNotDegenerate() {
-        for (String action : List.of("vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all")) {
+        for (String action : List.of("vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne")) {
             List<String> ids = oracleAllowedIds(action);
             assertTrue(!ids.isEmpty() && ids.size() < seeds.size(),
                     "oracle for '" + action + "' is degenerate: " + ids);

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchIntegrationTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchIntegrationTest.java
@@ -665,8 +665,8 @@ class ElasticsearchIntegrationTest {
     // --- Null checks (field existence) ---
 
     @Test
-    void isSet() throws Exception {
-        // aOptionalString != null → docs 1, 3 (field present)
+    void isNotNull() throws Exception {
+        // aOptionalString != null → ne(field, null) → docs 1, 3 (field present)
         assertEquals(List.of("1", "3"), executeQuery("is-set"));
     }
 

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapterTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapterTest.java
@@ -830,11 +830,31 @@ class ElasticsearchQueryPlanAdapterTest {
                 ((Result.Conditional) result).query());
     }
 
+    /**
+     * The planner has no existence operator. {@code R.attr.x != null} arrives as {@code ne}
+     * against a null value, and {@code isSet} is not a registered CEL function, so a policy
+     * naming it does not compile and the operator can never reach the wire — see
+     * cerbos/query-plan-adapters#261. These pin IS NOT NULL / IS NULL through that path.
+     */
     @Test
-    void isSetTrueProducesExists() {
-        Operand condition = expressionOperand("isSet",
+    void neAgainstNullProducesExists() {
+        Operand condition = expressionOperand("ne",
                 variableOperand("request.resource.attr.department"),
-                boolValueOperand(true));
+                nullValueOperand());
+        PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+
+        Result result = ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP);
+
+        Map<String, Object> query = ((Result.Conditional) result).query();
+        assertEquals(Map.of("exists", Map.of("field", "department")), query);
+    }
+
+    /** Value-first: the planner preserves source order, so {@code null != R.attr.x} inverts operands. */
+    @Test
+    void valueFirstNeAgainstNullProducesExists() {
+        Operand condition = expressionOperand("ne",
+                nullValueOperand(),
+                variableOperand("request.resource.attr.department"));
         PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
 
         Result result = ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP);
@@ -844,19 +864,16 @@ class ElasticsearchQueryPlanAdapterTest {
     }
 
     @Test
-    void isSetFalseProducesNotExists() {
+    void isSetIsRejectedRatherThanTranslated() {
         Operand condition = expressionOperand("isSet",
                 variableOperand("request.resource.attr.department"),
-                boolValueOperand(false));
+                boolValueOperand(true));
         PlanResourcesResponse resp = buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
 
-        Result result = ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP);
-
-        Map<String, Object> query = ((Result.Conditional) result).query();
-        assertEquals(
-                Map.of("bool", Map.of("must_not", List.of(
-                        Map.of("exists", Map.of("field", "department"))))),
-                query);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP));
+        assertTrue(e.getMessage().contains("isSet"),
+                "unknown operator must be named in the error, got: " + e.getMessage());
     }
 
     @Test

--- a/langchain-chromadb/README.md
+++ b/langchain-chromadb/README.md
@@ -37,7 +37,8 @@ ChromaDB's `Where` filter does not support `$not` or `$nor`. The adapter handles
 ChromaDB stores flat scalar metadata, so the following Cerbos operators cannot be mapped:
 
 - String helpers: `contains`, `startsWith`, `endsWith`
-- Existence: `isSet`
+- Null checks: `eq`/`ne` against a null value (Chroma metadata values are non-null scalars, so a
+  comparison against null cannot be represented)
 - Array/collection: `hasIntersection`, `exists`, `exists_one`, `all`, `filter`, `map`, `lambda`, `size`
 
 Any unsupported operator in the plan causes `queryPlanToChromaDB` to throw an error.
@@ -82,7 +83,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 | Classification | Coverage |
 | --- | --- |
 | Oracle-tested | 15 reference actions: directional and inequality comparisons, single/empty membership, Unicode and empty strings, negative numbers, n-ary/double/triple negation, membership on an optional resource field, mapped nested-field equality, and case-sensitive equality |
-| Fail-closed | 103 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (106 actions total) |
+| Fail-closed | 107 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (110 actions total) |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 Chroma metadata filters are limited to flat scalar comparisons and membership. Nested collections, field-to-field and arithmetic expressions, string helpers, hierarchy/timestamp operations, ternaries, nullable inequality, and other shapes that cannot be represented faithfully throw before a filter is returned.

--- a/langchain-chromadb/src/adversarial.test.ts
+++ b/langchain-chromadb/src/adversarial.test.ts
@@ -563,7 +563,7 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
 }
 
 describe("adversarial conformance corpus", () => {
-  test("manifest assigns all 120 policy actions exactly one Chroma outcome", () => {
+  test("manifest assigns all 126 policy actions exactly one Chroma outcome", () => {
     const oracle = new Set(CHROMA_SUPPORTED_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map(({ action }) => action));
     const misclassified = [...MANIFEST_ACTIONS].filter((action) => {
@@ -575,12 +575,12 @@ describe("adversarial conformance corpus", () => {
       return classificationCount !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(122);
+    expect(MANIFEST_ACTIONS.size).toBe(126);
     expect(CHROMA_SUPPORTED_ACTIONS).toHaveLength(15);
     expect(oracle.size).toBe(CHROMA_SUPPORTED_ACTIONS.length);
-    expect(CHROMA_UNSUPPORTED).toHaveLength(103);
+    expect(CHROMA_UNSUPPORTED).toHaveLength(107);
     expect(CHROMA_SUPPORTED_EXPECTED).toHaveLength(0);
-    expect(THROWING_ACTIONS).toHaveLength(106);
+    expect(THROWING_ACTIONS).toHaveLength(110);
     expect(misclassified).toEqual([]);
   });
 
@@ -622,7 +622,7 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    for (const action of ["vf-le", "nary-and", "p-in-null-multi", "pv-exists", "pv-all"]) {
+    for (const action of ["vf-le", "nary-and", "p-in-null-multi", "pv-exists", "pv-all", "null-eq", "null-ne"]) {
       const ids = await oracleAllowedIds(action);
       expect(ids.length).toBeGreaterThan(0);
       expect(ids.length).toBeLessThan(SEEDS.length);

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -22,7 +22,7 @@ You can merge the adapter output with existing application filters (for example,
 | Comparisons | `eq`, `ne`, `lt`, `le`, `gt`, `ge` | Emits `$eq`, `$ne`, `$lt`, `$lte`, `$gt`, `$gte` checks against the mapped field. |
 | Membership | `in`, `hasIntersection` | `$in` on simple lists, or `$elemMatch` when targeting array relations; `hasIntersection` supports either a direct array field or a `map` projection inside the plan. |
 | String helpers | `contains`, `startsWith`, `endsWith` | Generates escaped regular expressions that target substrings, prefixes, or suffixes. |
-| Existence helpers | `isSet`, `exists` | Uses `$exists`/`$ne: null` for scalars and `$elemMatch` for collections. |
+| Existence helpers | `eq`/`ne` against `null`, `exists` | Null checks arrive as `eq`/`ne` against a null value — the planner emits no existence operator. Uses `$eq: null`/`$ne: null` for scalars and `$elemMatch` for collections. |
 | Collection helpers | `filter`, `lambda`, `map`, `all` | Translates Cerbos collection expressions into scoped `$elemMatch` filters and maps lambda variables to the correct nested paths. `all` requires the stored field to be an array. `exists`/`all` over a *literal* value-list collection (a folded principal attribute above the planner's 10-element unroll cap) fold to `$or`/`$and` of the substituted lambda body instead — no relation mapping needed. |
 | Arithmetic and values | `add`, `sub`, `mult`, `div`, `mod`, `if`, `size`, `index`, `get-field` | Uses document-level MongoDB `$expr` expressions. Division requires a non-zero constant denominator; indexing requires a non-negative integer constant and adds a per-document bounds check. |
 | Conversions and matching | `string`, `double`, `int`, `timestamp`, `matches` | Uses guarded MongoDB conversion and regular-expression expressions. Timestamps accept BSON dates or millisecond-exact RFC 3339 strings in the CEL instant range. Regex matching accepts a validated common RE2/PCRE2 subset. |
@@ -44,7 +44,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 87 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (90 actions) |
+| Oracle-tested | 91 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (94 actions) |
 | Fail-closed | 31 reference actions |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -705,10 +705,10 @@ describe("adversarial conformance corpus", () => {
       return count !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(122);
+    expect(MANIFEST_ACTIONS.size).toBe(126);
     expect(unsupportedEntries).toHaveLength(31);
     expect(supportedExpectedEntries).toHaveLength(3);
-    expect(ORACLE_ACTIONS).toHaveLength(90);
+    expect(ORACLE_ACTIONS).toHaveLength(94);
     expect(THROWING_ACTIONS).toHaveLength(31);
     expect(misclassified).toEqual([]);
     expect(
@@ -751,7 +751,7 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all"]) {
+    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne"]) {
       const ids = await oracleAllowedIds(action);
       expect(ids.length).toBeGreaterThan(0);
       expect(ids.length).toBeLessThan(SEEDS.length);

--- a/mongoose/src/index.ts
+++ b/mongoose/src/index.ts
@@ -868,18 +868,6 @@ const getOperandAt = (
   return operand;
 };
 
-const findOperand = (
-  operands: PlanExpressionOperand[],
-  predicate: (operand: PlanExpressionOperand) => boolean,
-  errorMessage: string
-): PlanExpressionOperand => {
-  const operand = operands.find(predicate);
-  if (!operand) {
-    throw new Error(errorMessage);
-  }
-  return operand;
-};
-
 /**
  * Creates a scoped mapper for collection operations
  */
@@ -1245,11 +1233,6 @@ const buildMongooseFilterFromCerbosExpression = (
   const { operator, operands } = expression;
   const requireOperandAt = (index: number, message: string) =>
     getOperandAt(operands, index, message);
-  const requireOperandMatching = (
-    predicate: (operand: PlanExpressionOperand) => boolean,
-    message: string
-  ) => findOperand(operands, predicate, message);
-
   const resolveOperand = (operand: PlanExpressionOperand): any => {
     if (isVariable(operand)) {
       return resolveFieldReference(operand.name, mapper);
@@ -1645,38 +1628,6 @@ const buildMongooseFilterFromCerbosExpression = (
         { $regex: regexStr },
         nullable
       );
-    }
-
-    case "isSet": {
-      const { path, relation } = resolveOperand(
-        requireOperandMatching(
-          (o) => isVariable(o),
-          "isSet operator requires a field operand"
-        )
-      );
-      const { value } = resolveOperand(
-        requireOperandMatching(
-          (o) => isValue(o),
-          "isSet operator requires a boolean operand"
-        )
-      );
-
-      const existsFilter = value
-        ? { $exists: true, $ne: null }
-        : { $exists: false };
-
-      if (relation) {
-        if (relation.type === "many") {
-          return {
-            [relation.name]: {
-              $elemMatch: buildFieldFilter(path.slice(1), existsFilter),
-            },
-          };
-        }
-        return buildFieldFilter(path, existsFilter);
-      }
-
-      return buildFieldFilter(path, existsFilter);
     }
 
     case "hasIntersection": {

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -10,7 +10,9 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 
 - Logical operators: `and`, `or`, `not`
 - Comparison operators: `eq`, `ne`, `lt`, `gt`, `lte`, `gte`, `in`
-- String operations: `startsWith`, `endsWith`, `contains`, `isSet`
+- String operations: `startsWith`, `endsWith`, `contains`
+- Null checks: `eq`/`ne` against a null value map to `{ equals: null }` / `{ not: null }`. The
+  Cerbos planner emits no existence operator — `R.attr.x != null` arrives as a plain `ne`.
 
 #### Relation Operators
 
@@ -106,7 +108,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 85 reference actions |
+| Oracle-tested | 89 reference actions |
 | Fail-closed | 33 reference actions plus the 3 reference-unsupported shapes (36 actions total) |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -526,7 +526,7 @@ describe("adversarial conformance corpus", () => {
       return classificationCount !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(122);
+    expect(MANIFEST_ACTIONS.size).toBe(126);
     expect(misclassified).toEqual([]);
     expect(
       [...PRISMA_SUPPORTED_EXPECTED].filter(
@@ -577,7 +577,7 @@ describe("adversarial conformance corpus", () => {
   test("oracle is not degenerate", async () => {
     // Guard the guard: at least one action must produce a non-empty, non-total oracle set,
     // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all"]) {
+    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne"]) {
       const ids = await oracleAllowedIds(action);
       expect(ids.length).toBeGreaterThan(0);
       expect(ids.length).toBeLessThan(SEEDS.length);

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -1423,7 +1423,10 @@ describe("Field Operations", () => {
       );
     });
 
-    test("conditional - isSet", async () => {
+    // The planner has no existence operator: `!= null` arrives as `ne` against a null
+    // value, never `isSet` (cerbos/query-plan-adapters#261). A policy that writes `isSet`
+    // does not even compile, so the operator is unreachable rather than merely unused.
+    test("conditional - IS NOT NULL via ne against null", async () => {
       const queryPlan = await cerbos.planResources({
         principal: { id: "user1", roles: ["USER"] },
         resource: { kind: "resource" },
@@ -1469,7 +1472,7 @@ describe("Field Operations", () => {
       );
     });
 
-    test("conditional - isNotSet", async () => {
+    test("conditional - IS NULL via eq against null", async () => {
       const queryPlan = await cerbos.planResources({
         principal: { id: "user1", roles: ["USER"] },
         resource: { kind: "resource" },
@@ -5271,7 +5274,7 @@ describe("Complex Operations", () => {
       );
     });
 
-    test("isSet with nested relation", async () => {
+    test("IS NOT NULL through a nested relation", async () => {
       const queryPlan = await cerbos.planResources({
         principal: { id: "user1", roles: ["USER"] },
         resource: { kind: "resource" },

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -450,38 +450,6 @@ function isResolvedValue(operand: ResolvedOperand): operand is ResolvedValue {
   return "value" in operand;
 }
 
-function getNamedOperand(
-  operands: PlanExpressionOperand[],
-  message: string
-): NamedOperand {
-  const operand = operands.find(isNamedOperand);
-  if (!operand) {
-    throw new Error(message);
-  }
-  return operand;
-}
-
-function getValueOperand(
-  operands: PlanExpressionOperand[],
-  message: string
-): ValueOperand {
-  const operand = operands.find(isValueOperand);
-  if (!operand) {
-    throw new Error(message);
-  }
-  return operand;
-}
-
-function requireResolvedFieldReference(
-  operand: ResolvedOperand,
-  message: string
-): ResolvedFieldReference {
-  if (!isResolvedFieldReference(operand)) {
-    throw new Error(message);
-  }
-  return operand;
-}
-
 function requireResolvedValue(
   operand: ResolvedOperand,
   message: string
@@ -1337,10 +1305,6 @@ function buildPrismaFilterFromCerbosExpression(
     case "startsWith":
     case "endsWith": {
       return handleStringOperator(operator, operands, mapper);
-    }
-
-    case "isSet": {
-      return handleIsSetOperator(operands, mapper);
     }
 
     case "hasIntersection": {
@@ -2280,30 +2244,6 @@ function handleStringOperator(
   throw new Error(
     `${operator} between two constants must be folded by the Cerbos planner`
   );
-}
-
-/**
- * Helper function to handle "isSet" operator
- */
-function handleIsSetOperator(
-  operands: PlanExpressionOperand[],
-  mapper: Mapper
-): PrismaFilter {
-  const nameOperand = getNamedOperand(operands, "Name operand is undefined");
-  const valueOperand = getValueOperand(operands, "Value operand is undefined");
-  const fieldRef = requireResolvedFieldReference(
-    resolveOperand(nameOperand, mapper),
-    "Name operand must resolve to a field reference"
-  );
-  const resolvedValue = requireResolvedValue(
-    resolveOperand(valueOperand, mapper),
-    "Value operand must resolve to a value"
-  );
-
-  const fieldName = getLeafField(fieldRef.path);
-  return wrapRelations(fieldRef.relations, {
-    [fieldName]: resolvedValue.value ? { not: null } : { equals: null },
-  });
 }
 
 /**

--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -185,7 +185,7 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 | `in`                             | `path.in(values)` or correlated `EXISTS` for collections            |
 | `in(R.attr.x, R.attr.coll)` (attribute-in-attribute) | Correlated `EXISTS` comparing the collection's member column to the outer scalar column; a `NULL` scalar matches a `NULL` member element (CEL `null in [..., null]` is true) |
 | `contains` / `startsWith` / `endsWith` | `cb.like(...)` with proper `_`/`%`/`\`/`[` escaping (`[` guards SQL Server character classes — see Gotchas) — incl. the constant-receiver form (`"a,b".contains(R.attr.x)`: the constant is the haystack, the column the needle) |
-| `isSet(field, true/false)`       | `cb.isNotNull` / `cb.isNull`                                        |
+| `ne(field, null)` / `eq(field, null)` | `cb.isNotNull` / `cb.isNull`. The planner has no existence operator — `R.attr.x != null` arrives as `ne` against a null value |
 | `hasIntersection(coll, [values])` | Correlated `EXISTS` with `IN`                                      |
 | `hasIntersection(coll.map(x, x.f), [values])` | Correlated `EXISTS` with projected `IN`             |
 | `size(coll) > 0` / `>= 1`        | Correlated `EXISTS`                                                 |
@@ -258,7 +258,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | All 118 reference conformance actions |
+| Oracle-tested | All 122 reference conformance actions |
 | Fail-closed corpus shapes | Regex `matches()`, ordered list indexing/`get-field`, and `timestamp()` over an ambiguous string column (3 actions) |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute rows; this is pinned separately as an upstream divergence |
 

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/OperatorFunction.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/OperatorFunction.java
@@ -12,9 +12,10 @@ import jakarta.persistence.criteria.Predicate;
  * translation of that operator: {@code eq}, {@code ne}, {@code lt}, {@code gt}, {@code le},
  * {@code ge}, {@code contains}, {@code startsWith}, {@code endsWith} (including the {@code add}-folded
  * forms such as {@code field == "p:" + R.id}, and the null-RHS form where {@code value} is
- * {@code null}), the bare-boolean attribute (looked up as {@code eq}), {@code isSet} (where
- * {@code value} is the {@link Boolean} flag), and the scalar {@code in} (where {@code value} is the
- * resolved value or {@link java.util.List}).
+ * {@code null} — the planner has no existence operator, so {@code IS NULL} / {@code IS NOT NULL}
+ * arrive as {@code eq} / {@code ne} against a null value), the bare-boolean attribute (looked up as
+ * {@code eq}), and the scalar {@code in} (where {@code value} is the resolved value or
+ * {@link java.util.List}).
  *
  * <p>Operand order is normalized before overrides are consulted: a value-first comparison such as
  * {@code 5 < R.attr.x} is mirrored to field-first form, so the override is looked up (and invoked)

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -348,7 +348,6 @@ public final class SpringDataQueryPlanAdapter {
                 case "except" -> throw exceptUnsupported();
                 // has_intersection is the deprecated pre-camelCase alias still accepted by the PDP.
                 case "hasIntersection", "has_intersection" -> handleHasIntersection(operands, scope);
-                case "isSet" -> handleIsSet(operands, scope);
                 case "in" -> handleIn(operands, scope);
                 case "if" -> comparisons.handleBareTernary(operands, scope);
                 case "overlaps" -> hierarchy.handleOverlaps(operands, scope);
@@ -1966,36 +1965,6 @@ public final class SpringDataQueryPlanAdapter {
             }
         }
         // -- end ComparisonTranslator --
-
-        // -- isSet --
-
-        private Predicate handleIsSet(List<Operand> operands, Scope scope) {
-            if (operands.size() != 2) {
-                throw new IllegalArgumentException("isSet requires exactly 2 operands");
-            }
-            String variable = null;
-            Boolean flag = null;
-            for (Operand o : operands) {
-                if (o.getNodeCase() == Operand.NodeCase.VARIABLE) variable = o.getVariable();
-                else if (o.getNodeCase() == Operand.NodeCase.VALUE) {
-                    Object v = PlanValues.protoValueToJava(o.getValue());
-                    if (!(v instanceof Boolean b)) {
-                        throw new IllegalArgumentException("isSet second operand must be a boolean");
-                    }
-                    flag = b;
-                }
-            }
-            if (variable == null || flag == null) {
-                throw new IllegalArgumentException(
-                        "Invalid isSet operands: expected one attribute variable and one boolean "
-                                + "value, got " + describeOperand(operands.get(0)) + " / "
-                                + describeOperand(operands.get(1)));
-            }
-            Path<?> path = scope.resolvePath(variable);
-            boolean isSet = flag;
-            return withOverride("isSet", path, isSet,
-                    () -> isSet ? cb.isNotNull(path) : cb.isNull(path));
-        }
 
         // -- in (set membership or collection membership) --
 

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -728,6 +728,8 @@ class AdversarialConformanceTest {
         samples.put("vf-le", oracleAllowedIds("vf-le"));
         samples.put("like-percent", oracleAllowedIds("like-percent"));
         samples.put("all-on-empty", oracleAllowedIds("all-on-empty"));
+        samples.put("null-eq", oracleAllowedIds("null-eq"));
+        samples.put("null-ne", oracleAllowedIds("null-ne"));
         samples.forEach((action, ids) -> assertTrue(
                 !ids.isEmpty() && ids.size() < SEEDS.size(),
                 "oracle for '" + action + "' is degenerate: " + ids));

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataIntegrationTest.java
@@ -576,7 +576,8 @@ class SpringDataIntegrationTest {
     // -- null checks --
 
     @Test
-    void isSet() {
+    void isNotNull() {
+        // aOptionalString != null → ne(field, null); the planner has no existence operator (#261)
         assertEquals(List.of("1", "3"), run("is-set"));
     }
 
@@ -815,7 +816,7 @@ class SpringDataIntegrationTest {
         }
 
         @Test
-        void isSetNested() {
+        void isNotNullNested() {
             // request.resource.attr.nested.aOptionalString != null
             // No seeded row sets nested.aOptionalString, so the result is empty: this verifies
             // the nested-path predicate translates and executes, not a positive match.

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -346,16 +346,27 @@ class SpringDataQueryPlanAdapterTest {
         assertEquals(0, runCount(var("request.resource.attr.aBool")));
     }
 
+    /**
+     * The planner has no existence operator: {@code isSet} is not a registered CEL function,
+     * so a policy naming it fails to compile and it can never reach the wire. The adapter
+     * carried a dedicated branch for it regardless; it must now fail closed like any unknown
+     * operator rather than guess at IS NULL / IS NOT NULL. See
+     * cerbos/query-plan-adapters#261 — the eq/ne-null tests below are the live path.
+     */
     @Test
-    void isSetTrueBuildsIsNotNull() {
-        assertEquals(0, runCount(exprOp("isSet",
-                var("request.resource.attr.aOptionalString"), bval(true))));
+    void isSetIsRejectedRatherThanTranslated() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> runCount(exprOp("isSet",
+                        var("request.resource.attr.aOptionalString"), bval(true))));
+        assertTrue(e.getMessage().contains("isSet"),
+                "unknown operator must be named in the error, got: " + e.getMessage());
     }
 
+    /** Value-first: the planner preserves source order, so {@code null != R.attr.x} inverts operands. */
     @Test
-    void isSetFalseBuildsIsNull() {
-        assertEquals(0, runCount(exprOp("isSet",
-                var("request.resource.attr.aOptionalString"), bval(false))));
+    void valueFirstNeNullBuildsIsNotNull() {
+        assertEquals(0, runCount(exprOp("ne",
+                nullVal(), var("request.resource.attr.aOptionalString"))));
     }
 
     @Test
@@ -824,11 +835,19 @@ class SpringDataQueryPlanAdapterTest {
                 () -> runCount(cond, Map.of("in", THROWING_OVERRIDE)));
     }
 
+    /** Null existence reaches overrides as ne/eq against a null value, not as isSet (#261). */
     @Test
-    void overrideAppliesToIsSet() {
-        Operand cond = exprOp("isSet", var("request.resource.attr.aOptionalString"), bval(true));
+    void overrideAppliesToNeNull() {
+        Operand cond = exprOp("ne", var("request.resource.attr.aOptionalString"), nullVal());
         assertThrows(OverrideInvoked.class,
-                () -> runCount(cond, Map.of("isSet", THROWING_OVERRIDE)));
+                () -> runCount(cond, Map.of("ne", THROWING_OVERRIDE)));
+    }
+
+    @Test
+    void overrideAppliesToEqNull() {
+        Operand cond = exprOp("eq", var("request.resource.attr.aOptionalString"), nullVal());
+        assertThrows(OverrideInvoked.class,
+                () -> runCount(cond, Map.of("eq", THROWING_OVERRIDE)));
     }
 
     @Test
@@ -3574,20 +3593,18 @@ class SpringDataQueryPlanAdapterTest {
     }
 
     @Test
-    void invalidIsSetOperandsReportBothNodeCases() {
-        // Missing boolean flag (two variables): the bare "Invalid isSet operands" gave an
-        // on-call engineer nothing; the message must describe both operands.
+    void isSetReportsUnsupportedOperator() {
+        // isSet had bespoke operand-shape diagnostics; it is not a wire operator at all
+        // (#261), so every shape of it must now surface as a plain unsupported-operator
+        // error rather than a message implying the adapter was close to translating it.
         assertConditionThrows(
                 exprOp("isSet",
                         var("request.resource.attr.aString"),
                         var("request.resource.attr.createdBy")),
-                "Invalid isSet operands",
-                "VARIABLE 'request.resource.attr.aString'",
-                "VARIABLE 'request.resource.attr.createdBy'");
-        // Missing variable (two booleans).
+                "isSet");
         assertConditionThrows(
                 exprOp("isSet", bval(true), bval(false)),
-                "Invalid isSet operands", "VALUE (BOOL_VALUE)");
+                "isSet");
     }
 
     @Test

--- a/sqlalchemy/README.md
+++ b/sqlalchemy/README.md
@@ -10,7 +10,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 116 reference conformance actions |
+| Oracle-tested | 120 reference conformance actions |
 | Fail-closed corpus shapes | Nanosecond `now()` thresholds plus regex `matches()`, ordered list indexing/`get-field`, and `timestamp()` over an ambiguous string column (5 actions) |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -755,6 +755,6 @@ class TestAdversarialConformance:
         # Guard the guard: these actions must produce a non-empty, non-total
         # oracle set, otherwise the differential comparison could pass
         # vacuously (e.g. a PDP that denies everything).
-        for action in ("vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all"):
+        for action in ("vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne"):
             ids = _oracle_allowed_ids(adv_cerbos_client, action)
             assert 0 < len(ids) < len(SEEDS)


### PR DESCRIPTION
Closes #261.

The Cerbos planner has no existence operator. `R.attr.x != null` arrives as a plain `ne` against a `{"value": null}` operand, never `isSet`. Six adapters — prisma, mongoose, drizzle, convex, elasticsearch-java, spring-data — carried dedicated `isSet` branches that no real plan could reach.

## The operator is unreachable, not merely unused

Worth stating precisely, because it changes what the right fix is. The wire operator **is** the CEL function name (`internal/ruletable/planner/ast.go`, `mkExprOpExpr(op string, ...)`), and Cerbos registers no `isSet` function. So `cerbos compile` rejects any policy naming it:

```
Invalid expression `isSet(R.attr.aOptionalString)`:
  [undeclared reference to 'isSet' (in container '')]
```

Same for `R.attr.x.isSet()` and the two-arg form. A policy mentioning `isSet` cannot load into a PDP at all — which also closes the unknown-operator-passthrough route, since that only carries operators that compiled.

Evidence gathered while verifying:

- 16 null-existence shapes planned against a live PDP on **0.54.0** (the pinned conformance version) and **0.55.0-prerelease** — byte-identical output, zero `isSet` in either
- `git log --all -S'isSet'` over cerbos/cerbos returns no planner commit; the only hits are cerbosctl flag helpers, the Go `IsSet` hook backing the `has()` macro, and the adapter reference docs
- `has()` folds at plan time to `ALWAYS_ALLOWED`/`ALWAYS_DENIED`, so it never reaches the wire either

The announced v0.55 strict-eval change is **not** implemented upstream yet (only a hint string in `internal/evaluator/cel_errors.go`), and it targets check()-time effect resolution for DENY rules with runtime errors. Not a planner change, and the corpus is 122 `EFFECT_ALLOW` rules with zero DENY, so it has no bearing here.

## What changed

**Corpus first.** Four actions pin the live path, with golden wire fixtures replanned against the pinned PDP (122 → 126 actions; the existing 122 fixtures are unchanged):

| Action | Wire | Pins |
| --- | --- | --- |
| `null-eq` | `eq(owner, null)` | `IS NULL` |
| `null-ne` | `ne(owner, null)` | `IS NOT NULL` |
| `vf-null-ne` | `ne(null, owner)` | value-first operand inversion (the #258/#259 class) |
| `null-not-eq` | `not(eq(owner, null))` | negation over `IS NULL` is never `UNKNOWN` |

These use the explicit-null `owner` alias rather than `aOptionalString`, deliberately — see the reviewer note below.

**Deletions.** The `isSet` branch in all six adapters, plus five helper functions in prisma and mongoose that existed solely to serve it. Dead code propping up dead code.

**Tests.** Existing `isSet` tests converted to `eq`/`ne`-null regressions; new fail-closed tests in convex, elasticsearch-java and spring-data asserting a synthetic `isSet` plan now throws rather than being translated. Corpus-size tripwires and degeneracy guards updated in all eight harnesses.

**Docs.** Adapter README operator tables and conformance-contract counts.

## Classification came from observed runs

Per the corpus README, classification is an output of the harness, not an input. All four went into `conformance` first and the suites decided:

- **prisma, drizzle, mongoose, convex, sqlalchemy, spring-data** — all four oracle-tested
- **elasticsearch-java** — `null-eq` fails closed: ES does not index explicit null scalars, so positive equality against null cannot distinguish an explicit null attribute (check() allows) from a missing field (CEL error, denies) without a `null_value` sentinel. The three negated forms are expressible as `exists` and stay oracle-tested
- **langchain-chromadb** — all four fail closed: `$eq` accepts only scalar literals and Chroma metadata has no null value; `$ne` matches records whose key is absent

Both rejecting adapters throw rather than emitting a filter, per the repo invariant.

I had predicted the ES outcome from the `in-null-elem-only` precedent, but its first run aborted in `@BeforeAll` on a count assertion before any action executed — the prediction was unconfirmed until I unblocked it and watched it fail.

## Reviewer notes

**Breaking change (drizzle).** `"isSet"` is removed from the `ComparisonOperator` union, which is publicly reachable through the exported `Mapper`/`MapperEntry` types via `MapperTransform`. A consumer whose `transform` callback has a `case "isSet"` will no longer typecheck. The branch was dead for every real plan, so no runtime behaviour changes — but this is consumer-visible and likely wants a major version bump for drizzle, which this repo does as a separate commit.

**Why `owner` and not `aOptionalString`.** The corpus has two NULL representations: the default is DB NULL → missing attribute, while `owner`/`tagNames` are declared explicit-null aliases. Under `owner` the operator and the oracle agree. Under `aOptionalString` they would not — `== null` denies every row at check time while the adapter's `IS NULL` returns five. That is a real over-grant, but it probes attribute *representation* rather than the operator, so it is filed separately as #302 rather than conflated with this cleanup.

**Follow-up outside this repo.** The adapter reference docs in cerbos/cerbos (commits `2f1fa677`, `1d55d67a`) still document `isSet` as a supported operator and go stale when this merges. Alex is taking that.

## Verification

| Adapter | Unit | Adversarial |
| --- | --- | --- |
| prisma | 202 | 129 |
| drizzle | 118 | 128 |
| mongoose | 99 | 128 |
| convex | 109 + 8 integration | 128 |
| langchain-chromadb | 54 | 128 |
| sqlalchemy | 267 (incl. adversarial) | — |
| spring-data | 514 total | ✓ |
| elasticsearch-java | 314 total | ✓ |

`conformance/scripts/validate-corpus.sh` green at 126 actions / 126 fixtures. Java suites run via the repo-root Docker mount per `CLAUDE.md`.

Reviewers reproducing locally: the mongoose suite needs `npm run mongo`, and if `mongoose/data/` was written by MongoDB 8.x the pinned 7.0.39 image exits 62 — move the directory aside and let it recreate.
