### PR TITLE
fix(conformance): pin the NULL-attribute representation behind an explicit option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,10 @@ So when you add, fix, or change the handling of any shape:
    upstream planner bug (`knownDivergences`).
 5. **Bump the per-harness tripwires deliberately** — corpus size, oracle/throwing counts, and the
    degeneracy-guard action list. Add the new action to that guard so it cannot pass vacuously.
+   The exception is an action whose oracle is empty *by construction* (a `nullRepresentationOmitted`
+   probe): the guard asserts a non-empty, non-total oracle, so such an action must stay out of it
+   and carry a different anti-vacuity assertion — one pinning *why* its rejection is required, not
+   merely that a rejection happens. See `conformance/README.md`.
 6. **Update the affected READMEs' `Conformance contract` tables** in the same commit.
 
 A per-adapter unit test is not a substitute for a corpus action. Unit tests pin the filter an

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -33,9 +33,12 @@ rows, and one oracle recipe that every adapter's harness implements against its 
   match), `expectedUnsupported` (planner shapes rejected by the Spring reference adapter; other
   adapters must also fail loudly unless listed in `adapterSupportedExpected`),
   `adapterSupportedExpected` (per-adapter exceptions that intentionally translate a
-  reference-unsupported shape through a documented database capability), and `knownDivergences`
-  (an action plus the affected adapters intentionally excluded from the oracle run, with a
-  reason — currently only `p-has`, excluded because of a planner bug, not an adapter bug).
+  reference-unsupported shape through a documented database capability), `nullRepresentationOmitted`
+  (actions probing `== null` against an attribute the oracle OMITS for NULL columns; every adapter
+  must translate these with its NULL representation set to omitted and reject them — see "NULL
+  conventions" below), and `knownDivergences` (an action plus the affected adapters intentionally
+  excluded from the oracle run, with a reason — currently only `p-has`, excluded because of a
+  planner bug, not an adapter bug).
 - `wire-fixtures/*.json` — one golden `PlanResources` response per action, captured against the
   pinned Cerbos version in `CERBOS_VERSION`. These pin planner *wire shape* independent of any
   adapter or database — a `diff` against a freshly-regenerated fixture after bumping
@@ -79,6 +82,47 @@ NULL, and `tagNames` is the scalar projection of `tags[].name` with NULL names r
 null list elements. This pins `null in [null]`, `null in tagNames`, and variable-in-variable
 membership. Object-valued `tags` still omit a NULL `name`, so collection lambda bodies continue to
 exercise missing-attribute errors. Each harness must implement both representations exactly.
+
+#### `nullRepresentationOmitted`: the two conventions are indistinguishable on the wire
+
+The planner emits the same `eq(attr, null)` node under both conventions — `null-eq` (against the
+explicit-null `owner`) and `null-eq-missing` (against the default-convention `aOptionalString`)
+have byte-identical wire fixtures apart from the variable name. Their oracles do not agree:
+
+| action | attribute convention | `check()` allows | a NULL-selecting filter returns |
+|---|---|---|---|
+| `null-eq` | explicit null | `a2 a4 a8 c2 e1` | the same 5 — aligned |
+| `null-eq-missing` | omitted | **nothing** | those 5 — **over-grants** |
+
+Under the omitted convention CEL raises a missing-attribute error for every NULL row and compares
+`"set" == null` false for every other, so `check()` denies all 20 seeds. An adapter cannot recover
+the caller's convention from the plan, so it has to be told: every adapter that can emit a
+NULL-selecting predicate takes a `nullAttributeRepresentation` option, defaulting to `explicit`
+(the historical translation). See cerbos/query-plan-adapters#302.
+
+`null-eq-missing` lives in its own `actions.json` group rather than in `conformance`, because a
+rejected shape has no filter to compare against the oracle. Each harness translates the group's
+actions with its adapter's representation set to omitted and asserts the rejection — and asserts
+the *reason* the rejection is needed, so the test cannot pass by throwing for an unrelated cause.
+What that second assertion looks like depends on where the adapter's NULL lives:
+
+- **prisma, drizzle, sqlalchemy, spring-data** — a SQL `NULL` is a stored value, so the default
+  translation genuinely returns the five rows the PDP denies. The harnesses pin that over-grant.
+- **mongoose** — already discriminates per attribute: `nullable: true` on a mapper entry means "a
+  stored null is a missing Cerbos attribute" and makes `eq(field, null)` contradictory. Its
+  harness asserts the aligned empty result *and* that `owner` (same column, no `nullable`) still
+  returns its five explicit-null documents, so the empty set is the flag talking.
+- **convex** — a document store, so the seeded shape mirrors the convention directly: the harness
+  omits the field entirely and `q.eq(field, null)` does not match an absent field. Same paired
+  assertion as mongoose. Alignment here comes from the storage layout, not from the plan.
+- **langchain-chromadb, elasticsearch-java** — need no option at all: neither store can represent
+  an explicit null distinguishably from a missing key, so every null-selecting direction already
+  fails closed under both conventions. Their harnesses assert the rejection happens regardless,
+  which is also the tripwire for a future null sentinel introducing a representation dependency.
+
+Because the oracle for these actions is empty by construction, they must **not** join the
+degeneracy guard below — that guard asserts a non-empty, non-total oracle, which is exactly what
+this shape cannot have.
 ### The degeneracy guard
 
 The comparison in step 4 can pass vacuously if the oracle itself is trivial (e.g. the PDP denies
@@ -109,15 +153,16 @@ These are part of the shared contract. Do not replace them with adapter-specific
 ## Adding a new hostile shape
 
 1. Add the action + condition to `policies/adversarial.yaml`.
-2. Add the action name to `actions.json` (`conformance` or `expectedUnsupported`, with a comment
-   in the policy explaining what it probes and which seed rows discriminate it — follow the
-   existing comment style).
+2. Add the action name to `actions.json` — `conformance` or `expectedUnsupported`, or
+   `nullRepresentationOmitted` if it probes `== null` against an attribute the oracle omits for
+   NULL columns — with a comment in the policy explaining what it probes and which seed rows
+   discriminate it (follow the existing comment style).
 3. If the shape needs new seed data to be non-degenerate, add a seed to `seeds.json` with a `note`
    explaining what it witnesses (see `a9`, `b1`-`b6` for examples).
 4. Run `scripts/regenerate-wire-fixtures.sh` and commit the new fixture alongside the policy change.
 5. Every adapter harness picks up the new action automatically from `actions.json` on next run;
    triage any divergence into a per-adapter fix issue rather than special-casing it in the harness.
-6. Each harness pins the corpus size as a tripwire (e.g. `expect(MANIFEST_ACTIONS.size).toBe(126)`
+6. Each harness pins the corpus size as a tripwire (e.g. `expect(MANIFEST_ACTIONS.size).toBe(127)`
    in `prisma/src/adversarial.test.ts`, and the oracle/throwing counts in the convex and
    langchain-chromadb harnesses). Bump them deliberately — that assertion exists so a new action
    cannot slip past an adapter unnoticed.
@@ -127,6 +172,12 @@ These are part of the shared contract. Do not replace them with adapter-specific
    `principal.attr.manyTeams`, the projection dropped it, the plan folded to `ALWAYS_DENIED`, and
    the oracle — built from the same projected principal — agreed. The action passed on both sides
    while testing nothing. Pass corpus data through verbatim.
+
+   The one exception is a `nullRepresentationOmitted` action: its oracle is empty *by
+   construction*, which the degeneracy guard asserts against, so it must stay out of that list.
+   It needs a different anti-vacuity assertion instead — assert why the rejection is required,
+   not merely that one happens. See the `nullRepresentationOmitted` section above for the form
+   that takes in each adapter.
 
 ## Adding a new adapter
 
@@ -145,11 +196,19 @@ unsupported before you have watched it fail is how a translatable shape gets per
    ```
    oracleActions   = conformance - adapterUnsupported[me] + adapterSupportedExpected[me]
    throwingActions = adapterUnsupported[me] + (expectedUnsupported - adapterSupportedExpected[me])
+   nullOmitted     = nullRepresentationOmitted            (translated with the option flipped)
    skipped         = knownDivergences where adapters contains me
    ```
 
    `drizzle/src/adversarial.test.ts` is the cleanest example of this wiring. Every adapter's key
    in `actions.json` is its **directory name** (`langchain-chromadb`, `elasticsearch-java`).
+
+   **Read every group, and derive the manifest from the same expressions.** The manifest assertion
+   ("each action classified exactly once") is what catches a group you forgot — but only if the
+   group feeds both sides. Harnesses that re-validate `actions.json` into a local record
+   (mongoose, langchain-chromadb) must parse each group explicitly: a field the parser does not
+   name is dropped silently, and a dropped group makes its actions vanish from every count and
+   every parameterised case at once. That is the projection trap, and it passes vacuously.
 
 3. **Persist the seeds exactly**, including the NULL conventions and the derived fields above.
    `aOptionalString` is NULL for several seeds and `tags[].name` is NULL for others — those are

--- a/conformance/actions.json
+++ b/conformance/actions.json
@@ -1,5 +1,5 @@
 {
-  "description": "Every action defined in policies/adversarial.yaml, grouped against the Spring Data reference harness. 'conformance' actions must match the check() oracle. 'adapterUnsupported' lists conformance actions an adapter cannot express and must reject loudly. 'expectedUnsupported' lists shapes rejected by the reference; 'adapterSupportedExpected' records adapters that intentionally translate one of those shapes. 'knownDivergences' records upstream planner behavior that prevents an oracle comparison.",
+  "description": "Every action defined in policies/adversarial.yaml, grouped against the Spring Data reference harness. 'conformance' actions must match the check() oracle. 'adapterUnsupported' lists conformance actions an adapter cannot express and must reject loudly. 'expectedUnsupported' lists shapes rejected by the reference; 'adapterSupportedExpected' records adapters that intentionally translate one of those shapes. 'nullRepresentationOmitted' lists actions that probe a `== null` comparison against an attribute the oracle OMITS for NULL columns; every adapter must translate these with its null representation set to 'omitted' and reject them. 'knownDivergences' records upstream planner behavior that prevents an oracle comparison.",
   "conformance": [
     "vf-le", "vf-ge", "vf-ne",
     "in-single", "in-empty",
@@ -334,6 +334,13 @@
     { "action": "p-timestamp", "shape": "timestamp() comparison over an ISO-date string column", "springDataMessage": "Unexpected timestamp() expression in leaf operand of lt" },
     { "action": "p-matches",   "shape": "matches() regex", "springDataMessage": "Unsupported operator: matches" },
     { "action": "p-index",     "shape": "list indexing (tags[0].name)", "springDataMessage": "Unexpected get-field() expression in leaf operand of eq" }
+  ],
+  "nullRepresentationOmitted": [
+    {
+      "action": "null-eq-missing",
+      "reason": "`aOptionalString` follows the corpus default: a NULL column sends NO attribute, so `R.attr.aOptionalString == null` is a CEL missing-attribute error and check() denies all 20 seeds. The planner emits the same `eq(var, null)` node as `null-eq` (explicit null, 5 rows allowed), so the wire cannot tell the two conventions apart. Every adapter must be told which one the caller uses. Harnesses translate this action with the adapter's null representation set to `omitted` and assert a throw; under the default `explicit` the adapter would emit IS NULL and return the 5 rows the PDP denies (#302).",
+      "relatedIssue": "https://github.com/cerbos/query-plan-adapters/issues/302"
+    }
   ],
   "knownDivergences": [
     {

--- a/conformance/policies/adversarial.yaml
+++ b/conformance/policies/adversarial.yaml
@@ -1044,6 +1044,25 @@ resourcePolicy:
         match:
           expr: '!(R.attr.owner == null)'
 
+    # The SAME shape against `aOptionalString`, which follows the corpus DEFAULT convention:
+    # a NULL column sends NO attribute at all. CEL then raises a missing-attribute error for
+    # every NULL row, and `"set" == null` is false for every non-NULL row, so check() denies
+    # ALL 20 seeds. The planner emits the identical `eq(a_optional_string, null)` wire node as
+    # `null-eq` — the two are indistinguishable on the wire, which is exactly the point: the
+    # adapter cannot recover the caller's representation from the plan.
+    #
+    # Rendering this as IS NULL returns the five NULL-column rows the PDP denies (#302), so
+    # under `nullAttributeRepresentation: "omitted"` every adapter must reject it instead.
+    # `actions.json` lists it in `nullRepresentationOmitted`: harnesses translate this action
+    # with the option set to "omitted" and assert the throw. Do not add it to `conformance`;
+    # a throwing action has no filter to compare against the oracle.
+    - actions: ["null-eq-missing"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: 'R.attr.aOptionalString == null'
+
     # ==================== in-lists containing null ====================
     # `R.attr.owner in [..., null]` compiles and the planner emits the null element
     # VERBATIM in the value list; check() ALLOWS an explicitly-null attribute (CEL

--- a/conformance/scripts/regenerate-wire-fixtures.sh
+++ b/conformance/scripts/regenerate-wire-fixtures.sh
@@ -59,6 +59,7 @@ mkdir -p wire-fixtures
 ACTIONS="$(jq -r '
   .conformance[],
   .expectedUnsupported[].action,
+  .nullRepresentationOmitted[].action,
   .knownDivergences[].action
 ' actions.json | sort -u)"
 COUNT=0

--- a/conformance/scripts/validate-corpus.sh
+++ b/conformance/scripts/validate-corpus.sh
@@ -18,6 +18,7 @@ sed -n 's/^[[:space:]]*- actions: \["\([^"]*\)"\].*/\1/p' \
 jq -r '
   .conformance[],
   .expectedUnsupported[].action,
+  .nullRepresentationOmitted[].action,
   .knownDivergences[].action
 ' actions.json | sort >"${VALIDATION_TMP}/classified-actions"
 

--- a/conformance/wire-fixtures/null-eq-missing.json
+++ b/conformance/wire-fixtures/null-eq-missing.json
@@ -1,0 +1,20 @@
+{
+  "action": "null-eq-missing",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "eq",
+        "operands": [
+          {
+            "variable": "request.resource.attr.aOptionalString"
+          },
+          {
+            "value": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/convex/README.md
+++ b/convex/README.md
@@ -74,6 +74,36 @@ const { kind, filter, postFilter } = queryPlanToConvex({
 
 If your Cerbos policies only use operators that Convex supports natively (comparisons, `in`, null checks, logical combinators), you don't need this flag — `filter` alone will enforce the full policy at the DB level.
 
+## NULL attribute representation
+
+`R.attr.x == null` compiles to the same `eq(x, null)` plan node however your application represents
+a NULL field in the attributes it sends to `check()`, so the adapter cannot infer the convention
+and has to be told which one you use.
+
+| attributes you send for a NULL field | `check()` on that document | `q.eq(field, null)` |
+| --- | --- | --- |
+| `{"x": null}` — explicit null | allow | selects it — aligned |
+| `{}` — attribute omitted | **deny** (CEL missing-attribute error) | selects it if the field is stored as null — **over-grants** |
+
+`nullAttributeRepresentation` defaults to `"explicit"`, preserving the historical translation. If
+your application omits attributes for NULL fields, set it to `"omitted"`: the adapter then rejects
+every null comparison operand — in the pushed-down filter *and* in the in-memory `postFilter` —
+instead of returning documents the PDP denies.
+
+```ts
+queryPlanToConvex({ queryPlan, mapper, nullAttributeRepresentation: "omitted" });
+```
+
+Storing the field as absent rather than as an explicit `null` also aligns the two, since
+`q.eq(field, null)` does not match an absent field — but that is a property of your document
+shape, not of the plan, so the option remains the reliable guard.
+
+The rejection is deliberately wider than the shapes that actually over-grant — `x != null` and
+`!(x == null)` are aligned under both conventions — because negation is applied around the built
+predicate rather than pushed into the leaf, so a leaf cannot tell whether an enclosing `not` will
+flip a not-null predicate back into a null-selecting one. Rejecting every null operand is correct
+under any nesting. See [#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ## Conformance contract
 
 The adapter is differentially tested with 20 hostile seed documents against Cerbos PDP 0.54.0 `checkResource` decisions: each query plan is executed by Convex, and the returned document IDs must equal the PDP's per-document decisions. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
@@ -83,6 +113,7 @@ The adapter is differentially tested with 20 hostile seed documents against Cerb
 | Oracle-tested | All 122 reference conformance actions, plus `matches()`, list indexing/`get-field`, and `timestamp()` plans that the Spring Data reference adapter rejects (125 actions total) |
 | Fail-closed | No corpus shape when `allowPostFilter: true`; unknown operators and invalid expression structures still throw |
 | Explicit opt-in | Any plan that cannot be represented entirely as a Convex database filter requires `allowPostFilter: true` |
+| Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`. Under the default it already returns the empty set the PDP demands *when the document omits the field for a NULL value*, which is what the conformance harness seeds; a deployment that stores explicit nulls while omitting the attribute would over-grant |
 | Known planner divergence | `has()` on a missing attribute is currently folded by the Cerbos planner to `ALWAYS_ALLOWED`; `checkResource` still denies documents where the attribute is missing. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 This support statement includes value-first comparisons, field-to-field expressions, null and missing-attribute behavior, nested lambdas, collection macros, string and arithmetic expressions, timestamps, hierarchy operations, and chained nested fields. Fields that may be absent must be marked `nullable: true` in the mapper so the adapter evaluates their predicates with CEL-compatible missing-value semantics instead of pushing them to a Convex filter.

--- a/convex/convex/adversarial.ts
+++ b/convex/convex/adversarial.ts
@@ -115,7 +115,14 @@ export const deleteAll = mutation({
 });
 
 export const executePlan = query({
-  args: { queryPlan: v.any() },
+  args: {
+    queryPlan: v.any(),
+    // #302: the conformance harness runs the `nullRepresentationOmitted` actions through the
+    // same entry point with the option flipped, so it has to cross the Convex boundary.
+    nullAttributeRepresentation: v.optional(
+      v.union(v.literal("explicit"), v.literal("omitted")),
+    ),
+  },
   handler: async (ctx, args) => {
     const queryPlan: unknown = args.queryPlan;
     if (!isPlanResourcesResponse(queryPlan)) {
@@ -125,7 +132,12 @@ export const executePlan = query({
     const translated = queryPlanToConvex<
       FilterBuilder<DataModel["adversarial"]>,
       Expression<boolean>
-    >({ queryPlan, mapper: MAPPER, allowPostFilter: true });
+    >({
+      queryPlan,
+      mapper: MAPPER,
+      allowPostFilter: true,
+      nullAttributeRepresentation: args.nullAttributeRepresentation ?? "explicit",
+    });
 
     if (translated.kind === PlanKind.ALWAYS_DENIED) return [];
 

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -54,6 +54,7 @@ interface ActionsFile {
   adapterUnsupported: Record<string, AdapterOutcome[]>;
   adapterSupportedExpected: Record<string, AdapterOutcome[]>;
   expectedUnsupported: ExpectedUnsupported[];
+  nullRepresentationOmitted: AdapterOutcome[];
   knownDivergences: KnownDivergence[];
 }
 
@@ -192,6 +193,16 @@ const KNOWN_DIVERGENCES = new Set(
     .filter((entry) => entry.adapters.includes("convex"))
     .map((entry) => entry.action),
 );
+// Actions whose `== null` probe targets an attribute the oracle OMITS for NULL columns. They
+// carry no oracle comparison: under the omitted representation check() denies every document, so
+// the adapter must reject the shape rather than emit a filter (#302).
+const NULL_REPRESENTATION_OMITTED = actionsFile.nullRepresentationOmitted;
+const MANIFEST_ACTIONS = new Set([
+  ...actionsFile.conformance,
+  ...actionsFile.expectedUnsupported.map((entry) => entry.action),
+  ...NULL_REPRESENTATION_OMITTED.map((entry) => entry.action),
+  ...KNOWN_DIVERGENCES,
+]);
 
 function doubleFor(seed: Seed): number | null {
   switch (seed.id) {
@@ -370,7 +381,10 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
   return ids.sort();
 }
 
-async function adapterFilteredIds(action: string): Promise<string[]> {
+async function adapterFilteredIds(
+  action: string,
+  nullAttributeRepresentation: "explicit" | "omitted" = "explicit",
+): Promise<string[]> {
   const queryPlan = await cerbos.planResources({
     principal: seedsFile.principal,
     resource: { kind: seedsFile.resourceKind },
@@ -379,6 +393,7 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
   if (queryPlan.kind === PlanKind.ALWAYS_DENIED) return [];
   return convex.query(api.adversarial.executePlan, {
     queryPlan: JSON.parse(JSON.stringify(queryPlan)),
+    nullAttributeRepresentation,
   });
 }
 
@@ -393,25 +408,37 @@ afterAll(async () => {
   await convex.mutation(api.adversarial.deleteAll, {});
 });
 
+/** Whether any operand anywhere in the plan is a literal null, or a list containing one. */
+function planCarriesNullLiteral(operand: unknown): boolean {
+  if (typeof operand !== "object" || operand === null) return false;
+  const node = operand as Record<string, unknown>;
+  if ("value" in node) {
+    const value = node["value"];
+    return value === null || (Array.isArray(value) && value.includes(null));
+  }
+  const operands = node["operands"];
+  return Array.isArray(operands) && operands.some(planCarriesNullLiteral);
+}
+
 describe("adversarial conformance corpus", () => {
   test("assigns all policy actions exactly one Convex outcome", () => {
-    const allActions = new Set([
-      ...actionsFile.conformance,
-      ...actionsFile.expectedUnsupported.map((entry) => entry.action),
-      ...KNOWN_DIVERGENCES,
-    ]);
+    const allActions = MANIFEST_ACTIONS;
     const oracle = new Set(ORACLE_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS);
+    const nullOmitted = new Set(
+      NULL_REPRESENTATION_OMITTED.map((entry) => entry.action),
+    );
     const misclassified = [...allActions].filter(
       (action) =>
         [
           oracle.has(action),
           throwing.has(action),
+          nullOmitted.has(action),
           KNOWN_DIVERGENCES.has(action),
         ].filter(Boolean).length !== 1,
     );
 
-    expect(allActions.size).toBe(126);
+    expect(allActions.size).toBe(127);
     expect(CONVEX_UNSUPPORTED).toHaveLength(0);
     expect(CONVEX_SUPPORTED_EXPECTED).toHaveLength(3);
     expect(ORACLE_ACTIONS).toHaveLength(125);
@@ -425,6 +452,71 @@ describe("adversarial conformance corpus", () => {
       adapterFilteredIds(action),
     ]);
     expect(filtered).toEqual(oracle);
+  });
+
+  // #302. `null-eq-missing` probes `aOptionalString == null`, and `aOptionalString` follows the
+  // corpus default: a NULL column sends NO attribute, so check() denies every document.
+  //
+  // Convex is a document store, so the SEEDED SHAPE can mirror that convention directly: this
+  // harness omits `aOptionalString` entirely for a NULL column, and `q.eq(field, null)` does not
+  // match an absent field. The default translation therefore already returns the empty set the
+  // oracle demands — alignment that comes from the storage layout, not from anything the adapter
+  // knows about the plan. A deployment that stored explicit nulls while omitting the attribute at
+  // check time would over-grant exactly as a SQL adapter does, which is what the option guards.
+  test.each(NULL_REPRESENTATION_OMITTED)(
+    "$action aligns via the omitted document shape and is rejected under omitted ($reason)",
+    async ({ action }) => {
+      expect(await oracleAllowedIds(action)).toEqual([]);
+      expect(await adapterFilteredIds(action, "explicit")).toEqual([]);
+
+      // `owner` maps to the same seed field but IS stored as an explicit null, so the empty
+      // result above is the document shape talking, not a filter that matches nothing everywhere.
+      const explicitNullOracle = await oracleAllowedIds("null-eq");
+      expect(explicitNullOracle.length).toBeGreaterThan(0);
+      expect(await adapterFilteredIds("null-eq", "explicit")).toEqual(
+        explicitNullOracle,
+      );
+
+      await expect(adapterFilteredIds(action, "omitted")).rejects.toThrow(
+        /missing-attribute error/,
+      );
+    },
+  );
+
+  // #302 completeness guard. The rejection must key off the null OPERAND, not off a list of
+  // operators: `hasIntersection(tagNames, ["public", null])` carries one in its value list, and
+  // an allowlist of eq/ne/in silently misses it. Enumerating the corpus rather than naming
+  // shapes means a newly added action carrying a null constant is covered automatically.
+  test("every corpus action carrying a null literal is rejected under omitted", async () => {
+    const nullCarrying: string[] = [];
+    for (const action of [...MANIFEST_ACTIONS].sort()) {
+      const queryPlan = await cerbos.planResources({
+        principal: seedsFile.principal,
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      if (
+        queryPlan.kind === PlanKind.CONDITIONAL &&
+        planCarriesNullLiteral(queryPlan.condition)
+      ) {
+        nullCarrying.push(action);
+      }
+    }
+
+    // Guard the guard: if the walk stopped finding null operands the loop below is vacuous.
+    expect(nullCarrying).toContain("null-eq-missing");
+    expect(nullCarrying).toContain("in-null-elem-hasint");
+
+    const notRejected: string[] = [];
+    for (const action of nullCarrying) {
+      try {
+        await adapterFilteredIds(action, "omitted");
+        notRejected.push(action);
+      } catch {
+        // expected: the shape must be rejected under this representation
+      }
+    }
+    expect(notRejected).toEqual([]);
   });
 
   test("pins the upstream has() planner over-grant", async () => {

--- a/convex/src/index.test.ts
+++ b/convex/src/index.test.ts
@@ -2886,3 +2886,103 @@ describe("Known-Value Collections (planner unroll cliff)", () => {
     ).toBe(true);
   });
 });
+
+// cerbos/query-plan-adapters#302. Both NULL-field conventions produce the identical
+// `eq(attr, null)` wire node, so the adapter cannot infer which one the caller uses. Under
+// "omitted" a NULL field carries no attribute at all, CEL raises a missing-attribute error, and
+// check() denies every document — a null-matching filter would return precisely the documents
+// the PDP refuses.
+describe("nullAttributeRepresentation", () => {
+  const planFor = (
+    operator: string,
+    value: unknown,
+  ): PlanResourcesConditionalResponse =>
+    ({
+      kind: PlanKind.CONDITIONAL,
+      condition: new PlanExpression(operator, [
+        new PlanExpressionVariable("request.resource.attr.aOptionalString"),
+        { value } as PlanExpressionOperand,
+      ]),
+    }) as PlanResourcesConditionalResponse;
+
+  test('"explicit" is the default and keeps the null-matching translation', () => {
+    const queryPlan = planFor("eq", null);
+
+    expect(
+      queryPlanToConvex({ queryPlan, mapper: defaultMapper }).kind,
+    ).toEqual(PlanKind.CONDITIONAL);
+    expect(() =>
+      queryPlanToConvex({
+        queryPlan,
+        mapper: defaultMapper,
+        nullAttributeRepresentation: "explicit",
+      }),
+    ).not.toThrow();
+  });
+
+  test('"omitted" rejects eq against a null operand', () => {
+    expect(() =>
+      queryPlanToConvex({
+        queryPlan: planFor("eq", null),
+        mapper: defaultMapper,
+        nullAttributeRepresentation: "omitted",
+      }),
+    ).toThrow(/missing-attribute error/);
+  });
+
+  // Conservatively rejected too: `ne` alone is aligned under "omitted", but negation is applied
+  // around the built predicate, so a leaf cannot see whether an enclosing `not` will flip a
+  // not-null predicate back into a null-selecting one.
+  test('"omitted" rejects ne against a null operand', () => {
+    expect(() =>
+      queryPlanToConvex({
+        queryPlan: planFor("ne", null),
+        mapper: defaultMapper,
+        nullAttributeRepresentation: "omitted",
+      }),
+    ).toThrow(/missing-attribute error/);
+  });
+
+  test('"omitted" rejects a null element in an in-list', () => {
+    expect(() =>
+      queryPlanToConvex({
+        queryPlan: planFor("in", ["x", null]),
+        mapper: defaultMapper,
+        nullAttributeRepresentation: "omitted",
+      }),
+    ).toThrow(/missing-attribute error/);
+  });
+
+  // The scan walks the whole tree, not just the root: a null operand nested under a logical
+  // operator is the same over-grant.
+  test('"omitted" rejects a null operand nested under and/not', () => {
+    const queryPlan = {
+      kind: PlanKind.CONDITIONAL,
+      condition: new PlanExpression("and", [
+        new PlanExpression("not", [planFor("eq", null).condition]),
+        new PlanExpression("eq", [
+          new PlanExpressionVariable("request.resource.attr.aString"),
+          { value: "x" } as PlanExpressionOperand,
+        ]),
+      ]),
+    } as PlanResourcesConditionalResponse;
+
+    expect(() =>
+      queryPlanToConvex({
+        queryPlan,
+        mapper: defaultMapper,
+        nullAttributeRepresentation: "omitted",
+      }),
+    ).toThrow(/missing-attribute error/);
+  });
+
+  test('"omitted" leaves null-free comparisons untouched', () => {
+    expect(() =>
+      queryPlanToConvex({
+        queryPlan: planFor("eq", "x"),
+        mapper: defaultMapper,
+        nullAttributeRepresentation: "omitted",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/convex/src/index.ts
+++ b/convex/src/index.ts
@@ -20,10 +20,31 @@ export type Mapper =
   | Record<string, MapperConfig>
   | ((key: string) => MapperConfig);
 
+/**
+ * How the caller represents a NULL field when building the attributes it sends to `check()`.
+ *
+ * The planner emits the same `eq(attr, null)` node either way, so the plan cannot reveal which
+ * convention is in use and the adapter has to be told.
+ *
+ * - `"explicit"` (default) — a NULL field is sent as an explicit `null` attribute. CEL compares
+ *   `null == null`, so matching null selects exactly the documents `check()` allows.
+ * - `"omitted"` — a NULL field sends no attribute at all. CEL then raises a missing-attribute
+ *   error, which Cerbos treats as a deny, so a filter that *selects* null documents returns
+ *   documents the PDP denies. Null comparison operands are rejected instead of translated.
+ *
+ * See https://github.com/cerbos/query-plan-adapters/issues/302.
+ */
+export type NullAttributeRepresentation = "explicit" | "omitted";
+
 export interface QueryPlanToConvexArgs {
   queryPlan: PlanResourcesResponse;
   mapper?: Mapper;
   allowPostFilter?: boolean;
+  /**
+   * Which NULL-field representation the caller uses when building `check()` attributes.
+   * Defaults to `"explicit"`, preserving the historical null-matching translation.
+   */
+  nullAttributeRepresentation?: NullAttributeRepresentation;
 }
 
 export interface QueryPlanToConvexResult<Q = unknown, R = unknown> {
@@ -1037,10 +1058,56 @@ const buildFilters = (
   };
 };
 
+/**
+ * Rejects every null literal operand in the plan when the caller omits attributes for NULL
+ * fields.
+ *
+ * Under the `"omitted"` representation a NULL field carries no attribute, so CEL raises a
+ * missing-attribute error and `check()` denies the document; matching null would return exactly
+ * the documents the PDP refuses. Convex translates a plan down two paths — a pushed-down
+ * `q.eq(...)` filter and an in-memory `postFilter` — so the check runs once over the plan tree
+ * rather than at each emission site.
+ *
+ * The scan matches on the OPERAND, never on an allowlist of operators. A null constant reaches a
+ * null-selecting predicate through more shapes than the obvious `eq`/`ne`/`in` — `hasIntersection`
+ * carries one in its value list too — and any operator added later would silently escape a list
+ * that has to be maintained by hand.
+ *
+ * The rejection is also deliberately wider than the over-granting shapes: `ne(x, null)` on its own
+ * is aligned, but negation is applied around the built predicate, so a leaf cannot tell whether an
+ * enclosing `not` will flip a not-null predicate back into a null-selecting one. Rejecting every
+ * null operand is correct under any nesting; narrowing it requires negation-parity tracking.
+ */
+const carriesNullLiteral = (operand: PlanExpressionOperand): boolean =>
+  isValue(operand) &&
+  (operand.value === null ||
+    (Array.isArray(operand.value) && operand.value.includes(null)));
+
+const assertNoNullComparisonOperands = (
+  expression: PlanExpressionOperand,
+): void => {
+  if (!isExpression(expression)) return;
+
+  if (expression.operands.some(carriesNullLiteral)) {
+    throw new Error(
+      `Cannot translate \`${expression.operator}\` against a null operand under ` +
+      'nullAttributeRepresentation "omitted": a NULL field sends no attribute, so Cerbos ' +
+      "evaluates the comparison as a missing-attribute error (deny) while a null-selecting " +
+      'filter would return those documents. Send NULL fields as explicit nulls and use ' +
+      '"explicit", or keep this shape out of the policy.',
+    );
+  }
+
+  for (const operand of expression.operands) {
+    assertNoNullComparisonOperands(operand);
+  }
+};
+
 export function queryPlanToConvex<Q = unknown, R = unknown>({
   queryPlan,
   mapper = {},
   allowPostFilter = false,
+  nullAttributeRepresentation = "explicit",
 }: QueryPlanToConvexArgs): QueryPlanToConvexResult<Q, R> {
   switch (queryPlan.kind) {
     case PlanKind.ALWAYS_ALLOWED:
@@ -1048,6 +1115,9 @@ export function queryPlanToConvex<Q = unknown, R = unknown>({
     case PlanKind.ALWAYS_DENIED:
       return { kind: PlanKind.ALWAYS_DENIED };
     case PlanKind.CONDITIONAL: {
+      if (nullAttributeRepresentation === "omitted") {
+        assertNoNullComparisonOperands(queryPlan.condition);
+      }
       const { filter, postFilter } = buildFilters(queryPlan.condition, mapper);
 
       if (postFilter && !allowPostFilter) {

--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -13,6 +13,32 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 - Supports relation-aware mappings, including nested relations and many-to-many joins
 - Works with Drizzle SQLite, PostgreSQL, MySQL and PlanetScale drivers
 
+## NULL attribute representation
+
+`R.attr.x == null` compiles to the same `eq(x, null)` plan node however your application represents
+a NULL column in the attributes it sends to `check()`, so the adapter cannot infer the convention
+and has to be told which one you use.
+
+| attributes you send for a NULL column | `check()` on that row | null-matching filter |
+| --- | --- | --- |
+| `{"x": null}` — explicit null | allow | selects it — aligned |
+| `{}` — attribute omitted | **deny** (CEL missing-attribute error) | selects it — **over-grants** |
+
+``nullAttributeRepresentation`` defaults to ``"explicit"``, preserving the historical translation. If your application
+omits attributes for NULL columns, set it to ``"omitted"``: the adapter then rejects every null
+comparison operand instead of emitting a filter that returns rows the PDP denies.
+
+```ts
+queryPlanToDrizzle({ queryPlan, mapper, nullAttributeRepresentation: "omitted" });
+```
+
+The rejection is deliberately wider than the shapes that actually over-grant — `x != null` and
+`!(x == null)` are aligned under both conventions — because negation is applied by wrapping the
+built condition rather than pushing it into the leaf, so a leaf cannot tell whether an enclosing
+`not` will flip a not-null predicate back into a null-selecting one. Rejecting every null operand
+is correct under any nesting. See
+[#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ## Conformance contract
 
 The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` decisions using 20 hostile seed rows and real Drizzle queries. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
@@ -21,6 +47,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 | --- | --- |
 | Oracle-tested | 120 reference conformance actions |
 | Fail-closed corpus shapes | Sub-millisecond `now()` thresholds plus regex `matches()`, ordered list indexing/`get-field`, and `timestamp()` over an untyped string field (5 actions) |
+| Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 The oracle coverage includes value-first and field-to-field comparisons, escaped string predicates, relation counts and nested collection macros, null/error propagation, arithmetic and ternaries, hierarchy operations, typed timestamps, and multi-hop relations. The five fail-closed shapes throw rather than return a broader SQL filter. `matches()` is rejected because SQL regex dialects do not guarantee CEL/RE2 semantics.

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -71,6 +71,7 @@ interface ActionsFile {
   adapterUnsupported?: Record<string, AdapterUnsupportedEntry[]>;
   adapterSupportedExpected?: Record<string, AdapterUnsupportedEntry[]>;
   expectedUnsupported: UnsupportedShape[];
+  nullRepresentationOmitted: AdapterUnsupportedEntry[];
   knownDivergences?: KnownDivergence[];
 }
 
@@ -122,9 +123,17 @@ const THROWING_ACTIONS: ThrowingAction[] = [
     .map((entry): ThrowingAction => [entry.action, entry.shape]),
 ];
 
+// Actions whose `== null` probe targets an attribute the oracle OMITS for NULL columns. They
+// carry no oracle comparison: under the omitted representation check() denies every row, so the
+// adapter must reject the shape rather than emit a filter (#302).
+const NULL_REPRESENTATION_OMITTED = actionsFile.nullRepresentationOmitted.map(
+  (entry): ThrowingAction => [entry.action, entry.reason]
+);
+
 const MANIFEST_ACTIONS = new Set([
   ...actionsFile.conformance,
   ...actionsFile.expectedUnsupported.map((entry) => entry.action),
+  ...NULL_REPRESENTATION_OMITTED.map(([action]) => action),
   ...DRIZZLE_SUPPORTED_EXPECTED,
   ...DRIZZLE_DIVERGENCES,
 ]);
@@ -535,13 +544,20 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
 
 // -- adapter execution through the public queryPlanToDrizzle path --
 
-async function adapterFilteredIds(action: string): Promise<string[]> {
+async function adapterFilteredIds(
+  action: string,
+  nullAttributeRepresentation: "explicit" | "omitted" = "explicit"
+): Promise<string[]> {
   const queryPlan = await cerbos.planResources({
     principal: principal(),
     resource: { kind: seedsFile.resourceKind },
     action,
   });
-  const result = queryPlanToDrizzle({ queryPlan, mapper: MAPPER });
+  const result = queryPlanToDrizzle({
+    queryPlan,
+    mapper: MAPPER,
+    nullAttributeRepresentation,
+  });
   if (result.kind === PlanKind.ALWAYS_DENIED) {
     return [];
   }
@@ -555,19 +571,37 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
   return rows.map((row) => row.id).sort();
 }
 
+/** Whether any operand anywhere in the plan is a literal null, or a list containing one. */
+function planCarriesNullLiteral(operand: unknown): boolean {
+  if (typeof operand !== "object" || operand === null) return false;
+  const node = operand as Record<string, unknown>;
+  if ("value" in node) {
+    const value = node["value"];
+    return value === null || (Array.isArray(value) && value.includes(null));
+  }
+  const operands = node["operands"];
+  return Array.isArray(operands) && operands.some(planCarriesNullLiteral);
+}
+
 describe("adversarial conformance corpus", () => {
   test("manifest assigns every action exactly one Drizzle outcome", () => {
     const oracle = new Set(ORACLE_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map(([action]) => action));
+    const nullOmitted = new Set(
+      NULL_REPRESENTATION_OMITTED.map(([action]) => action)
+    );
     const misclassified = [...MANIFEST_ACTIONS].filter((action) => {
       const classificationCount = [
         oracle.has(action),
         throwing.has(action),
+        nullOmitted.has(action),
         DRIZZLE_DIVERGENCES.has(action),
       ].filter(Boolean).length;
       return classificationCount !== 1;
     });
 
+    expect(MANIFEST_ACTIONS.size).toBe(127);
+    expect(NULL_REPRESENTATION_OMITTED).toHaveLength(1);
     expect(misclassified).toEqual([]);
     expect(
       [...DRIZZLE_SUPPORTED_EXPECTED].filter(
@@ -595,6 +629,62 @@ describe("adversarial conformance corpus", () => {
       await expect(adapterFilteredIds(action)).rejects.toThrow();
     }
   );
+
+  // #302. `null-eq-missing` probes `aOptionalString == null`, and `aOptionalString` follows the
+  // corpus default: a NULL column sends NO attribute. Both halves are asserted because the
+  // rejection alone would pass vacuously if the adapter threw for an unrelated reason — the
+  // over-grant under the default representation is what makes the rejection necessary.
+  test.each(NULL_REPRESENTATION_OMITTED)(
+    "%s over-grants under the explicit representation and is rejected under omitted (%s)",
+    async (action) => {
+      const oracle = await oracleAllowedIds(action);
+      expect(oracle).toEqual([]);
+
+      // The default translation emits IS NULL and returns exactly the rows the PDP denies.
+      const overGranted = await adapterFilteredIds(action, "explicit");
+      expect(overGranted.length).toBeGreaterThan(0);
+
+      await expect(adapterFilteredIds(action, "omitted")).rejects.toThrow(
+        /missing-attribute error/
+      );
+    }
+  );
+
+  // #302 completeness guard. The rejection must key off the null OPERAND, not off a list of
+  // operators: `hasIntersection(tagNames, ["public", null])` carries one in its value list, and
+  // an allowlist of eq/ne/in silently misses it. Enumerating the corpus rather than naming
+  // shapes means a newly added action carrying a null constant is covered automatically.
+  test("every corpus action carrying a null literal is rejected under omitted", async () => {
+    const nullCarrying: string[] = [];
+    for (const action of [...MANIFEST_ACTIONS].sort()) {
+      const queryPlan = await cerbos.planResources({
+        principal: principal(),
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      if (
+        queryPlan.kind === PlanKind.CONDITIONAL &&
+        planCarriesNullLiteral(queryPlan.condition)
+      ) {
+        nullCarrying.push(action);
+      }
+    }
+
+    // Guard the guard: if the walk stopped finding null operands the loop below is vacuous.
+    expect(nullCarrying).toContain("null-eq-missing");
+    expect(nullCarrying).toContain("in-null-elem-hasint");
+
+    const notRejected: string[] = [];
+    for (const action of nullCarrying) {
+      try {
+        await adapterFilteredIds(action, "omitted");
+        notRejected.push(action);
+      } catch {
+        // expected: the shape must be rejected under this representation
+      }
+    }
+    expect(notRejected).toEqual([]);
+  });
 
   test("pins the upstream has() planner over-grant", async () => {
     const action = "p-has";

--- a/drizzle/src/index.test.ts
+++ b/drizzle/src/index.test.ts
@@ -1541,3 +1541,109 @@ describe("known-value collections (planner unroll cliff)", () => {
     });
   });
 });
+
+// cerbos/query-plan-adapters#302. Both NULL-column conventions produce the identical
+// `eq(attr, null)` wire node, so the adapter cannot infer which one the caller uses. Under
+// "omitted" a NULL column carries no attribute at all, CEL raises a missing-attribute error,
+// and check() denies every row — an IS NULL filter would return precisely the rows the PDP
+// refuses.
+describe("nullAttributeRepresentation", () => {
+  const nullEqPlan = buildPlan({
+    operator: "eq",
+    operands: [
+      { name: "request.resource.attr.aOptionalString" },
+      { value: null },
+    ],
+  } as PlanExpressionOperand);
+
+  const nullNePlan = buildPlan({
+    operator: "ne",
+    operands: [
+      { name: "request.resource.attr.aOptionalString" },
+      { value: null },
+    ],
+  } as PlanExpressionOperand);
+
+  test('"explicit" is the default and keeps the IS NULL translation', () => {
+    const withDefault = ensureFilter(
+      queryPlanToDrizzle({ queryPlan: nullEqPlan, mapper })
+    );
+    const withExplicit = ensureFilter(
+      queryPlanToDrizzle({
+        queryPlan: nullEqPlan,
+        mapper,
+        nullAttributeRepresentation: "explicit",
+      })
+    );
+
+    expect(db.select().from(resources).where(withDefault).toSQL().sql).toEqual(
+      db.select().from(resources).where(withExplicit).toSQL().sql
+    );
+    expect(db.select().from(resources).where(withDefault).toSQL().sql).toContain(
+      "is null"
+    );
+  });
+
+  test('"omitted" rejects eq against a null operand', () => {
+    expect(() =>
+      queryPlanToDrizzle({
+        queryPlan: nullEqPlan,
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    ).toThrow(/missing-attribute error/);
+  });
+
+  // Conservatively rejected too: `ne` alone is aligned under "omitted", but negation is applied
+  // by wrapping the built condition, so a leaf cannot see whether an enclosing `not` will flip
+  // IS NOT NULL back into a NULL-selecting predicate.
+  test('"omitted" rejects ne against a null operand', () => {
+    expect(() =>
+      queryPlanToDrizzle({
+        queryPlan: nullNePlan,
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    ).toThrow(/missing-attribute error/);
+  });
+
+  test('"omitted" rejects a null element in an in-list', () => {
+    const plan = buildPlan({
+      operator: "in",
+      operands: [
+        { name: "request.resource.attr.aOptionalString" },
+        { value: ["x", null] },
+      ],
+    } as PlanExpressionOperand);
+
+    expect(() =>
+      queryPlanToDrizzle({
+        queryPlan: plan,
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    ).toThrow(/null element in an `in` list/);
+  });
+
+  test('"omitted" leaves null-free comparisons untouched', () => {
+    const plan = buildPlan({
+      operator: "eq",
+      operands: [
+        { name: "request.resource.attr.aOptionalString" },
+        { value: "x" },
+      ],
+    } as PlanExpressionOperand);
+
+    const filter = ensureFilter(
+      queryPlanToDrizzle({
+        queryPlan: plan,
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    );
+
+    expect(db.select().from(resources).where(filter).toSQL().sql).toContain(
+      "="
+    );
+  });
+});

--- a/drizzle/src/index.ts
+++ b/drizzle/src/index.ts
@@ -136,9 +136,30 @@ export type Mapper =
     }
   | ((reference: string) => MapperEntry | undefined);
 
+/**
+ * How the caller represents a NULL column when building the attributes it sends to `check()`.
+ *
+ * The planner emits the same `eq(attr, null)` node either way, so the plan cannot reveal which
+ * convention is in use and the adapter has to be told.
+ *
+ * - `"explicit"` (default) — a NULL column is sent as an explicit `null` attribute. CEL compares
+ *   `null == null`, so `IS NULL` selects exactly the rows `check()` allows.
+ * - `"omitted"` — a NULL column sends no attribute at all. CEL then raises a missing-attribute
+ *   error, which Cerbos treats as a deny, so a filter that *selects* NULL rows returns rows the
+ *   PDP denies. Null comparison operands are rejected instead of translated.
+ *
+ * See https://github.com/cerbos/query-plan-adapters/issues/302.
+ */
+export type NullAttributeRepresentation = "explicit" | "omitted";
+
 export interface QueryPlanToDrizzleArgs {
   queryPlan: PlanResourcesResponse;
   mapper: Mapper;
+  /**
+   * Which NULL-column representation the caller uses when building `check()` attributes.
+   * Defaults to `"explicit"`, preserving the historical `IS NULL` translation.
+   */
+  nullAttributeRepresentation?: NullAttributeRepresentation;
 }
 
 export type QueryPlanToDrizzleResult =
@@ -1097,11 +1118,43 @@ const applyComparisonWithExpression = (
   }
 };
 
+// Translation-scoped, set at the queryPlanToDrizzle entry. Translation is synchronous, so
+// module scope is safe.
+let nullRepresentation: NullAttributeRepresentation = "explicit";
+
+/**
+ * Guards every site that would emit a NULL-selecting predicate out of a `null` comparison
+ * operand.
+ *
+ * Under the `"omitted"` representation a NULL column carries no attribute, so CEL raises a
+ * missing-attribute error and `check()` denies the row — `IS NULL` would return exactly the rows
+ * the PDP refuses. The rejection is deliberately wider than the over-granting shapes: `ne(x,
+ * null)` on its own is aligned, but negation is applied by wrapping the built condition rather
+ * than by pushing it into the leaf, so a leaf cannot tell whether an enclosing `not` will flip
+ * `IS NOT NULL` back into a NULL-selecting predicate. Rejecting every null operand is correct
+ * under any nesting; narrowing it requires negation-parity tracking.
+ */
+const assertNullOperandTranslatable = (context: string): void => {
+  if (nullRepresentation === "omitted") {
+    throw new Error(
+      `Cannot translate ${context} under nullAttributeRepresentation "omitted": a NULL column ` +
+        "sends no attribute, so Cerbos evaluates the comparison as a missing-attribute error " +
+        "(deny) while a NULL-selecting filter would return those rows. Send NULL columns as " +
+        'explicit nulls and use "explicit", or keep this shape out of the policy.'
+    );
+  }
+};
+
 const applyComparison = (
   mapping: BaseMapperEntry,
   operator: ComparisonOperator,
   value: Value
 ): SQL => {
+  if (value === null) {
+    assertNullOperandTranslatable(`\`${operator}\` against a null operand`);
+  } else if (Array.isArray(value) && value.includes(null)) {
+    assertNullOperandTranslatable("a null element in an `in` list");
+  }
   if (isRelationValue(mapping)) {
     return applyRelationComparison(mapping, operator);
   }
@@ -2439,7 +2492,9 @@ const buildFilterFromExpression = (
 export function queryPlanToDrizzle({
   queryPlan,
   mapper,
+  nullAttributeRepresentation = "explicit",
 }: QueryPlanToDrizzleArgs): QueryPlanToDrizzleResult {
+  nullRepresentation = nullAttributeRepresentation;
   switch (queryPlan.kind) {
     case PlanKind.ALWAYS_ALLOWED:
       return { kind: PlanKind.ALWAYS_ALLOWED };

--- a/elasticsearch-java/README.md
+++ b/elasticsearch-java/README.md
@@ -352,6 +352,21 @@ CEL timestamp range, rejects sub-millisecond precision, and callers must also en
 attributes sent to Cerbos and the corresponding indexed values are millisecond-exact. This adapter
 has no `date_nanos` mapping mode.
 
+### NULL attribute representation
+
+Other adapters in this repo take a NULL-representation option, because `R.attr.x == null` compiles
+to the same `eq(x, null)` plan node whether the caller sends a NULL column as an explicit `null`
+attribute (where `check()` allows the document) or omits the attribute entirely (where CEL raises a
+missing-attribute error and `check()` denies it) — and a null-selecting filter over-grants in the
+second case.
+
+**This adapter needs no such option.** Elasticsearch cannot index an explicit null distinguishably
+from a missing field, so every direction that would *select* null documents already fails closed
+(`x == null`, and `!(x != null)`), and the two that translate both lower to `exists`, which denies
+a document with no value for the field under either convention. `null-eq` and `null-eq-missing` are
+fail-closed for the same underlying reason. See
+[#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ### Conformance contract
 
 The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisions using 20 hostile seed documents and real Elasticsearch queries. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
@@ -360,6 +375,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 | --- | --- |
 | Oracle-tested | 41 reference conformance actions plus regex and timestamp probes (43 actions) |
 | Fail-closed | 81 reference actions plus ordered list indexing/`get-field` (82 actions total) |
+| Representation-independent | `null-eq-missing` — rejected like every other null-selecting comparison, so no NULL-representation option is required |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for indexed attributes instead of `has(R.attr.x)` |
 
 The oracle-tested set covers value-first comparisons, literal-safe wildcard matching, safe

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -102,6 +102,7 @@ class ElasticsearchAdversarialConformanceTest {
                                Map<String, List<AdapterOutcome>> adapterUnsupported,
                                Map<String, List<AdapterOutcome>> adapterSupportedExpected,
                                List<UnsupportedShape> expectedUnsupported,
+                               List<AdapterOutcome> nullRepresentationOmitted,
                                List<KnownDivergence> knownDivergences) {}
 
     private static SeedsFile seedsFile;
@@ -109,6 +110,7 @@ class ElasticsearchAdversarialConformanceTest {
     private static List<Seed> seeds;
     private static List<String> oracleActions;
     private static List<String> throwingActions;
+    private static List<String> nullRepresentationOmittedActions;
 
     private static GenericContainer<?> cerbos;
     private static ElasticsearchContainer elasticsearch;
@@ -122,6 +124,10 @@ class ElasticsearchAdversarialConformanceTest {
 
     static Stream<String> throwingActions() {
         return throwingActions.stream();
+    }
+
+    static Stream<String> nullRepresentationOmittedActions() {
+        return nullRepresentationOmittedActions.stream();
     }
 
     @BeforeAll
@@ -173,6 +179,12 @@ class ElasticsearchAdversarialConformanceTest {
         Set<String> divergences = actionsFile.knownDivergences().stream()
                 .filter(divergence -> divergence.adapters().contains("elasticsearch-java"))
                 .map(KnownDivergence::action).collect(java.util.stream.Collectors.toSet());
+        // Actions whose `== null` probe targets an attribute the oracle OMITS for NULL columns.
+        // Elasticsearch needs no representation option — it cannot index an explicit null
+        // distinguishably from a missing field, so every null-SELECTING direction already fails
+        // closed — but the action still has to be classified somewhere (#302).
+        nullRepresentationOmittedActions = actionsFile.nullRepresentationOmitted().stream()
+                .map(AdapterOutcome::action).sorted().toList();
 
         assertTrue(conformance.containsAll(unsupported),
                 "adapterUnsupported.elasticsearch-java contains non-conformance actions");
@@ -198,14 +210,17 @@ class ElasticsearchAdversarialConformanceTest {
         Set<String> classified = new LinkedHashSet<>();
         classified.addAll(oracleActions);
         classified.addAll(throwingActions);
+        classified.addAll(nullRepresentationOmittedActions);
         classified.addAll(divergences);
         Set<String> manifest = new LinkedHashSet<>();
         manifest.addAll(conformance);
         manifest.addAll(expected);
+        manifest.addAll(nullRepresentationOmittedActions);
         manifest.addAll(divergences);
         assertEquals(43, oracleActions.size());
         assertEquals(82, throwingActions.size());
-        assertEquals(126, classified.size());
+        assertEquals(1, nullRepresentationOmittedActions.size());
+        assertEquals(127, classified.size());
         assertEquals(manifest, classified, "every manifest action must be classified locally");
     }
 
@@ -450,6 +465,26 @@ class ElasticsearchAdversarialConformanceTest {
     void unsupportedShapesThrow(String action) {
         assertThrows(IllegalArgumentException.class, () -> adapterFilteredIds(action),
                 "unsupported action must fail during translation: " + action);
+    }
+
+    /**
+     * #302. Elasticsearch is one of two adapters that need no NULL-representation option: it
+     * cannot index an explicit null distinguishably from a missing field, so every shape that
+     * would SELECT null documents already fails closed and only the {@code exists}-shaped
+     * directions translate. {@code null-eq} (explicit null) is already in
+     * {@code adapterUnsupported} for that reason; {@code null-eq-missing} must fail the same way.
+     * If Elasticsearch ever gains a null sentinel, this stops throwing and the adapter acquires a
+     * representation dependency it must then declare.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nullRepresentationOmittedActions")
+    void nullRepresentationOmittedIsRejectedRegardless(String action) throws Exception {
+        assertEquals(List.of(), oracleAllowedIds(action),
+                "the omitted representation must deny every seed for " + action);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> adapterFilteredIds(action));
+        assertTrue(ex.getMessage().contains("explicit null value from a missing field"),
+                ex.getMessage());
     }
 
     @Test

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapterTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchQueryPlanAdapterTest.java
@@ -706,6 +706,46 @@ class ElasticsearchQueryPlanAdapterTest {
                 ((Result.Conditional) result).query());
     }
 
+    /**
+     * cerbos/query-plan-adapters#302 pins the other adapters' NULL-column representation to a
+     * caller-declared option, because {@code eq(attr, null)} means "the explicitly-null rows"
+     * under one convention and "no rows at all" under the other, and the wire node is identical.
+     *
+     * <p>This adapter needs no such option: Elasticsearch cannot index an explicit null
+     * distinguishably from a missing field, so every shape that would SELECT null documents
+     * already fails closed, and only the two {@code exists}-shaped directions translate. Those
+     * two are aligned under both conventions — a document whose field is absent is denied either
+     * way. This test is the guard on that claim: if a future change starts emitting a
+     * null-selecting query here, the adapter acquires a representation dependency and must gain
+     * the option.
+     */
+    @Test
+    void nullComparisonsAreRepresentationIndependent() {
+        Operand eqNull = expressionOperand("eq",
+                variableOperand("request.resource.attr.department"), nullValueOperand());
+        Operand neNull = expressionOperand("ne",
+                variableOperand("request.resource.attr.department"), nullValueOperand());
+
+        // Null-SELECTING directions: rejected, so neither convention can be mistranslated.
+        for (Operand rejected : List.of(eqNull, expressionOperand("not", neNull))) {
+            PlanResourcesResponse resp =
+                    buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, rejected);
+            IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                    () -> ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP));
+            assertTrue(error.getMessage().contains("explicit null value from a missing field"));
+        }
+
+        // Presence-SELECTING directions: both translate to `exists`, which denies a document
+        // with no value for the field under either convention.
+        for (Operand accepted : List.of(neNull, expressionOperand("not", eqNull))) {
+            PlanResourcesResponse resp =
+                    buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, accepted);
+            Result result = ElasticsearchQueryPlanAdapter.toElasticsearchQuery(resp, FIELD_MAP);
+            assertEquals(Map.of("exists", Map.of("field", "department")),
+                    ((Result.Conditional) result).query());
+        }
+    }
+
     @Test
     void hasIntersectionProducesTermsQuery() {
         Operand condition = expressionOperand("hasIntersection",

--- a/langchain-chromadb/README.md
+++ b/langchain-chromadb/README.md
@@ -76,6 +76,20 @@ filter, which is also cheaper for ChromaDB to evaluate than an `or` chain, and
 needs no `required` assertion. All three spellings are pinned across the
 10-element boundary in the adapter's test suite.
 
+## NULL attribute representation
+
+Other adapters in this repo take a `nullAttributeRepresentation` option, because `R.attr.x == null`
+compiles to the same `eq(x, null)` plan node whether the caller sends a NULL column as an explicit
+`null` attribute (where `check()` allows the row) or omits the attribute entirely (where CEL raises
+a missing-attribute error and `check()` denies it) — and an `IS NULL`-shaped filter over-grants in
+the second case.
+
+**This adapter needs no such option.** Chroma metadata holds only finite numbers, strings and
+booleans, so it cannot store an explicit null distinguishably from an absent key: every null
+comparison operand is rejected outright, under either convention. `null-eq`, `null-ne`,
+`vf-null-ne`, `null-not-eq`, the `in-null-elem-*` family and `null-eq-missing` are all fail-closed
+for that reason. See [#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ## Conformance contract
 
 The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` decisions using 20 hostile seed documents and real ChromaDB metadata queries. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
@@ -84,6 +98,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 | --- | --- |
 | Oracle-tested | 15 reference actions: directional and inequality comparisons, single/empty membership, Unicode and empty strings, negative numbers, n-ary/double/triple negation, membership on an optional resource field, mapped nested-field equality, and case-sensitive equality |
 | Fail-closed | 107 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (110 actions total) |
+| Representation-independent | `null-eq-missing` — rejected like every other null comparison operand, so no `nullAttributeRepresentation` option is required |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 Chroma metadata filters are limited to flat scalar comparisons and membership. Nested collections, field-to-field and arithmetic expressions, string helpers, hierarchy/timestamp operations, ternaries, nullable inequality, and other shapes that cannot be represented faithfully throw before a filter is returned.

--- a/langchain-chromadb/src/adversarial.test.ts
+++ b/langchain-chromadb/src/adversarial.test.ts
@@ -73,6 +73,7 @@ interface ActionsFile {
   adapterUnsupported: Record<string, UnsupportedAction[]>;
   adapterSupportedExpected: Record<string, UnsupportedAction[]>;
   expectedUnsupported: UnsupportedShape[];
+  nullRepresentationOmitted: UnsupportedAction[];
   knownDivergences: KnownDivergence[];
 }
 
@@ -248,6 +249,15 @@ function parseActionsFile(value: unknown): ActionsFile {
       file["expectedUnsupported"],
       "expectedUnsupported",
     ).map(parseUnsupportedShape),
+    // This parser rebuilds the manifest field by field, so a corpus group it does not name is
+    // silently dropped — and a dropped group makes its actions vanish from every count and every
+    // test.each, passing vacuously. Parse each group explicitly.
+    nullRepresentationOmitted: requireArray(
+      file["nullRepresentationOmitted"],
+      "nullRepresentationOmitted",
+    ).map((entry, index) =>
+      parseUnsupportedAction(entry, `nullRepresentationOmitted[${index}]`),
+    ),
     knownDivergences: requireArray(
       file["knownDivergences"],
       "knownDivergences",
@@ -293,9 +303,14 @@ const THROWING_ACTIONS: UnsupportedAction[] = [
       reason: shape,
     })),
 ];
+// Actions whose `== null` probe targets an attribute the oracle OMITS for NULL columns. Chroma
+// needs no representation option: it cannot index an explicit null distinguishably from a missing
+// key, so every null comparison operand is already rejected outright (#302).
+const NULL_REPRESENTATION_OMITTED = actionsFile.nullRepresentationOmitted;
 const MANIFEST_ACTIONS = new Set([
   ...actionsFile.conformance,
   ...actionsFile.expectedUnsupported.map(({ action }) => action),
+  ...NULL_REPRESENTATION_OMITTED.map(({ action }) => action),
   ...CHROMA_DIVERGENCES,
 ]);
 
@@ -563,19 +578,23 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
 }
 
 describe("adversarial conformance corpus", () => {
-  test("manifest assigns all 126 policy actions exactly one Chroma outcome", () => {
+  test("manifest assigns all 127 policy actions exactly one Chroma outcome", () => {
     const oracle = new Set(CHROMA_SUPPORTED_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map(({ action }) => action));
+    const nullOmitted = new Set(
+      NULL_REPRESENTATION_OMITTED.map(({ action }) => action),
+    );
     const misclassified = [...MANIFEST_ACTIONS].filter((action) => {
       const classificationCount = [
         oracle.has(action),
         throwing.has(action),
+        nullOmitted.has(action),
         CHROMA_DIVERGENCES.has(action),
       ].filter(Boolean).length;
       return classificationCount !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(126);
+    expect(MANIFEST_ACTIONS.size).toBe(127);
     expect(CHROMA_SUPPORTED_ACTIONS).toHaveLength(15);
     expect(oracle.size).toBe(CHROMA_SUPPORTED_ACTIONS.length);
     expect(CHROMA_UNSUPPORTED).toHaveLength(107);
@@ -605,6 +624,27 @@ describe("adversarial conformance corpus", () => {
           fieldNameMapper: FIELD_NAME_MAPPER,
         }),
       ).toThrow();
+    },
+  );
+
+  // #302. Chroma is one of two adapters that need no `nullAttributeRepresentation` option: its
+  // metadata filters accept only finite numbers, strings and booleans, so a null comparison
+  // operand is rejected before the representation could matter. `null-eq` (explicit null) is
+  // already in `adapterUnsupported` for the same reason, and `null-eq-missing` must fail the same
+  // way. This test guards that equivalence: if Chroma ever gains a null sentinel, the shape stops
+  // throwing here and the adapter acquires a representation dependency it must then declare.
+  test.each(NULL_REPRESENTATION_OMITTED)(
+    "$action is rejected regardless of representation ($reason)",
+    async ({ action }) => {
+      expect(await oracleAllowedIds(action)).toEqual([]);
+
+      const queryPlan = await planFor(action);
+      expect(() =>
+        queryPlanToChromaDB({
+          queryPlan,
+          fieldNameMapper: FIELD_NAME_MAPPER,
+        }),
+      ).toThrow(/finite number, string, or boolean literal/);
     },
   );
 

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -38,6 +38,32 @@ Timestamp values must fall in CEL's UTC instant range (`0001-01-01T00:00:00Z` th
 
 `matches` supports literals, `.`, the `*`, `+`, and `?` quantifiers, leading `^`, terminal `$`, and escaped regex metacharacters. Other constructs fail closed. A terminal `$` is translated to PCRE2's absolute end-of-text anchor so MongoDB cannot match before a final newline, preserving RE2 semantics.
 
+## NULL attribute representation
+
+`R.attr.x == null` compiles to the same `eq(x, null)` plan node however your application represents
+a NULL field in the attributes it sends to `check()`, so the adapter cannot infer the convention
+and has to be told which one you use.
+
+| attributes you send for a NULL field | `check()` on that document | null-matching filter |
+| --- | --- | --- |
+| `{"x": null}` — explicit null | allow | selects it — aligned |
+| `{}` — attribute omitted | **deny** (CEL missing-attribute error) | selects it — **over-grants** |
+
+``nullAttributeRepresentation`` defaults to ``"explicit"``, preserving the historical translation. If your application
+omits attributes for NULL fields, set it to ``"omitted"``: the adapter then rejects every null
+comparison operand instead of emitting a filter that returns documents the PDP denies.
+
+```ts
+queryPlanToMongoose({ queryPlan, mapper, nullAttributeRepresentation: "omitted" });
+```
+
+The rejection is deliberately wider than the shapes that actually over-grant — `x != null` and
+`!(x == null)` are aligned under both conventions — because negation is applied by wrapping the
+built filter rather than pushing it into the leaf, so a leaf cannot tell whether an enclosing
+`not` will flip a not-null predicate back into a null-selecting one. Rejecting every null operand
+is correct under any nesting. See
+[#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ## Conformance contract
 
 The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` decisions using 20 hostile seed documents and real MongoDB 7 and 8 queries. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
@@ -46,6 +72,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 | --- | --- |
 | Oracle-tested | 91 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (94 actions) |
 | Fail-closed | 31 reference actions |
+| Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`. Under the default it already returns the empty set the PDP demands, because `nullable: true` on a mapper entry declares per-attribute that a stored null is a missing Cerbos attribute; the global option is the backstop for mappings that do not declare it |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 The fail-closed set covers exact-one cardinality, aggregation expressions or outer-document references inside `$elemMatch`, nested collection counts, correlated variable-in-variable membership, unsafe division/non-finite arithmetic, and negated nullable collection predicates that cannot preserve CEL's three-valued error semantics. These plans throw instead of silently degrading to a weaker MongoDB filter.

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -53,6 +53,7 @@ interface ActionsFile {
   adapterUnsupported: Record<string, AdapterEntry[]>;
   adapterSupportedExpected: Record<string, AdapterEntry[]>;
   expectedUnsupported: ExpectedUnsupportedEntry[];
+  nullRepresentationOmitted: AdapterEntry[];
   knownDivergences: KnownDivergence[];
 }
 
@@ -218,7 +219,12 @@ function parseActionsFile(value: unknown): ActionsFile {
   const record = expectRecord(value, "actions.json");
   const expected = record["expectedUnsupported"];
   const divergences = record["knownDivergences"];
-  if (!Array.isArray(expected) || !Array.isArray(divergences)) {
+  const nullOmitted = record["nullRepresentationOmitted"];
+  if (
+    !Array.isArray(expected) ||
+    !Array.isArray(divergences) ||
+    !Array.isArray(nullOmitted)
+  ) {
     throw new Error("actions.json classifications must be arrays");
   }
   return {
@@ -241,6 +247,22 @@ function parseActionsFile(value: unknown): ActionsFile {
         shape: expectString(
           parsed["shape"],
           `expectedUnsupported[${index}].shape`
+        ),
+      };
+    }),
+    // This parser rebuilds the manifest field by field, so a corpus group it does not name is
+    // silently dropped — and a dropped group makes its actions vanish from every count and
+    // every test.each, passing vacuously. Parse each group explicitly.
+    nullRepresentationOmitted: nullOmitted.map((entry, index) => {
+      const parsed = expectRecord(entry, `nullRepresentationOmitted[${index}]`);
+      return {
+        action: expectString(
+          parsed["action"],
+          `nullRepresentationOmitted[${index}].action`
+        ),
+        reason: expectString(
+          parsed["reason"],
+          `nullRepresentationOmitted[${index}].reason`
         ),
       };
     }),
@@ -293,9 +315,14 @@ const THROWING_ACTIONS = [
     .filter((entry) => !supportedExpectedActions.has(entry.action))
     .map((entry) => ({ action: entry.action, reason: entry.shape })),
 ].sort((left, right) => left.action.localeCompare(right.action));
+// Actions whose `== null` probe targets an attribute the oracle OMITS for NULL columns. They
+// carry no oracle comparison: under the omitted representation check() denies every document, so
+// the adapter must reject the shape rather than emit a filter (#302).
+const NULL_REPRESENTATION_OMITTED = actionsFile.nullRepresentationOmitted;
 const MANIFEST_ACTIONS = new Set([
   ...actionsFile.conformance,
   ...actionsFile.expectedUnsupported.map((entry) => entry.action),
+  ...NULL_REPRESENTATION_OMITTED.map((entry) => entry.action),
   ...actionsFile.knownDivergences.map((entry) => entry.action),
 ]);
 
@@ -673,13 +700,20 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
     .sort();
 }
 
-async function adapterFilteredIds(action: string): Promise<string[]> {
+async function adapterFilteredIds(
+  action: string,
+  nullAttributeRepresentation: "explicit" | "omitted" = "explicit"
+): Promise<string[]> {
   const queryPlan = await cerbos.planResources({
     principal: seedsFile.principal,
     resource: { kind: seedsFile.resourceKind },
     action,
   });
-  const result = queryPlanToMongoose({ queryPlan, mapper: MAPPER });
+  const result = queryPlanToMongoose({
+    queryPlan,
+    mapper: MAPPER,
+    nullAttributeRepresentation,
+  });
   if (result.kind === PlanKind.ALWAYS_DENIED) {
     return [];
   }
@@ -692,20 +726,36 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
   return rows.map((row) => row.resourceId).sort();
 }
 
+/** Whether any operand anywhere in the plan is a literal null, or a list containing one. */
+function planCarriesNullLiteral(operand: unknown): boolean {
+  if (typeof operand !== "object" || operand === null) return false;
+  const node = operand as Record<string, unknown>;
+  if ("value" in node) {
+    const value = node["value"];
+    return value === null || (Array.isArray(value) && value.includes(null));
+  }
+  const operands = node["operands"];
+  return Array.isArray(operands) && operands.some(planCarriesNullLiteral);
+}
+
 describe("adversarial conformance corpus", () => {
-  test("manifest assigns all 120 actions exactly one Mongoose outcome", () => {
+  test("manifest assigns all 127 actions exactly one Mongoose outcome", () => {
     const oracle = new Set(ORACLE_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map((entry) => entry.action));
+    const nullOmitted = new Set(
+      NULL_REPRESENTATION_OMITTED.map((entry) => entry.action)
+    );
     const misclassified = [...MANIFEST_ACTIONS].filter((action) => {
       const count = [
         oracle.has(action),
         throwing.has(action),
+        nullOmitted.has(action),
         divergenceActions.has(action),
       ].filter(Boolean).length;
       return count !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(126);
+    expect(MANIFEST_ACTIONS.size).toBe(127);
     expect(unsupportedEntries).toHaveLength(31);
     expect(supportedExpectedEntries).toHaveLength(3);
     expect(ORACLE_ACTIONS).toHaveLength(94);
@@ -732,6 +782,70 @@ describe("adversarial conformance corpus", () => {
       await expect(adapterFilteredIds(action)).rejects.toThrow();
     }
   );
+
+  // #302. `null-eq-missing` probes `aOptionalString == null`, and `aOptionalString` follows the
+  // corpus default: a NULL column sends NO attribute, so check() denies every document.
+  //
+  // Mongoose is the one adapter that already expresses this PER ATTRIBUTE: `nullable: true` on a
+  // mapper entry declares "a stored null is a missing Cerbos attribute", and the resulting
+  // `$exists`/`$ne: null` guards make `eq(field, null)` contradictory — the empty set the oracle
+  // demands. `owner` maps to the SAME column without `nullable`, so `null-eq` still returns its
+  // five explicit-null documents. Both are asserted here: the pair is what proves the mapper
+  // flag, not the corpus, is doing the discriminating.
+  test.each(NULL_REPRESENTATION_OMITTED)(
+    "$action already aligns via the nullable mapper flag and is rejected under omitted ($reason)",
+    async ({ action }) => {
+      expect(await oracleAllowedIds(action)).toEqual([]);
+      expect(await adapterFilteredIds(action, "explicit")).toEqual([]);
+
+      // The same column WITHOUT `nullable` keeps the explicit-null translation, so the empty
+      // result above is the mapper flag talking, not a filter that matches nothing everywhere.
+      expect(await adapterFilteredIds("null-eq", "explicit")).toEqual(
+        await oracleAllowedIds("null-eq")
+      );
+      expect((await oracleAllowedIds("null-eq")).length).toBeGreaterThan(0);
+
+      // The global switch is still the fail-closed backstop for callers who omit attributes
+      // without declaring `nullable` on every affected mapper entry.
+      await expect(adapterFilteredIds(action, "omitted")).rejects.toThrow(
+        /missing-attribute error/
+      );
+    }
+  );
+
+  // #302 completeness guard. The rejection must key off the null OPERAND, not off a list of
+  // operators: `hasIntersection(tagNames, ["public", null])` carries one in its value list, and
+  // an allowlist of eq/ne/in silently misses it. Enumerating the corpus rather than naming
+  // shapes means a newly added action carrying a null constant is covered automatically.
+  test("every corpus action carrying a null literal is rejected under omitted", async () => {
+    const nullCarrying: string[] = [];
+    for (const action of [...MANIFEST_ACTIONS].sort()) {
+      const queryPlan = await cerbos.planResources({
+        principal: seedsFile.principal,
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      if (
+        queryPlan.kind === PlanKind.CONDITIONAL &&
+        planCarriesNullLiteral(queryPlan.condition)
+      ) {
+        nullCarrying.push(action);
+      }
+    }
+
+    // Guard the guard: if the walk stopped finding null operands the loop below is vacuous.
+    expect(nullCarrying).toContain("null-eq-missing");
+    expect(nullCarrying).toContain("in-null-elem-hasint");
+
+    const notRejected: string[] = [];
+    for (const action of nullCarrying) {
+      try {
+        await adapterFilteredIds(action, "omitted");
+        notRejected.push(action);
+      } catch { /* expected */ }
+    }
+    expect(notRejected).toEqual([]);
+  });
 
   test("pins the upstream has() planner over-grant", async () => {
     const action = "p-has";

--- a/mongoose/src/index.test.ts
+++ b/mongoose/src/index.test.ts
@@ -245,6 +245,84 @@ const checkedConversion = (
   },
 });
 
+// cerbos/query-plan-adapters#302. Both NULL-field conventions produce the identical
+// `eq(attr, null)` wire node, so the adapter cannot infer which one the caller uses. Under
+// "omitted" a NULL field carries no attribute at all, CEL raises a missing-attribute error, and
+// check() denies every document — a null-matching filter would return precisely the documents
+// the PDP refuses.
+describe("nullAttributeRepresentation", () => {
+  const mapper: Mapper = {
+    "request.resource.attr.aOptionalString": { field: "aOptionalString" },
+  };
+
+  const planFor = (operator: string, value: unknown): PlanResourcesResponse =>
+    ({
+      kind: PlanKind.CONDITIONAL,
+      condition: new PlanExpression(operator, [
+        new PlanExpressionVariable("request.resource.attr.aOptionalString"),
+        new PlanExpressionValue(value as never),
+      ]),
+    }) as PlanResourcesResponse;
+
+  test('"explicit" is the default and keeps the null-matching translation', () => {
+    const queryPlan = planFor("eq", null);
+
+    expect(queryPlanToMongoose({ queryPlan, mapper })).toStrictEqual(
+      queryPlanToMongoose({
+        queryPlan,
+        mapper,
+        nullAttributeRepresentation: "explicit",
+      })
+    );
+  });
+
+  test('"omitted" rejects eq against a null operand', () => {
+    expect(() =>
+      queryPlanToMongoose({
+        queryPlan: planFor("eq", null),
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    ).toThrow(/missing-attribute error/);
+  });
+
+  // Conservatively rejected too: `ne` alone is aligned under "omitted", but negation is applied
+  // by wrapping the built filter, so a leaf cannot see whether an enclosing `not` will flip a
+  // not-null predicate back into a null-selecting one.
+  test('"omitted" rejects ne against a null operand', () => {
+    expect(() =>
+      queryPlanToMongoose({
+        queryPlan: planFor("ne", null),
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    ).toThrow(/missing-attribute error/);
+  });
+
+  test('"omitted" rejects a null element in an in-list', () => {
+    expect(() =>
+      queryPlanToMongoose({
+        queryPlan: planFor("in", ["x", null]),
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    ).toThrow(/missing-attribute error/);
+  });
+
+  test('"omitted" leaves null-free comparisons untouched', () => {
+    expect(
+      queryPlanToMongoose({
+        queryPlan: planFor("eq", "x"),
+        mapper,
+        nullAttributeRepresentation: "omitted",
+      })
+    ).toStrictEqual({
+      kind: PlanKind.CONDITIONAL,
+      filters: { aOptionalString: { $eq: "x" } },
+    });
+  });
+});
+
 describe("Adapter Unit Behavior", () => {
   test("maps single-object relations without elemMatch", async () => {
     const queryPlan = {

--- a/mongoose/src/index.ts
+++ b/mongoose/src/index.ts
@@ -33,9 +33,30 @@ export type Mapper =
     }
   | ((key: string) => MapperConfig);
 
+/**
+ * How the caller represents a NULL field when building the attributes it sends to `check()`.
+ *
+ * The planner emits the same `eq(attr, null)` node either way, so the plan cannot reveal which
+ * convention is in use and the adapter has to be told.
+ *
+ * - `"explicit"` (default) — a NULL field is sent as an explicit `null` attribute. CEL compares
+ *   `null == null`, so matching null selects exactly the documents `check()` allows.
+ * - `"omitted"` — a NULL field sends no attribute at all. CEL then raises a missing-attribute
+ *   error, which Cerbos treats as a deny, so a filter that *selects* null documents returns
+ *   documents the PDP denies. Null comparison operands are rejected instead of translated.
+ *
+ * See https://github.com/cerbos/query-plan-adapters/issues/302.
+ */
+export type NullAttributeRepresentation = "explicit" | "omitted";
+
 export interface QueryPlanToMongooseArgs {
   queryPlan: PlanResourcesResponse;
   mapper?: Mapper;
+  /**
+   * Which NULL-field representation the caller uses when building `check()` attributes.
+   * Defaults to `"explicit"`, preserving the historical null-matching translation.
+   */
+  nullAttributeRepresentation?: NullAttributeRepresentation;
 }
 
 export interface QueryPlanToMongooseResult {
@@ -172,7 +193,9 @@ const isRfc3339Timestamp = (value: string): boolean => {
 export function queryPlanToMongoose({
   queryPlan,
   mapper = {},
+  nullAttributeRepresentation = "explicit",
 }: QueryPlanToMongooseArgs): QueryPlanToMongooseResult {
+  nullRepresentation = nullAttributeRepresentation;
   switch (queryPlan.kind) {
     case PlanKind.ALWAYS_ALLOWED:
       return {
@@ -364,6 +387,42 @@ const buildNestedObject = (path: string[], value: any) =>
 
 const buildFieldFilter = (path: string[], value: any) =>
   path.length === 0 ? value : buildNestedObject(path, value);
+
+// Translation-scoped, set at the queryPlanToMongoose entry. Translation is synchronous, so
+// module scope is safe.
+let nullRepresentation: NullAttributeRepresentation = "explicit";
+
+/**
+ * Guards every site that would emit a null-selecting predicate out of a `null` comparison
+ * operand.
+ *
+ * Under the `"omitted"` representation a NULL field carries no attribute, so CEL raises a
+ * missing-attribute error and `check()` denies the document; matching null would return exactly
+ * the documents the PDP refuses. The rejection is deliberately wider than the over-granting
+ * shapes: `ne(x, null)` on its own is aligned, but negation is applied by wrapping the built
+ * filter rather than by pushing it into the leaf, so a leaf cannot tell whether an enclosing
+ * `not` will flip a not-null predicate back into a null-selecting one. Rejecting every null
+ * operand is correct under any nesting; narrowing it requires negation-parity tracking.
+ */
+const assertNullOperandTranslatable = (context: string): void => {
+  if (nullRepresentation === "omitted") {
+    throw new Error(
+      `Cannot translate ${context} under nullAttributeRepresentation "omitted": a NULL field ` +
+        "sends no attribute, so Cerbos evaluates the comparison as a missing-attribute error " +
+        "(deny) while a null-selecting filter would return those documents. Send NULL fields " +
+        'as explicit nulls and use "explicit", or keep this shape out of the policy.'
+    );
+  }
+};
+
+/**
+ * Whether a comparison operand carries a plan-level `null` — directly, or as an element of an
+ * `in` list. This is the guard's own predicate rather than a reuse of `requireExists`: the two
+ * happen to coincide today, but `requireExists` means "the field must be present", and a future
+ * caller setting it for that reason alone must not trip the null rejection.
+ */
+const carriesNullOperand = (value: unknown): boolean =>
+  value === null || (Array.isArray(value) && value.includes(null));
 
 const buildGuardedFieldFilter = (
   path: string[],
@@ -1418,7 +1477,12 @@ const buildMongooseFilterFromCerbosExpression = (
         ),
       };
       const nullable = isNullableReference(variableOperand.name, mapper);
-      const requireExists = valueOperand.value === null;
+      const requireExists = carriesNullOperand(valueOperand.value);
+      if (requireExists) {
+        assertNullOperandTranslatable(
+          `\`${effectiveOperator}\` against a null operand`
+        );
+      }
       if (relation?.type === "many") {
         return {
           [relation.name]: {
@@ -1457,7 +1521,10 @@ const buildMongooseFilterFromCerbosExpression = (
           ),
         };
         const nullable = isNullableReference(leftOperand.name, mapper);
-        const requireExists = rightOperand.value.includes(null);
+        const requireExists = carriesNullOperand(rightOperand.value);
+        if (requireExists) {
+          assertNullOperandTranslatable("a null element in an `in` list");
+        }
         if (relation?.type === "many") {
           return {
             [relation.name]: {
@@ -1491,7 +1558,12 @@ const buildMongooseFilterFromCerbosExpression = (
           ),
         };
         const nullable = isNullableReference(rightOperand.name, mapper);
-        const requireExists = leftOperand.value === null;
+        const requireExists = carriesNullOperand(leftOperand.value);
+        if (requireExists) {
+          assertNullOperandTranslatable(
+            "a null needle in a mapped-collection `in`"
+          );
+        }
         if (relation?.type === "many") {
           return {
             [relation.name]: {
@@ -1643,6 +1715,14 @@ const buildMongooseFilterFromCerbosExpression = (
         1,
         "hasIntersection requires a value operand"
       );
+
+      // A null element in the intersection list lowers to a null-matching disjunct exactly as
+      // it does for `in`, so it is subject to the same representation guard.
+      if (isValue(rightOperand) && carriesNullOperand(rightOperand.value)) {
+        assertNullOperandTranslatable(
+          "a null element in a `hasIntersection` list"
+        );
+      }
 
       // Handle map expressions specially for hasIntersection
       if (isExpression(leftOperand) && leftOperand.operator === "map") {

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -102,6 +102,32 @@ The adapter cannot override a column's collation in a Prisma `where` filter. See
 [case-sensitivity documentation](https://docs.prisma.io/docs/orm/v6/prisma-client/queries/case-sensitivity)
 for provider-specific details.
 
+### NULL attribute representation
+
+`R.attr.x == null` compiles to the same `eq(x, null)` plan node however your application represents
+a NULL column in the attributes it sends to `check()`, so the adapter cannot infer the convention
+and has to be told which one you use.
+
+| attributes you send for a NULL column | `check()` on that row | `IS NULL` filter |
+| --- | --- | --- |
+| `{"x": null}` — explicit null | allow | selects it — aligned |
+| `{}` — attribute omitted | **deny** (CEL missing-attribute error) | selects it — **over-grants** |
+
+`nullAttributeRepresentation` defaults to `"explicit"`, preserving the historical `IS NULL`
+translation. If your application omits attributes for NULL columns, set it to `"omitted"`: the
+adapter then rejects every null comparison operand instead of emitting a filter that returns rows
+the PDP denies.
+
+```ts
+queryPlanToPrisma({ queryPlan, mapper, nullAttributeRepresentation: "omitted" });
+```
+
+The rejection is deliberately wider than the shapes that actually over-grant — `x != null` and
+`!(x == null)` are aligned under both conventions — because Prisma applies negation by wrapping
+(`{ NOT: ... }`) rather than pushing it into the leaf, so a leaf cannot tell whether an enclosing
+`not` will flip `IS NOT NULL` back into a NULL-selecting predicate. Rejecting every null operand is
+correct under any nesting. See [#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ### Conformance contract
 
 The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` decisions using 20 hostile seed rows and both Prisma 6 and 7. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
@@ -110,6 +136,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 | --- | --- |
 | Oracle-tested | 89 reference actions |
 | Fail-closed | 33 reference actions plus the 3 reference-unsupported shapes (36 actions total) |
+| Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 The fail-closed set consists of literal `LIKE` cases Prisma cannot escape safely, cross-model field references, arbitrary relation counts and string lengths, `exists_one`, unsolved column arithmetic, sub-millisecond `now()` thresholds, and the reference probes for regex, ordered indexing, and `timestamp()` over a string field. Supported timestamp plans require a mapper entry with `valueType: "dateTime"` and a strict, millisecond-exact RFC 3339 literal in CEL's supported instant range. These shapes throw instead of producing a broader authorization filter.

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -66,6 +66,7 @@ interface ActionsFile {
   adapterUnsupported?: Record<string, AdapterUnsupportedEntry[]>;
   adapterSupportedExpected?: Record<string, AdapterUnsupportedEntry[]>;
   expectedUnsupported: UnsupportedShape[];
+  nullRepresentationOmitted: AdapterUnsupportedEntry[];
   knownDivergences?: KnownDivergence[];
 }
 
@@ -133,9 +134,16 @@ const PRISMA_KNOWN_DIVERGENCES = new Set(
 const EXPECTED_UNSUPPORTED_ACTIONS = new Set(
   actionsFile.expectedUnsupported.map((entry) => entry.action)
 );
+// Actions whose `== null` probe targets an attribute the oracle OMITS for NULL columns. They
+// carry no oracle comparison: under the omitted representation check() denies every row, so the
+// adapter must reject the shape rather than emit a filter (#302).
+const NULL_REPRESENTATION_OMITTED = actionsFile.nullRepresentationOmitted.map(
+  (entry): ThrowingAction => [entry.action, entry.reason]
+);
 const MANIFEST_ACTIONS = new Set([
   ...actionsFile.conformance,
   ...EXPECTED_UNSUPPORTED_ACTIONS,
+  ...NULL_REPRESENTATION_OMITTED.map(([action]) => action),
   ...PRISMA_KNOWN_DIVERGENCES,
 ]);
 
@@ -466,7 +474,10 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
 
 // -- adapter execution through the public queryPlanToPrisma path --
 
-async function adapterFilteredIds(action: string): Promise<string[]> {
+async function adapterFilteredIds(
+  action: string,
+  nullAttributeRepresentation: "explicit" | "omitted" = "explicit"
+): Promise<string[]> {
   const queryPlan = await cerbos.planResources({
     principal: principal(),
     resource: { kind: seedsFile.resourceKind },
@@ -476,6 +487,7 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
     queryPlan,
     mapper: MAPPER,
     model: "AdversarialResource",
+    nullAttributeRepresentation,
   });
   if (result.kind === PlanKind.ALWAYS_DENIED) {
     return [];
@@ -486,6 +498,18 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
     select: { id: true },
   });
   return rows.map((r) => r.id).sort();
+}
+
+/** Whether any operand anywhere in the plan is a literal null, or a list containing one. */
+function planCarriesNullLiteral(operand: unknown): boolean {
+  if (typeof operand !== "object" || operand === null) return false;
+  const node = operand as Record<string, unknown>;
+  if ("value" in node) {
+    const value = node["value"];
+    return value === null || (Array.isArray(value) && value.includes(null));
+  }
+  const operands = node["operands"];
+  return Array.isArray(operands) && operands.some(planCarriesNullLiteral);
 }
 
 describe("adversarial conformance corpus", () => {
@@ -504,6 +528,7 @@ describe("adversarial conformance corpus", () => {
             springDataMessage: "unsupported",
           },
         ],
+        nullRepresentationOmitted: [],
       },
       "prisma"
     );
@@ -514,19 +539,23 @@ describe("adversarial conformance corpus", () => {
     ).not.toContain(promotedAction);
   });
 
-  test("manifest assigns all 118 policy actions exactly one Prisma outcome", () => {
+  test("manifest assigns all 127 policy actions exactly one Prisma outcome", () => {
     const oracle = new Set(ORACLE_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map(([action]) => action));
+    const nullOmitted = new Set(
+      NULL_REPRESENTATION_OMITTED.map(([action]) => action)
+    );
     const misclassified = [...MANIFEST_ACTIONS].filter((action) => {
       const classificationCount = [
         oracle.has(action),
         throwing.has(action),
+        nullOmitted.has(action),
         PRISMA_KNOWN_DIVERGENCES.has(action),
       ].filter(Boolean).length;
       return classificationCount !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(126);
+    expect(MANIFEST_ACTIONS.size).toBe(127);
     expect(misclassified).toEqual([]);
     expect(
       [...PRISMA_SUPPORTED_EXPECTED].filter(
@@ -555,6 +584,62 @@ describe("adversarial conformance corpus", () => {
       await expect(adapterFilteredIds(action)).rejects.toThrow();
     }
   );
+
+  // #302. `null-eq-missing` probes `aOptionalString == null`, and `aOptionalString` follows the
+  // corpus default: a NULL column sends NO attribute. Both halves are asserted because the
+  // rejection alone would pass vacuously if the adapter threw for an unrelated reason — the
+  // over-grant under the default representation is what makes the rejection necessary.
+  test.each(NULL_REPRESENTATION_OMITTED)(
+    "%s over-grants under the explicit representation and is rejected under omitted (%s)",
+    async (action) => {
+      const oracle = await oracleAllowedIds(action);
+      expect(oracle).toEqual([]);
+
+      // The default translation emits IS NULL and returns exactly the rows the PDP denies.
+      const overGranted = await adapterFilteredIds(action, "explicit");
+      expect(overGranted.length).toBeGreaterThan(0);
+
+      await expect(adapterFilteredIds(action, "omitted")).rejects.toThrow(
+        /missing-attribute error/
+      );
+    }
+  );
+
+  // #302 completeness guard. The rejection must key off the null OPERAND, not off a list of
+  // operators: `hasIntersection(tagNames, ["public", null])` carries one in its value list, and
+  // an allowlist of eq/ne/in silently misses it. Enumerating the corpus rather than naming
+  // shapes means a newly added action carrying a null constant is covered automatically.
+  test("every corpus action carrying a null literal is rejected under omitted", async () => {
+    const nullCarrying: string[] = [];
+    for (const action of [...MANIFEST_ACTIONS].sort()) {
+      const queryPlan = await cerbos.planResources({
+        principal: principal(),
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      if (
+        queryPlan.kind === PlanKind.CONDITIONAL &&
+        planCarriesNullLiteral(queryPlan.condition)
+      ) {
+        nullCarrying.push(action);
+      }
+    }
+
+    // Guard the guard: if the walk stopped finding null operands the loop below is vacuous.
+    expect(nullCarrying).toContain("null-eq-missing");
+    expect(nullCarrying).toContain("in-null-elem-hasint");
+
+    const notRejected: string[] = [];
+    for (const action of nullCarrying) {
+      try {
+        await adapterFilteredIds(action, "omitted");
+        notRejected.push(action);
+      } catch {
+        // expected: the shape must be rejected under this representation
+      }
+    }
+    expect(notRejected).toEqual([]);
+  });
 
   test("pins the upstream has() planner over-grant", async () => {
     const action = "p-has";

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -1516,6 +1516,106 @@ describe("Field Operations", () => {
           .sort()
       );
     });
+
+    // cerbos/query-plan-adapters#302. Both conventions produce the identical `eq(attr, null)`
+    // wire node, so the adapter cannot infer which one the caller uses. Under "omitted" a NULL
+    // column carries no attribute at all, CEL raises a missing-attribute error, and check()
+    // denies every row — an IS NULL filter would return precisely the rows the PDP refuses.
+    describe("nullAttributeRepresentation", () => {
+      const mapper = {
+        "request.resource.attr.aOptionalString": { field: "aOptionalString" },
+      };
+
+      async function planFor(action: string) {
+        return cerbos.planResources({
+          principal: { id: "user1", roles: ["USER"] },
+          resource: { kind: "resource" },
+          action,
+        });
+      }
+
+      test('"explicit" is the default and keeps the IS NULL translation', async () => {
+        const queryPlan = await planFor("is-not-set");
+
+        expect(queryPlanToPrisma({ queryPlan, mapper })).toStrictEqual(
+          queryPlanToPrisma({
+            queryPlan,
+            mapper,
+            nullAttributeRepresentation: "explicit",
+          })
+        );
+      });
+
+      test('"omitted" rejects eq against a null operand', async () => {
+        const queryPlan = await planFor("is-not-set");
+
+        expect(() =>
+          queryPlanToPrisma({
+            queryPlan,
+            mapper,
+            nullAttributeRepresentation: "omitted",
+          })
+        ).toThrow(/missing-attribute error/);
+      });
+
+      // Conservatively rejected too: `ne` alone is aligned under "omitted", but Prisma negates
+      // by wrapping (`{ NOT: ... }`), so a leaf cannot see whether an enclosing `not` will flip
+      // IS NOT NULL back into a NULL-selecting predicate.
+      test('"omitted" rejects ne against a null operand', async () => {
+        const queryPlan = await planFor("is-set");
+
+        expect(() =>
+          queryPlanToPrisma({
+            queryPlan,
+            mapper,
+            nullAttributeRepresentation: "omitted",
+          })
+        ).toThrow(/missing-attribute error/);
+      });
+
+      test('"omitted" rejects a null element in an in-list', () => {
+        expect(() =>
+          queryPlanToPrisma({
+            queryPlan: {
+              kind: PlanKind.CONDITIONAL,
+              condition: {
+                operator: "in",
+                operands: [
+                  { name: "request.resource.attr.aOptionalString" },
+                  { value: ["x", null] },
+                ],
+              },
+            } as PlanResourcesConditionalResponse,
+            mapper,
+            nullAttributeRepresentation: "omitted",
+          })
+        ).toThrow(/null element in an `in` list/);
+      });
+
+      test('"omitted" leaves null-free comparisons untouched', () => {
+        const queryPlan = {
+          kind: PlanKind.CONDITIONAL,
+          condition: {
+            operator: "eq",
+            operands: [
+              { name: "request.resource.attr.aOptionalString" },
+              { value: "x" },
+            ],
+          },
+        } as PlanResourcesConditionalResponse;
+
+        expect(
+          queryPlanToPrisma({
+            queryPlan,
+            mapper,
+            nullAttributeRepresentation: "omitted",
+          })
+        ).toStrictEqual({
+          kind: PlanKind.CONDITIONAL,
+          filters: { aOptionalString: { equals: "x" } },
+        });
+      });
+    });
   });
 });
 

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -142,6 +142,22 @@ export type Mapper =
   | Record<string, MapperConfig>
   | ((key: string) => MapperConfig);
 
+/**
+ * How the caller represents a NULL column when building the attributes it sends to `check()`.
+ *
+ * The planner emits the same `eq(attr, null)` node either way, so the plan cannot reveal which
+ * convention is in use and the adapter has to be told.
+ *
+ * - `"explicit"` (default) — a NULL column is sent as an explicit `null` attribute. CEL compares
+ *   `null == null`, so `IS NULL` selects exactly the rows `check()` allows.
+ * - `"omitted"` — a NULL column sends no attribute at all. CEL then raises a missing-attribute
+ *   error, which Cerbos treats as a deny, so a filter that *selects* NULL rows returns rows the
+ *   PDP denies. Null comparison operands are rejected instead of translated.
+ *
+ * See https://github.com/cerbos/query-plan-adapters/issues/302.
+ */
+export type NullAttributeRepresentation = "explicit" | "omitted";
+
 export interface QueryPlanToPrismaArgs {
   queryPlan: PlanResourcesResponse;
   mapper?: Mapper;
@@ -151,6 +167,11 @@ export interface QueryPlanToPrismaArgs {
    * references and need the model name as their container.
    */
   model?: string;
+  /**
+   * Which NULL-column representation the caller uses when building `check()` attributes.
+   * Defaults to `"explicit"`, preserving the historical `IS NULL` translation.
+   */
+  nullAttributeRepresentation?: NullAttributeRepresentation;
 }
 
 export type QueryPlanToPrismaResult =
@@ -495,6 +516,9 @@ function buildMembershipFilter(
   values: Value[]
 ): PrismaFilter {
   const nonNullValues = values.filter((value) => value !== null);
+  if (nonNullValues.length !== values.length) {
+    assertNullOperandTranslatable("a null element in an `in` list");
+  }
   const filters: PrismaFilter[] = [];
 
   if (nonNullValues.length > 0 || values.length === 0) {
@@ -531,6 +555,30 @@ type LambdaScope = {
 };
 let lambdaScopes: LambdaScope[] = [];
 let rootModelName: string | undefined;
+let nullRepresentation: NullAttributeRepresentation = "explicit";
+
+/**
+ * Guards every site that would emit a NULL-selecting predicate out of a `null` comparison
+ * operand.
+ *
+ * Under the `"omitted"` representation a NULL column carries no attribute, so CEL raises a
+ * missing-attribute error and `check()` denies the row — `IS NULL` would return exactly the rows
+ * the PDP refuses. The rejection is deliberately wider than the over-granting shapes: `ne(x,
+ * null)` on its own is aligned, but Prisma applies negation by wrapping (`{ NOT: ... }`) rather
+ * than by pushing it into the leaf, so a leaf cannot tell whether an enclosing `not` will flip
+ * `IS NOT NULL` back into a NULL-selecting predicate. Rejecting every null operand is correct
+ * under any nesting; narrowing it requires negation-parity tracking.
+ */
+function assertNullOperandTranslatable(context: string): void {
+  if (nullRepresentation === "omitted") {
+    throw new Error(
+      `Cannot translate ${context} under nullAttributeRepresentation "omitted": a NULL column ` +
+        "sends no attribute, so Cerbos evaluates the comparison as a missing-attribute error " +
+        "(deny) while a NULL-selecting filter would return those rows. Send NULL columns as " +
+        'explicit nulls and use "explicit", or keep this shape out of the policy.'
+    );
+  }
+}
 
 /**
  * Converts a Cerbos query plan to a Prisma filter.
@@ -539,7 +587,9 @@ export function queryPlanToPrisma({
   queryPlan,
   mapper = {},
   model,
+  nullAttributeRepresentation = "explicit",
 }: QueryPlanToPrismaArgs): QueryPlanToPrismaResult {
+  nullRepresentation = nullAttributeRepresentation;
   switch (queryPlan.kind) {
     case PlanKind.ALWAYS_ALLOWED:
       return { kind: PlanKind.ALWAYS_ALLOWED };
@@ -1986,6 +2036,10 @@ function buildComparisonFilter(
     CERBOS_TO_PRISMA_OPERATOR[operator],
     `Unsupported operator: ${operator}`
   );
+
+  if (value === null) {
+    assertNullOperandTranslatable(`\`${operator}\` against a null operand`);
+  }
 
   if (typeof value === "number" && !Number.isInteger(value)) {
     const fieldName = getLeafField(fieldRef.path);

--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -252,6 +252,34 @@ the construct: rows marked **no** are rejected while resolving an operand,
 | `eq`/`ne` against a list constant               | `R.attr.tags == ["a", "b"]`                       | no          | Whole-list equality has no scalar-column translation (the plan arrives as `eq(variable, value-list)` verbatim); rejected before path resolution. Map the attribute as a Relation and use `in`/`hasIntersection`, or compare elements individually. |
 | `except` (list difference)                      | `size(R.attr.tags.except(["archived"])) > 0`      | no          | Cerbos `except(list, list)` is a two-list function (the wire shape is `except(variable, value-list)`, typically inside `size()` — PDP-verified); list difference has no JPA Criteria translation. Rewrite with an equivalent macro: `size(coll.except([...])) > 0` ≡ `coll.exists(x, !(x in [...]))`. |
 
+## NULL attribute representation
+
+`R.attr.x == null` compiles to the same `eq(x, null)` plan node however your application represents
+a NULL column in the attributes it sends to `check()`, so the adapter cannot infer the convention
+and has to be told which one you use.
+
+| attributes you send for a NULL column | `check()` on that row | `IS NULL` filter |
+| --- | --- | --- |
+| `{"x": null}` — explicit null | allow | selects it — aligned |
+| `{}` — attribute omitted | **deny** (CEL missing-attribute error) | selects it — **over-grants** |
+
+`NullAttributeRepresentation` defaults to `EXPLICIT`, preserving the historical `IS NULL`
+translation. If your application omits attributes for NULL columns, pass `OMITTED`: the adapter
+then rejects every null comparison operand instead of emitting a filter that returns rows the PDP
+denies. Unlike the rest of the translation, this check runs eagerly from `toSpecification` rather
+than when the Specification is first evaluated.
+
+```java
+Result<ResourceEntity> result = SpringDataQueryPlanAdapter.toSpecification(
+        planResult, mapper, Map.of(), NullAttributeRepresentation.OMITTED);
+```
+
+The rejection is deliberately wider than the shapes that actually over-grant — `x != null` and
+`!(x == null)` are aligned under both conventions — because negation is applied around the built
+predicate rather than pushed into the leaf, so a leaf cannot tell whether an enclosing `not` will
+flip `IS NOT NULL` back into a NULL-selecting predicate. Rejecting every null operand is correct
+under any nesting. See [#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ## Conformance contract
 
 The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisions using 20 hostile seed rows on H2, PostgreSQL, and MySQL. This Spring Data implementation defines the reference semantics that the other adapters follow.
@@ -260,6 +288,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 | --- | --- |
 | Oracle-tested | All 122 reference conformance actions |
 | Fail-closed corpus shapes | Regex `matches()`, ordered list indexing/`get-field`, and `timestamp()` over an ambiguous string column (3 actions) |
+| Representation-dependent | `null-eq-missing` — rejected under `NullAttributeRepresentation.OMITTED`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute rows; this is pinned separately as an upstream divergence |
 
 The oracle coverage includes value-first and field-to-field comparisons, literal-safe string matching, nested and correlated collection macros, three-valued null/error propagation, arithmetic and ternaries, hierarchy operations, timestamp comparisons on supported absolute-instant columns, and multi-hop relations. Unsupported shapes throw before a predicate can be used.

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/NullAttributeRepresentation.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/NullAttributeRepresentation.java
@@ -1,0 +1,27 @@
+package dev.cerbos.queryplan.springdata;
+
+/**
+ * How the caller represents a NULL column when building the attributes it sends to
+ * {@code check()}.
+ *
+ * <p>The planner emits the same {@code eq(attr, null)} node either way, so the plan cannot
+ * reveal which convention is in use and the adapter has to be told.
+ *
+ * <p>See <a href="https://github.com/cerbos/query-plan-adapters/issues/302">issue #302</a>.
+ */
+public enum NullAttributeRepresentation {
+
+    /**
+     * A NULL column is sent as an explicit {@code null} attribute. CEL compares
+     * {@code null == null}, so {@code IS NULL} selects exactly the rows {@code check()} allows.
+     * This is the historical behaviour and the default.
+     */
+    EXPLICIT,
+
+    /**
+     * A NULL column sends no attribute at all. CEL then raises a missing-attribute error, which
+     * Cerbos treats as a deny, so a filter that <em>selects</em> NULL rows returns rows the PDP
+     * denies. Null comparison operands are rejected instead of translated.
+     */
+    OMITTED
+}

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -110,6 +110,37 @@ public final class SpringDataQueryPlanAdapter {
             PlanResourcesResult planResult,
             Map<String, AttributeMapping> mapper,
             Map<String, OperatorFunction> overrides) {
+        return toSpecification(
+                planResult, mapper, overrides, NullAttributeRepresentation.EXPLICIT);
+    }
+
+    /**
+     * Translates a Cerbos query plan into a {@link Result}, declaring how the caller represents
+     * a NULL column in the attributes it sends to {@code check()}.
+     *
+     * <p>The planner emits the same {@code eq(attr, null)} node under both conventions, so the
+     * plan cannot reveal which one is in use. Under
+     * {@link NullAttributeRepresentation#OMITTED} a NULL column carries no attribute, CEL
+     * raises a missing-attribute error, and {@code check()} denies the row — {@code IS NULL}
+     * would return exactly the rows the PDP refuses. Every null comparison operand in the plan
+     * is therefore rejected eagerly, from this call rather than at Specification evaluation.
+     *
+     * @param <T> the entity type the Specification will be executed against
+     * @param planResult the SDK plan result
+     * @param mapper maps each plan variable to a JPA path or relation
+     * @param overrides per-operator replacement translations, keyed by Cerbos operator name
+     * @param nullAttributeRepresentation the caller's NULL-column convention
+     * @return {@link Result.AlwaysAllowed}, {@link Result.AlwaysDenied}, or a
+     *         {@link Result.Conditional} wrapping the translated Specification
+     * @throws IllegalArgumentException if the conditional plan carries no condition, or if the
+     *         plan carries a null comparison operand under
+     *         {@link NullAttributeRepresentation#OMITTED}
+     */
+    public static <T> Result<T> toSpecification(
+            PlanResourcesResult planResult,
+            Map<String, AttributeMapping> mapper,
+            Map<String, OperatorFunction> overrides,
+            NullAttributeRepresentation nullAttributeRepresentation) {
         if (planResult.isAlwaysAllowed()) {
             return new Result.AlwaysAllowed<>();
         }
@@ -118,6 +149,9 @@ public final class SpringDataQueryPlanAdapter {
         }
         Operand condition = planResult.getCondition()
                 .orElseThrow(() -> new IllegalArgumentException("Conditional plan has no condition"));
+        if (nullAttributeRepresentation == NullAttributeRepresentation.OMITTED) {
+            assertNoNullComparisonOperands(condition);
+        }
         // Defensive copies: the returned Specification is re-invoked fresh per query execution
         // (see Result), so capturing the caller's maps by reference would let post-construction
         // mutation silently change which columns the authorization filter resolves.
@@ -178,6 +212,33 @@ public final class SpringDataQueryPlanAdapter {
             PlanResourcesResponse response,
             Map<String, AttributeMapping> mapper,
             Map<String, OperatorFunction> overrides) {
+        return toSpecification(
+                response, mapper, overrides, NullAttributeRepresentation.EXPLICIT);
+    }
+
+    /**
+     * Translates a raw {@link PlanResourcesResponse} protobuf into a {@link Result}, declaring
+     * how the caller represents a NULL column in the attributes it sends to {@code check()}.
+     *
+     * <p>See {@link #toSpecification(PlanResourcesResult, Map, Map,
+     * NullAttributeRepresentation)} for what the representation changes.
+     *
+     * @param <T> the entity type the Specification will be executed against
+     * @param response the raw {@code PlanResources} RPC response
+     * @param mapper maps each plan variable to a JPA path or relation
+     * @param overrides per-operator replacement translations, keyed by Cerbos operator name
+     * @param nullAttributeRepresentation the caller's NULL-column convention
+     * @return {@link Result.AlwaysAllowed}, {@link Result.AlwaysDenied}, or a
+     *         {@link Result.Conditional} wrapping the translated Specification
+     * @throws IllegalArgumentException if the filter kind is unknown, a conditional filter
+     *         carries no condition, or the plan carries a null comparison operand under
+     *         {@link NullAttributeRepresentation#OMITTED}
+     */
+    public static <T> Result<T> toSpecification(
+            PlanResourcesResponse response,
+            Map<String, AttributeMapping> mapper,
+            Map<String, OperatorFunction> overrides,
+            NullAttributeRepresentation nullAttributeRepresentation) {
         PlanResourcesFilter filter = response.getFilter();
         return switch (filter.getKind()) {
             case KIND_ALWAYS_ALLOWED -> new Result.AlwaysAllowed<>();
@@ -187,6 +248,9 @@ public final class SpringDataQueryPlanAdapter {
                 if (cond.getNodeCase() == Operand.NodeCase.NODE_NOT_SET) {
                     throw new IllegalArgumentException("Conditional plan has no condition");
                 }
+                if (nullAttributeRepresentation == NullAttributeRepresentation.OMITTED) {
+                    assertNoNullComparisonOperands(cond);
+                }
                 // Defensive copies — same rationale as the PlanResourcesResult overload.
                 Map<String, AttributeMapping> mapperCopy = Map.copyOf(mapper);
                 Map<String, OperatorFunction> overridesCopy = Map.copyOf(overrides);
@@ -195,6 +259,62 @@ public final class SpringDataQueryPlanAdapter {
                                 .traverse(cond, Scope.root(root, query, mapperCopy)));
             }
             default -> throw new IllegalArgumentException("Unknown filter kind: " + filter.getKind());
+        };
+    }
+
+    // -- NULL representation guard --
+
+    /**
+     * Rejects every null literal operand in the plan under
+     * {@link NullAttributeRepresentation#OMITTED}.
+     *
+     * <p>A NULL column then carries no attribute at all, so CEL raises a missing-attribute
+     * error and {@code check()} denies the row — {@code IS NULL} would return exactly the rows
+     * the PDP refuses (cerbos/query-plan-adapters#302).
+     *
+     * <p>The scan runs over the plan tree rather than at each emission site because the
+     * translator lowers a null constant to {@code IS NULL} from several places (scalar leaf,
+     * scalar {@code in} with null elements, relation membership, {@code hasIntersection}). For
+     * the same reason it matches on the OPERAND and never on an allowlist of operators: a null
+     * constant reaches a NULL-selecting predicate through more shapes than the obvious
+     * {@code eq}/{@code ne}/{@code in}, and any operator added later would silently escape a
+     * list that has to be maintained by hand.
+     *
+     * <p>The rejection is also deliberately wider than the over-granting shapes:
+     * {@code ne(x, null)} on its own is aligned, but negation is applied around the built
+     * predicate rather than pushed into the leaf, so a leaf cannot tell whether an enclosing
+     * {@code not} will flip {@code IS NOT NULL} back into a NULL-selecting predicate. Rejecting
+     * every null operand is correct under any nesting; narrowing it requires negation-parity
+     * tracking.
+     */
+    private static void assertNoNullComparisonOperands(Operand operand) {
+        if (operand.getNodeCase() != Operand.NodeCase.EXPRESSION) {
+            return;
+        }
+        var expression = operand.getExpression();
+        List<Operand> operands = expression.getOperandsList();
+        if (operands.stream().anyMatch(SpringDataQueryPlanAdapter::carriesNull)) {
+            throw new IllegalArgumentException(
+                    "Cannot translate `" + expression.getOperator() + "` against a null operand"
+                            + " under NullAttributeRepresentation.OMITTED: a NULL column sends no"
+                            + " attribute, so Cerbos evaluates the comparison as a"
+                            + " missing-attribute error (deny) while a NULL-selecting filter"
+                            + " would return those rows. Send NULL columns as explicit nulls and"
+                            + " use EXPLICIT, or keep this shape out of the policy.");
+        }
+        operands.forEach(SpringDataQueryPlanAdapter::assertNoNullComparisonOperands);
+    }
+
+    private static boolean carriesNull(Operand operand) {
+        if (operand.getNodeCase() != Operand.NodeCase.VALUE) {
+            return false;
+        }
+        Value value = operand.getValue();
+        return switch (value.getKindCase()) {
+            case NULL_VALUE -> true;
+            case LIST_VALUE -> value.getListValue().getValuesList().stream()
+                    .anyMatch(element -> element.getKindCase() == Value.KindCase.NULL_VALUE);
+            default -> false;
         };
     }
 

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -3,6 +3,7 @@ package dev.cerbos.queryplan.springdata;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter.Expression.Operand;
 import dev.cerbos.queryplan.springdata.testmodel.CategoryEntity;
 import dev.cerbos.queryplan.springdata.testmodel.LabelEntity;
 import dev.cerbos.queryplan.springdata.testmodel.ResourceEntity;
@@ -43,13 +44,18 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import com.google.protobuf.Value;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -148,7 +154,13 @@ class AdversarialConformanceTest {
     private record UnsupportedShape(String action, String shape, String springDataMessage) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ActionsFile(List<String> conformance, List<UnsupportedShape> expectedUnsupported) {}
+    private record NullRepresentationOmitted(String action, String reason) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ActionsFile(
+            List<String> conformance,
+            List<UnsupportedShape> expectedUnsupported,
+            List<NullRepresentationOmitted> nullRepresentationOmitted) {}
 
     private static SeedsFile seedsFile;
     private static ActionsFile actionsFile;
@@ -162,6 +174,16 @@ class AdversarialConformanceTest {
         return actionsFile.expectedUnsupported().stream()
                 .filter(u -> !u.action().equals("p-timestamp"))
                 .map(u -> Arguments.of(u.action(), u.springDataMessage()));
+    }
+
+    /**
+     * Actions whose {@code == null} probe targets an attribute the oracle OMITS for NULL
+     * columns. They carry no oracle comparison: under the omitted representation check() denies
+     * every row, so the adapter must reject the shape rather than emit a filter (#302).
+     */
+    static Stream<Arguments> nullRepresentationOmitted() {
+        return actionsFile.nullRepresentationOmitted().stream()
+                .map(n -> Arguments.of(n.action(), n.reason()));
     }
     /**
      * Deterministic label names per seed for the {@code macro-depth3-*} actions — the third
@@ -558,10 +580,16 @@ class AdversarialConformanceTest {
     // -- adapter execution through the public Specification path --
 
     private static List<String> adapterFilteredIds(String action) {
+        return adapterFilteredIds(action, NullAttributeRepresentation.EXPLICIT);
+    }
+
+    private static List<String> adapterFilteredIds(
+            String action, NullAttributeRepresentation representation) {
         PlanResourcesResult plan = client.plan(
                 principal(), Resource.newInstance(seedsFile.resourceKind()), action);
         Specification<ResourceEntity> spec =
-                SpringDataQueryPlanAdapter.<ResourceEntity>toSpecification(plan, MAPPING).toSpecification();
+                SpringDataQueryPlanAdapter.<ResourceEntity>toSpecification(
+                        plan, MAPPING, Map.of(), representation).toSpecification();
 
         EntityManager em = emf.createEntityManager();
         try {
@@ -599,6 +627,80 @@ class AdversarialConformanceTest {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class, () -> adapterFilteredIds(action));
         assertEquals(expectedMessage, ex.getMessage());
+    }
+
+    /**
+     * #302. {@code null-eq-missing} probes {@code aOptionalString == null}, and
+     * {@code aOptionalString} follows the corpus default: a NULL column sends NO attribute. Both
+     * halves are asserted because the rejection alone would pass vacuously if the adapter threw
+     * for an unrelated reason — the over-grant under the default representation is what makes the
+     * rejection necessary.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nullRepresentationOmitted")
+    void nullRepresentationOmittedIsRejected(String action, String reason) {
+        assertEquals(List.of(), oracleAllowedIds(action), reason);
+
+        // The default translation emits IS NULL and returns exactly the rows the PDP denies.
+        assertFalse(adapterFilteredIds(action).isEmpty(), reason);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> adapterFilteredIds(action, NullAttributeRepresentation.OMITTED));
+        assertTrue(ex.getMessage().contains("missing-attribute error"), ex.getMessage());
+    }
+
+    /**
+     * #302 completeness guard. The rejection must key off the null OPERAND, not off a list of
+     * operators: {@code hasIntersection(tagNames, ["public", null])} carries one in its value
+     * list, and an allowlist of eq/ne/in silently misses it. Enumerating the corpus rather than
+     * naming shapes means a newly added action carrying a null constant is covered automatically.
+     */
+    @Test
+    void everyNullCarryingActionIsRejectedUnderOmitted() {
+        Set<String> manifest = new LinkedHashSet<>(actionsFile.conformance());
+        actionsFile.expectedUnsupported().forEach(u -> manifest.add(u.action()));
+        actionsFile.nullRepresentationOmitted().forEach(n -> manifest.add(n.action()));
+
+        List<String> nullCarrying = new ArrayList<>();
+        for (String action : manifest.stream().sorted().toList()) {
+            PlanResourcesResult plan = client.plan(
+                    principal(), Resource.newInstance(seedsFile.resourceKind()), action);
+            plan.getCondition()
+                    .filter(AdversarialConformanceTest::planCarriesNullLiteral)
+                    .ifPresent(c -> nullCarrying.add(action));
+        }
+
+        // Guard the guard: if the walk stopped finding null operands the loop below is vacuous.
+        assertTrue(nullCarrying.contains("null-eq-missing"), nullCarrying.toString());
+        assertTrue(nullCarrying.contains("in-null-elem-hasint"), nullCarrying.toString());
+
+        List<String> notRejected = new ArrayList<>();
+        for (String action : nullCarrying) {
+            try {
+                adapterFilteredIds(action, NullAttributeRepresentation.OMITTED);
+                notRejected.add(action);
+            } catch (IllegalArgumentException expected) {
+                // the shape must be rejected under this representation
+            }
+        }
+        assertEquals(List.of(), notRejected);
+    }
+
+    /** Whether any operand anywhere in the plan is a literal null, or a list containing one. */
+    private static boolean planCarriesNullLiteral(Operand operand) {
+        return switch (operand.getNodeCase()) {
+            case VALUE -> {
+                Value value = operand.getValue();
+                yield value.getKindCase() == Value.KindCase.NULL_VALUE
+                        || (value.getKindCase() == Value.KindCase.LIST_VALUE
+                                && value.getListValue().getValuesList().stream()
+                                        .anyMatch(e -> e.getKindCase()
+                                                == Value.KindCase.NULL_VALUE));
+            }
+            case EXPRESSION -> operand.getExpression().getOperandsList().stream()
+                    .anyMatch(AdversarialConformanceTest::planCarriesNullLiteral);
+            default -> false;
+        };
     }
 
     /**

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapterTest.java
@@ -1246,6 +1246,92 @@ class SpringDataQueryPlanAdapterTest {
         }
     }
 
+    // -- NULL attribute representation (issue #302) --
+
+    /**
+     * Both NULL-column conventions produce the identical {@code eq(attr, null)} wire node, so
+     * the adapter cannot infer which one the caller uses. Under {@code OMITTED} a NULL column
+     * carries no attribute at all, CEL raises a missing-attribute error, and {@code check()}
+     * denies every row — {@code IS NULL} would return precisely the rows the PDP refuses.
+     */
+    @Nested
+    class NullAttributeRepresentationTest {
+
+        private Result<ResourceEntity> translate(
+                Operand condition, NullAttributeRepresentation representation) {
+            PlanResourcesResponse resp =
+                    buildResponse(PlanResourcesFilter.Kind.KIND_CONDITIONAL, condition);
+            return SpringDataQueryPlanAdapter.toSpecification(
+                    resp, MAPPER, Map.of(), representation);
+        }
+
+        private Operand nullEq() {
+            return exprOp("eq", var("request.resource.attr.aOptionalString"), nullVal());
+        }
+
+        @Test
+        void explicitIsTheDefaultAndKeepsIsNull() {
+            // The three-arg overload and an EXPLICIT fourth argument agree, and both still
+            // translate rather than throw.
+            assertEquals(0, runCount(nullEq()));
+            assertInstanceOf(
+                    Result.Conditional.class,
+                    translate(nullEq(), NullAttributeRepresentation.EXPLICIT));
+        }
+
+        @Test
+        void omittedRejectsEqAgainstNull() {
+            IllegalArgumentException thrown = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> translate(nullEq(), NullAttributeRepresentation.OMITTED));
+            assertTrue(thrown.getMessage().contains("missing-attribute error"));
+        }
+
+        /**
+         * Conservatively rejected too: {@code ne} alone is aligned under {@code OMITTED}, but
+         * negation wraps the built predicate, so a leaf cannot see whether an enclosing
+         * {@code not} will flip {@code IS NOT NULL} back into {@code IS NULL}.
+         */
+        @Test
+        void omittedRejectsNeAgainstNull() {
+            Operand condition =
+                    exprOp("ne", var("request.resource.attr.aOptionalString"), nullVal());
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> translate(condition, NullAttributeRepresentation.OMITTED));
+        }
+
+        @Test
+        void omittedRejectsNullElementInInList() {
+            Operand condition = exprOp("in",
+                    var("request.resource.attr.aOptionalString"),
+                    listOpNullable("x", null));
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> translate(condition, NullAttributeRepresentation.OMITTED));
+        }
+
+        /** The scan walks the whole tree, not just the root. */
+        @Test
+        void omittedRejectsNullOperandNestedUnderAnd() {
+            Operand condition = exprOp("and",
+                    exprOp("not", nullEq()),
+                    exprOp("eq", var("request.resource.attr.aString"), sval("x")));
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> translate(condition, NullAttributeRepresentation.OMITTED));
+        }
+
+        @Test
+        void omittedLeavesNullFreeComparisonsUntouched() {
+            Operand condition =
+                    exprOp("eq", var("request.resource.attr.aString"), sval("x"));
+            assertInstanceOf(
+                    Result.Conditional.class,
+                    translate(condition, NullAttributeRepresentation.OMITTED));
+        }
+    }
+
     // -- Minor operator/comparison shapes (PR #234) --
 
     @Nested

--- a/sqlalchemy/README.md
+++ b/sqlalchemy/README.md
@@ -4,6 +4,39 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 
 The adapter supports logical and comparison operators, value-first and field-to-field comparisons, literal-safe string helpers, arithmetic and conditional expressions, scalar casts and sizes, timestamps, and hierarchy comparisons. `operator_override_fns` can provide database- or schema-specific translations for collection and other non-portable shapes.
 
+## NULL attribute representation
+
+`R.attr.x == null` compiles to the same `eq(x, null)` plan node however your application represents
+a NULL column in the attributes it sends to `check()`, so the adapter cannot infer the convention
+and has to be told which one you use.
+
+| attributes you send for a NULL column | `check()` on that row | `IS NULL` filter |
+| --- | --- | --- |
+| `{"x": None}` — explicit null | allow | selects it — aligned |
+| `{}` — attribute omitted | **deny** (CEL missing-attribute error) | selects it — **over-grants** |
+
+`null_attribute_representation` defaults to `"explicit"`, preserving the historical `IS NULL`
+translation. If your application omits attributes for NULL columns, pass `"omitted"`: the adapter
+then raises on every null comparison operand instead of emitting a filter that returns rows the PDP
+denies.
+
+```python
+get_query(
+    plan,
+    Resource,
+    attr_map,
+    null_attribute_representation="omitted",
+)
+```
+
+The rejection is deliberately wider than the shapes that actually over-grant — `x != null` and
+`!(x == null)` are aligned under both conventions — because negation is applied around the built
+predicate rather than pushed into the leaf, so a leaf cannot tell whether an enclosing `not` will
+flip `IS NOT NULL` back into a NULL-selecting predicate. Rejecting every null operand is correct
+under any nesting. It also fires ahead of `operator_override_fns`, since an override cannot
+recover a representation the plan never carried. See
+[#302](https://github.com/cerbos/query-plan-adapters/issues/302).
+
 ## Conformance contract
 
 The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisions using 20 hostile seed rows and executable SQLAlchemy queries. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
@@ -12,6 +45,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 | --- | --- |
 | Oracle-tested | 120 reference conformance actions |
 | Fail-closed corpus shapes | Nanosecond `now()` thresholds plus regex `matches()`, ordered list indexing/`get-field`, and `timestamp()` over an ambiguous string column (5 actions) |
+| Representation-dependent | `null-eq-missing` — raises under `null_attribute_representation="omitted"`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 The conformance harness supplies the same public `operator_override_fns` mechanism available to applications for schema-specific collection translations. Regex `matches()` fails closed by default because SQL dialect regex engines do not guarantee CEL/RE2 semantics; applications may provide an override only when their database translation is known to be equivalent. Timestamp literals must use strict RFC 3339 grammar, resolve inside CEL's supported year 0001–9999 instant range, and be exactly representable at Python/SQLAlchemy microsecond precision: discarded fractional digits must be zero, and the mapped column/database must preserve microseconds. Unsupported shapes raise instead of producing a broader query.

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import MappingProxyType
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Tuple, Union
 
 from cerbos.engine.v1 import engine_pb2
 from cerbos.response.v1 import response_pb2
@@ -37,6 +37,11 @@ GenericTable = Union[Table, DeclarativeMeta]
 GenericColumn = Union[Column, InstrumentedAttribute]
 GenericExpression = Union[BinaryExpression, ColumnOperators]
 OperatorFnMap = Dict[str, Callable[[GenericColumn, Any], GenericExpression]]
+
+# How the caller represents a NULL column when building the attributes it sends
+# to check(). See get_query() and
+# https://github.com/cerbos/query-plan-adapters/issues/302.
+NullAttributeRepresentation = Literal["explicit", "omitted"]
 
 
 _LIKE_ESCAPE_CHAR = "\\"
@@ -447,6 +452,51 @@ def _unwrap_expression(operand: dict) -> dict:
     return operand if expression is None else expression
 
 
+def _carries_null_operand(operand: dict) -> bool:
+    if "value" not in operand:
+        return False
+    value = operand["value"]
+    if value is None:
+        return True
+    return isinstance(value, list) and any(member is None for member in value)
+
+
+def _assert_no_null_comparison_operands(node: dict) -> None:
+    """Reject every null literal operand under the ``omitted`` representation.
+
+    A NULL column then carries no attribute at all, so CEL raises a
+    missing-attribute error and ``check()`` denies the row -- ``IS NULL`` would
+    return exactly the rows the PDP refuses (cerbos/query-plan-adapters#302).
+
+    The scan matches on the OPERAND, never on an allowlist of operators. A null
+    constant reaches a NULL-selecting predicate through more shapes than the
+    obvious ``eq``/``ne``/``in`` -- ``hasIntersection`` carries one in its value
+    list too -- and any operator added later would silently escape a list that
+    has to be maintained by hand.
+
+    The rejection is also deliberately wider than the over-granting shapes:
+    ``ne(x, null)`` on its own is aligned, but negation is applied around the
+    built predicate rather than pushed into the leaf, so a leaf cannot tell
+    whether an enclosing ``not`` will flip ``IS NOT NULL`` back into a
+    NULL-selecting predicate. Rejecting every null operand is correct under any
+    nesting; narrowing it requires negation-parity tracking.
+    """
+    expression = _unwrap_expression(node)
+    operator = expression.get("operator")
+    operands = expression.get("operands", [])
+    if any(_carries_null_operand(_unwrap_expression(operand)) for operand in operands):
+        raise ValueError(
+            f"Cannot translate `{operator}` against a null operand under "
+            'null_attribute_representation="omitted": a NULL column sends no '
+            "attribute, so Cerbos evaluates the comparison as a missing-attribute "
+            "error (deny) while a NULL-selecting filter would return those rows. "
+            'Send NULL columns as explicit nulls and use "explicit", or keep this '
+            "shape out of the policy."
+        )
+    for operand in operands:
+        _assert_no_null_comparison_operands(operand)
+
+
 def _substitute_lambda_variable(
     operand: dict, variable_name: str, element: Any
 ) -> dict:
@@ -576,7 +626,31 @@ def get_query(
     attr_map: Dict[str, GenericColumn],
     table_mapping: Union[List[Tuple[GenericTable, GenericExpression]], None] = None,
     operator_override_fns: Union[OperatorFnMap, None] = None,
+    null_attribute_representation: NullAttributeRepresentation = "explicit",
 ) -> Select:
+    """Translate a Cerbos query plan into a SQLAlchemy ``Select``.
+
+    ``null_attribute_representation`` declares how the caller represents a NULL
+    column when building the attributes it sends to ``check()``. The planner
+    emits the same ``eq(attr, null)`` node either way, so the plan cannot reveal
+    which convention is in use and the adapter has to be told.
+
+    - ``"explicit"`` (default) -- a NULL column is sent as an explicit ``null``
+      attribute. CEL compares ``null == null``, so ``IS NULL`` selects exactly
+      the rows ``check()`` allows.
+    - ``"omitted"`` -- a NULL column sends no attribute at all. CEL then raises a
+      missing-attribute error, which Cerbos treats as a deny, so a filter that
+      *selects* NULL rows returns rows the PDP denies. Null comparison operands
+      are rejected instead of translated.
+
+    See https://github.com/cerbos/query-plan-adapters/issues/302.
+    """
+    if null_attribute_representation not in ("explicit", "omitted"):
+        raise ValueError(
+            "null_attribute_representation must be 'explicit' or 'omitted', got "
+            f"{null_attribute_representation!r}"
+        )
+
     if query_plan.filter is None or query_plan.filter.kind in _deny_types:
         return select(table).where(False)
 
@@ -588,6 +662,9 @@ def get_query(
         if isinstance(query_plan, response_pb2.PlanResourcesResponse)
         else query_plan.filter.condition.to_dict()
     )
+
+    if null_attribute_representation == "omitted":
+        _assert_no_null_comparison_operands(cond)
 
     # Inspect columns that the normal translator owns. Override-owned operands
     # may legitimately be relation markers or columns translated into

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -98,6 +98,15 @@ THROWING_ACTIONS = sorted(
     - SQLALCHEMY_SUPPORTED_EXPECTED
 )
 
+# Actions whose `== null` probe targets an attribute the oracle OMITS for NULL
+# columns. They carry no oracle comparison: under the omitted representation
+# check() denies every row, so the adapter must reject the shape rather than
+# emit a filter (#302).
+NULL_REPRESENTATION_OMITTED = [
+    (item["action"], item["reason"])
+    for item in ACTIONS_FILE["nullRepresentationOmitted"]
+]
+
 
 def _iso_for(seed: Dict[str, Any]) -> str:
     """Deterministic ISO instant per seed for the timestamp probe (see
@@ -671,16 +680,38 @@ def _oracle_allowed_ids(client: CerbosClient, action: str) -> Set[str]:
     }
 
 
+def _plan_carries_null_literal(node) -> bool:
+    """Whether any operand anywhere in the plan is a literal null, or a list containing one."""
+    if not isinstance(node, dict):
+        return False
+    if "value" in node:
+        value = node["value"]
+        return value is None or (
+            isinstance(value, list) and any(member is None for member in value)
+        )
+    expression = node.get("expression", node)
+    return any(
+        _plan_carries_null_literal(operand)
+        for operand in expression.get("operands", [])
+    )
+
+
 # -- adapter execution through the public get_query path --
 
 
-def _adapter_filtered_ids(client: CerbosClient, conn, action: str) -> Set[str]:
+def _adapter_filtered_ids(
+    client: CerbosClient,
+    conn,
+    action: str,
+    null_attribute_representation: str = "explicit",
+) -> Set[str]:
     plan = client.plan_resources(action, _principal(), ResourceDesc(RESOURCE_KIND))
     query = get_query(
         plan,
         AdvResource,
         ATTR_MAP,
         operator_override_fns=OPERATOR_OVERRIDES,
+        null_attribute_representation=null_attribute_representation,
     )
     return {row.id for row in conn.execute(query).fetchall()}
 
@@ -702,6 +733,75 @@ class TestAdversarialConformance:
         # a silently-wrong filter is the only unacceptable outcome.
         with pytest.raises(Exception):
             _adapter_filtered_ids(adv_cerbos_client, adv_conn, action)
+
+    # #302. `null-eq-missing` probes `aOptionalString == null`, and
+    # `aOptionalString` follows the corpus default: a NULL column sends NO
+    # attribute. Both halves are asserted because the rejection alone would pass
+    # vacuously if the adapter raised for an unrelated reason — the over-grant
+    # under the default representation is what makes the rejection necessary.
+    @pytest.mark.parametrize("action,reason", NULL_REPRESENTATION_OMITTED)
+    def test_null_representation_omitted_is_rejected(
+        self, action, reason, adv_cerbos_client, adv_conn
+    ):
+        assert _oracle_allowed_ids(adv_cerbos_client, action) == set()
+
+        # The default translation emits IS NULL and returns exactly the rows the
+        # PDP denies.
+        over_granted = _adapter_filtered_ids(adv_cerbos_client, adv_conn, action)
+        assert len(over_granted) > 0, reason
+
+        with pytest.raises(ValueError, match="missing-attribute"):
+            _adapter_filtered_ids(
+                adv_cerbos_client,
+                adv_conn,
+                action,
+                null_attribute_representation="omitted",
+            )
+
+    # #302 completeness guard. The rejection must key off the null OPERAND, not off a
+    # list of operators: `hasIntersection(tagNames, ["public", None])` carries one in
+    # its value list, and an allowlist of eq/ne/in silently misses it. Enumerating the
+    # corpus rather than naming shapes means a newly added action carrying a null
+    # constant is covered automatically.
+    def test_every_null_carrying_action_is_rejected_under_omitted(
+        self, adv_cerbos_client, adv_conn
+    ):
+        manifest = (
+            set(ACTIONS_FILE["conformance"])
+            | {u["action"] for u in ACTIONS_FILE["expectedUnsupported"]}
+            | {n["action"] for n in ACTIONS_FILE["nullRepresentationOmitted"]}
+            | {d["action"] for d in ACTIONS_FILE["knownDivergences"]}
+        )
+        null_carrying = []
+        for action in sorted(manifest):
+            plan = adv_cerbos_client.plan_resources(
+                action, _principal(), ResourceDesc(RESOURCE_KIND)
+            )
+            if (
+                plan.filter is None
+                or plan.filter.kind != PlanResourcesFilterKind.CONDITIONAL
+            ):
+                continue
+            if _plan_carries_null_literal(plan.filter.condition.to_dict()):
+                null_carrying.append(action)
+
+        # Guard the guard: if the walk stopped finding null operands the loop is vacuous.
+        assert "null-eq-missing" in null_carrying
+        assert "in-null-elem-hasint" in null_carrying
+
+        not_rejected = []
+        for action in null_carrying:
+            try:
+                _adapter_filtered_ids(
+                    adv_cerbos_client,
+                    adv_conn,
+                    action,
+                    null_attribute_representation="omitted",
+                )
+                not_rejected.append(action)
+            except Exception:
+                pass  # expected: the shape must be rejected under this representation
+        assert not_rejected == []
 
     @pytest.mark.parametrize(
         "action",
@@ -755,6 +855,14 @@ class TestAdversarialConformance:
         # Guard the guard: these actions must produce a non-empty, non-total
         # oracle set, otherwise the differential comparison could pass
         # vacuously (e.g. a PDP that denies everything).
-        for action in ("vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne"):
+        for action in (
+            "vf-le",
+            "like-percent",
+            "all-on-empty",
+            "pv-exists",
+            "pv-all",
+            "null-eq",
+            "null-ne",
+        ):
             ids = _oracle_allowed_ids(adv_cerbos_client, action)
             assert 0 < len(ids) < len(SEEDS)

--- a/sqlalchemy/tests/test_query.py
+++ b/sqlalchemy/tests/test_query.py
@@ -716,6 +716,159 @@ class TestGetQuery:
             get_query(plan, resource_table, attr)
 
 
+class TestNullAttributeRepresentation:
+    """cerbos/query-plan-adapters#302.
+
+    Both NULL-column conventions produce the identical ``eq(attr, null)`` wire
+    node, so the adapter cannot infer which one the caller uses. Under
+    ``"omitted"`` a NULL column carries no attribute at all, CEL raises a
+    missing-attribute error, and ``check()`` denies every row -- an ``IS NULL``
+    filter would return precisely the rows the PDP refuses.
+    """
+
+    @staticmethod
+    def _null_eq_plan():
+        return _conditional_plan(
+            {
+                "operator": "eq",
+                "operands": [
+                    {"variable": "request.resource.attr.name"},
+                    {"value": None},
+                ],
+            }
+        )
+
+    def test_explicit_is_the_default_and_keeps_is_null(self, resource_table):
+        attr = {"request.resource.attr.name": resource_table.name}
+        default = get_query(self._null_eq_plan(), resource_table, attr)
+        explicit = get_query(
+            self._null_eq_plan(),
+            resource_table,
+            attr,
+            null_attribute_representation="explicit",
+        )
+
+        compiled = str(default.compile(compile_kwargs={"literal_binds": True}))
+        assert " IS NULL" in compiled
+        assert compiled == str(explicit.compile(compile_kwargs={"literal_binds": True}))
+
+    def test_omitted_rejects_eq_against_null(self, resource_table):
+        with pytest.raises(ValueError, match="missing-attribute"):
+            get_query(
+                self._null_eq_plan(),
+                resource_table,
+                {"request.resource.attr.name": resource_table.name},
+                null_attribute_representation="omitted",
+            )
+
+    def test_omitted_rejects_ne_against_null(self, resource_table):
+        # Conservatively rejected too: `ne` alone is aligned under "omitted",
+        # but negation wraps the built predicate, so a leaf cannot see whether
+        # an enclosing `not` will flip IS NOT NULL back into IS NULL.
+        plan = _conditional_plan(
+            {
+                "operator": "ne",
+                "operands": [
+                    {"variable": "request.resource.attr.name"},
+                    {"value": None},
+                ],
+            }
+        )
+        with pytest.raises(ValueError, match="missing-attribute"):
+            get_query(
+                plan,
+                resource_table,
+                {"request.resource.attr.name": resource_table.name},
+                null_attribute_representation="omitted",
+            )
+
+    def test_omitted_rejects_null_element_in_in_list(self, resource_table):
+        plan = _conditional_plan(
+            {
+                "operator": "in",
+                "operands": [
+                    {"variable": "request.resource.attr.name"},
+                    {"value": ["resource1", None]},
+                ],
+            }
+        )
+        with pytest.raises(ValueError, match="missing-attribute"):
+            get_query(
+                plan,
+                resource_table,
+                {"request.resource.attr.name": resource_table.name},
+                null_attribute_representation="omitted",
+            )
+
+    def test_omitted_rejects_a_null_operand_nested_under_and(self, resource_table):
+        plan = _conditional_plan(
+            {
+                "operator": "and",
+                "operands": [
+                    {
+                        "expression": {
+                            "operator": "not",
+                            "operands": [
+                                {
+                                    "expression": {
+                                        "operator": "eq",
+                                        "operands": [
+                                            {"variable": "request.resource.attr.name"},
+                                            {"value": None},
+                                        ],
+                                    }
+                                }
+                            ],
+                        }
+                    },
+                    {
+                        "expression": {
+                            "operator": "eq",
+                            "operands": [
+                                {"variable": "request.resource.attr.name"},
+                                {"value": "resource1"},
+                            ],
+                        }
+                    },
+                ],
+            }
+        )
+        with pytest.raises(ValueError, match="missing-attribute"):
+            get_query(
+                plan,
+                resource_table,
+                {"request.resource.attr.name": resource_table.name},
+                null_attribute_representation="omitted",
+            )
+
+    def test_omitted_leaves_null_free_comparisons_untouched(self, resource_table, conn):
+        plan = _conditional_plan(
+            {
+                "operator": "eq",
+                "operands": [
+                    {"variable": "request.resource.attr.name"},
+                    {"value": "resource1"},
+                ],
+            }
+        )
+        query = get_query(
+            plan,
+            resource_table,
+            {"request.resource.attr.name": resource_table.name},
+            null_attribute_representation="omitted",
+        )
+        assert [row.name for row in conn.execute(query)] == ["resource1"]
+
+    def test_unknown_representation_is_rejected(self, resource_table):
+        with pytest.raises(ValueError, match="must be 'explicit' or 'omitted'"):
+            get_query(
+                self._null_eq_plan(),
+                resource_table,
+                {"request.resource.attr.name": resource_table.name},
+                null_attribute_representation="sometimes",
+            )
+
+
 class TestSemanticEdgeTranslations:
     def test_in_list_with_explicit_null_uses_is_null_disjunct(
         self, resource_table, conn


### PR DESCRIPTION
Closes #302.

## The bug

`R.attr.x == null` compiles to the same `eq(x, null)` plan node whichever way the caller represents a NULL column in the attributes it sends to `check()` — but the two conventions disagree about what that node means.

Verified against the pinned PDP (`conformance/CERBOS_VERSION` = 0.54.0), same policy, same 20 seed rows, varying only how the NULL column is represented:

| action | convention | wire | `check()` allows | an `IS NULL` filter returns |
|---|---|---|---|---|
| `null-eq` | explicit null | `eq(owner, null)` | `a2 a4 a8 c2 e1` | the same 5 — aligned |
| `null-eq-missing` | omitted | `eq(aOptionalString, null)` | **nothing** | those 5 — **over-grants** |

The two wire fixtures are byte-identical apart from the variable name, so the adapter cannot recover the caller's convention from the plan. This is the over-grant direction — an authorization bug, not a false-negative.

## The fix

Per the decision on the issue (option 3): a caller-declared option, defaulting to today's behaviour.

- `nullAttributeRepresentation: "explicit" | "omitted"` — prisma, drizzle, mongoose, convex
- `null_attribute_representation="explicit"|"omitted"` — sqlalchemy
- `NullAttributeRepresentation.EXPLICIT|OMITTED` — spring-data

**The default is `explicit`, so no existing caller changes behaviour.** Setting `omitted` rejects every null literal operand instead of emitting a filter that returns rows the PDP denies.

### Two adapters need no option

`langchain-chromadb` (metadata holds only finite numbers, strings and booleans) and `elasticsearch-java` (no null sentinel, and it already tracks negation parity via `whenTrue`) already reject every null-selecting direction under both conventions. Each gained a test pinning that, so if either store ever gains a null sentinel the new representation dependency surfaces instead of shipping silently.

## Corpus first

`null-eq-missing` probes `aOptionalString`, which follows the corpus default (a NULL column sends no attribute), alongside the existing `null-eq` against the explicit-null `owner` alias. It lives in a new `nullRepresentationOmitted` group rather than in `conformance` — a rejected shape has no filter to compare against the oracle. Both corpus scripts and all eight harnesses read the group; the wire-fixture diff adds only the new action.

## The rejection keys off the operand, not an operator list

An earlier allowlist of `eq`/`ne`/`in` missed `hasIntersection(tagNames, ["public", null])`, which lowers to the same `... OR IS NULL` disjunct in four adapters. Each harness now enumerates every corpus action whose plan carries a null literal and asserts all of them are rejected, rather than naming shapes by hand — that guard is what found the gap.

The rejection is also deliberately wider than the shapes that over-grant. `ne(x, null)` and `!(x == null)` are aligned under both conventions, but every adapter applies negation by wrapping the built predicate rather than pushing it into the leaf, so a leaf cannot tell whether an enclosing `not` will flip `IS NOT NULL` back into a NULL-selecting predicate. Rejecting every null operand is correct under any nesting; narrowing it needs negation-parity tracking, tracked as follow-up rather than attempted here.

## Harness assertions differ per adapter, deliberately

Each pins *why* the rejection is needed, not merely that one happens — otherwise the test passes if the adapter throws for an unrelated reason:

- **prisma, drizzle, sqlalchemy, spring-data** — a SQL `NULL` is a stored value, so the default translation genuinely returns the five rows the PDP denies. These pin that over-grant.
- **mongoose** — already discriminates per attribute: `nullable: true` on a mapper entry means "a stored null is a missing Cerbos attribute". Its harness asserts the aligned empty result *and* that `owner` (same column, no `nullable`) still returns its five explicit-null documents.
- **convex** — a document store, so the seeded shape mirrors the convention directly. Same paired assertion.

## Deviation from the documented corpus process

`CLAUDE.md` step 5 says to add each new action to the degeneracy guard. A `nullRepresentationOmitted` action's oracle is empty *by construction*, and that guard asserts a non-empty, non-total oracle — so it cannot join. Both `CLAUDE.md` and `conformance/README.md` now record the exception and the anti-vacuity assertions that replace it.

## Breaking change

None by default. `omitted` is opt-in, and a caller who selects it is choosing a throw over an over-grant on shapes that previously returned a filter.

## Verification

All run locally against the pinned PDP:

| adapter | unit | adversarial |
|---|---|---|
| prisma (v6 + v7) | 207 | 131 |
| drizzle | 123 | 130 |
| mongoose | 104 | 130 |
| convex | 115 + 8 integration | 130 |
| langchain-chromadb | 54 | 129 |
| sqlalchemy | 276 (incl. adversarial) | — |
| spring-data | `gradle build` green | 1 new case |
| elasticsearch-java | `gradle build` green | 1 new case |

`conformance/scripts/validate-corpus.sh` → 127 actions, 20 seeds. TypeScript build artifacts regenerated in the same commit.

## Reproducing locally

Convex and Mongo need their services up (`npm run convex:up`, `npm run mongo`); the Java suites must be run from the repository root so the harnesses can read `../conformance/`.