### PR TITLE
feat(sqlalchemy): accept DeclarativeBase models and return a typed Select

### DIFF
--- a/.github/workflows/sqlalchemy_pr.yaml
+++ b/.github/workflows/sqlalchemy_pr.yaml
@@ -17,8 +17,21 @@ defaults:
 
 jobs:
   test-sqla:
-    name: SQLA test
+    name: SQLA ${{ matrix.sqlalchemy.name }} test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # `pyproject.toml` declares `sqlalchemy>=1.4`, so both major lines are
+        # supported and both must be proven. 1.4 and 2.0 differ in ways this
+        # adapter touches directly — `DeclarativeBase` exists only on 2.0, and
+        # 1.4 connections need an explicit commit — so a single-version job
+        # leaves half the supported range untested.
+        sqlalchemy:
+          - name: "1.4"
+            constraint: "sqlalchemy<2"
+          - name: "2.x"
+            constraint: ""
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -29,7 +42,7 @@ jobs:
         with:
           path: |
             ./__pypackages__
-          key: ${{ runner.os }}-python-${{ hashFiles('**/pdm.lock') }}
+          key: ${{ runner.os }}-python-${{ matrix.sqlalchemy.name }}-${{ hashFiles('**/pdm.lock') }}
 
       - uses: pdm-project/setup-pdm@973541a5febeafcfdadf8a51211435be6ecfd90f # v4.5
         name: Setup PDM
@@ -38,6 +51,30 @@ jobs:
           prerelease: true # Allow prerelease versions to be installed
           enable-pep582: true # Enable PEP 582 package loading globally
 
-      - run: pdm install -G testcontainers
+      # The 2.x leg installs straight from the committed lockfile. The 1.4 leg
+      # re-resolves under a constraint into a throwaway lockfile, so pdm.lock
+      # stays the single pinned source of truth and no second lockfile has to be
+      # kept in step with it.
+      - if: matrix.sqlalchemy.constraint == ''
+        run: pdm install -G testcontainers
+
+      - if: matrix.sqlalchemy.constraint != ''
+        run: |
+          echo "${{ matrix.sqlalchemy.constraint }}" > /tmp/sqlalchemy-constraint.txt
+          pdm install -G testcontainers \
+            --override /tmp/sqlalchemy-constraint.txt \
+            --lockfile /tmp/sqlalchemy-${{ matrix.sqlalchemy.name }}.lock
+
+      # Fails the job if the constraint did not take, rather than silently
+      # running the same version twice.
+      - name: Assert SQLAlchemy version
+        run: |
+          pdm run python - <<'PY'
+          import sqlalchemy
+          installed = sqlalchemy.__version__
+          expected = "${{ matrix.sqlalchemy.name }}".rstrip("x")
+          assert installed.startswith(expected), f"expected {expected}*, got {installed}"
+          print(f"SQLAlchemy {installed}")
+          PY
 
       - run: pdm run test

--- a/.github/workflows/sqlalchemy_pr.yaml
+++ b/.github/workflows/sqlalchemy_pr.yaml
@@ -75,4 +75,12 @@ jobs:
           print(f"SQLAlchemy {installed}")
           PY
 
+      # `get_query`'s overloads are a static contract the runtime suite cannot
+      # reach, so pyright checks them separately. 2.x only: 1.4's stubs declare
+      # neither `DeclarativeBase` nor `__table__`, so none of the inferences the
+      # fixture pins exist there.
+      - name: Type-check the public signature
+        if: matrix.sqlalchemy.constraint == ''
+        run: npx -y pyright@1.1.411
+
       - run: pdm run test

--- a/.github/workflows/sqlalchemy_pr.yaml
+++ b/.github/workflows/sqlalchemy_pr.yaml
@@ -22,11 +22,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # `pyproject.toml` declares `sqlalchemy>=1.4`, so both major lines are
-        # supported and both must be proven. 1.4 and 2.0 differ in ways this
-        # adapter touches directly — `DeclarativeBase` exists only on 2.0, and
-        # 1.4 connections need an explicit commit — so a single-version job
-        # leaves half the supported range untested.
+        # `pyproject.toml` declares `sqlalchemy>=1.4`, and the two major lines
+        # differ where this adapter reaches — `DeclarativeBase` exists only on
+        # 2.0 — so a single-version job leaves half the supported range unproven.
         sqlalchemy:
           - name: "1.4"
             constraint: "sqlalchemy<2"

--- a/sqlalchemy/README.md
+++ b/sqlalchemy/README.md
@@ -54,6 +54,18 @@ The conformance harness supplies the same public `operator_override_fns` mechani
 - Cerbos > v0.16
 - SQLAlchemy >= 1.4 / 2.0
 
+### Model styles
+
+`get_query`'s `table` argument accepts a Core `Table`, a legacy
+`declarative_base()` model, or a SQLAlchemy 2.0 `DeclarativeBase` subclass. The
+2.0 style is not a relabelling of the legacy one — its metaclass sits outside the
+`DeclarativeMeta` hierarchy — so both are named explicitly in the accepted type.
+
+Passing an ORM model returns `Select[Tuple[Model]]` and passing a Core `Table`
+returns `Select[Any]`, so the row type reaches the caller instead of being erased
+to a bare `Select`. `DeclarativeBase` exists only on SQLAlchemy >= 2.0; on 1.4 the
+member is inert and the legacy style is unaffected.
+
 ### Database collation requirements
 
 Cerbos CEL string and hierarchy comparisons are case-sensitive. The database
@@ -119,15 +131,18 @@ attr_map = {
 
 
 # `get_query` supports both `Table` instances and ORM entities:
-# ORM entity - honouring object level relationships via the sqlalchemy ORM
-query: Select = get_query(plan, LeaveRequest, attr_map)
-# Alternatively it can generate legacy queries by passing the Table instance
+# ORM entity - honouring object level relationships via the sqlalchemy ORM.
+# Passing a model returns `Select[Tuple[LeaveRequest]]`, so the row type survives
+# into `session.execute(query).scalars()` without a manual annotation.
+query = get_query(plan, LeaveRequest, attr_map)
+# Alternatively it can generate legacy queries by passing the Table instance,
+# which returns `Select[Any]` — a Core table carries no row type.
 query: Select = get_query(plan, LeaveRequest.__table__, attr_map)
 
 
 # NOTE: if columns defined within the attr_map originate from more than one table, we need to define a mapping as the optional 4th positional arg to `get_query`.
 # The argument is in the form:
-#   `list[tuple[Table | DeclarativeMeta, BinaryExpression | ColumnOperators]]`
+#   `list[tuple[Table | DeclarativeMeta | type[DeclarativeBase], BinaryExpression | ColumnOperators]]`
 # e.g.:
 query: Select = get_query(
     plan,

--- a/sqlalchemy/README.md
+++ b/sqlalchemy/README.md
@@ -63,8 +63,7 @@ The conformance harness supplies the same public `operator_override_fns` mechani
 
 Passing an ORM model returns `Select[Tuple[Model]]` and passing a Core `Table`
 returns `Select[Any]`, so the row type reaches the caller instead of being erased
-to a bare `Select`. `DeclarativeBase` exists only on SQLAlchemy >= 2.0; on 1.4 the
-member is inert and the legacy style is unaffected.
+to a bare `Select`.
 
 ### Database collation requirements
 

--- a/sqlalchemy/pyrightconfig.json
+++ b/sqlalchemy/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "include": ["tests/typing"],
+  "venvPath": ".",
+  "venv": ".venv",
+  "typeCheckingMode": "basic",
+  "reportUnnecessaryTypeIgnoreComment": "error"
+}

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -1,9 +1,22 @@
+from __future__ import annotations
+
 import math
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import MappingProxyType
-from typing import Any, Callable, Dict, List, Literal, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from cerbos.engine.v1 import engine_pb2
 from cerbos.response.v1 import response_pb2
@@ -33,7 +46,26 @@ from sqlalchemy.orm import DeclarativeMeta, InstrumentedAttribute
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.expression import BinaryExpression, ColumnOperators
 
-GenericTable = Union[Table, DeclarativeMeta]
+try:  # SQLAlchemy >= 2.0
+    from sqlalchemy.orm import DeclarativeBase
+except ImportError:  # SQLAlchemy 1.4 predates the class-based declarative base.
+
+    class DeclarativeBase:  # type: ignore[no-redef]
+        """Stand-in so ``GenericTable`` stays constructible under SQLAlchemy 1.4.
+
+        Nothing subclasses it there, so including it in the union is inert; it
+        exists only to keep this module importable on the older release the
+        package still supports.
+        """
+
+
+_ORMModel = TypeVar("_ORMModel")
+
+# A model declared the 2.0 way subclasses `DeclarativeBase`, whose metaclass
+# (`DeclarativeAttributeIntercept`) is *not* a `DeclarativeMeta`, so the legacy
+# `declarative_base()` member alone does not admit it. Both spellings are
+# accepted, alongside a Core `Table`.
+GenericTable = Union[Table, DeclarativeMeta, Type[DeclarativeBase]]
 GenericColumn = Union[Column, InstrumentedAttribute]
 GenericExpression = Union[BinaryExpression, ColumnOperators]
 OperatorFnMap = Dict[str, Callable[[GenericColumn, Any], GenericExpression]]
@@ -583,10 +615,11 @@ _allow_types = frozenset(
 
 def _get_table_name(t: GenericTable) -> str:
     try:
-        # `DeclarativeMeta` type
+        # ORM model, declared either way: both `DeclarativeMeta` and
+        # `DeclarativeBase` styles carry the mapped `Table` on `__table__`.
         return t.__table__.name
     except AttributeError:
-        # `Table` type
+        # Core `Table` type
         return t.name
 
 
@@ -620,6 +653,33 @@ def _variables_outside_overrides(
     return variables
 
 
+# An ORM model class carries its row type; a Core `Table` does not. Overloading on
+# that distinction lets `session.execute(...).scalars()` infer the model instead of
+# `Any`, without asking the caller to annotate the result.
+@overload
+def get_query(
+    query_plan: Union[PlanResourcesResponse, response_pb2.PlanResourcesResponse],  # type: ignore (https://github.com/microsoft/pyright/issues/1035)
+    table: Type[_ORMModel],
+    attr_map: Dict[str, GenericColumn],
+    table_mapping: Union[List[Tuple[GenericTable, GenericExpression]], None] = ...,
+    operator_override_fns: Union[OperatorFnMap, None] = ...,
+    null_attribute_representation: NullAttributeRepresentation = ...,
+) -> Select[Tuple[_ORMModel]]:
+    ...
+
+
+@overload
+def get_query(
+    query_plan: Union[PlanResourcesResponse, response_pb2.PlanResourcesResponse],  # type: ignore (https://github.com/microsoft/pyright/issues/1035)
+    table: Table,
+    attr_map: Dict[str, GenericColumn],
+    table_mapping: Union[List[Tuple[GenericTable, GenericExpression]], None] = ...,
+    operator_override_fns: Union[OperatorFnMap, None] = ...,
+    null_attribute_representation: NullAttributeRepresentation = ...,
+) -> Select[Any]:
+    ...
+
+
 def get_query(
     query_plan: Union[PlanResourcesResponse, response_pb2.PlanResourcesResponse],  # type: ignore (https://github.com/microsoft/pyright/issues/1035)
     table: GenericTable,
@@ -627,7 +687,7 @@ def get_query(
     table_mapping: Union[List[Tuple[GenericTable, GenericExpression]], None] = None,
     operator_override_fns: Union[OperatorFnMap, None] = None,
     null_attribute_representation: NullAttributeRepresentation = "explicit",
-) -> Select:
+) -> Select[Any]:
     """Translate a Cerbos query plan into a SQLAlchemy ``Select``.
 
     ``null_attribute_representation`` declares how the caller represents a NULL

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -8,9 +8,11 @@ from types import MappingProxyType
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Dict,
     List,
     Literal,
+    Protocol,
     Tuple,
     Type,
     TypeVar,
@@ -44,7 +46,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeMeta, InstrumentedAttribute
 from sqlalchemy.sql import Select
-from sqlalchemy.sql.expression import BinaryExpression, ColumnOperators
+from sqlalchemy.sql.expression import BinaryExpression, ColumnOperators, FromClause
 
 try:  # SQLAlchemy >= 2.0
     from sqlalchemy.orm import DeclarativeBase
@@ -54,7 +56,19 @@ except ImportError:  # SQLAlchemy 1.4 predates the class-based declarative base.
         """Stand-in so ``GenericTable`` stays constructible under SQLAlchemy 1.4."""
 
 
-_ORMModel = TypeVar("_ORMModel")
+class _MappedClass(Protocol):
+    """What `get_query` actually needs of an ORM model: a mapped `__table__`.
+
+    Structural rather than nominal because the two declarative styles share no
+    base class. Bounding the overload's TypeVar on it keeps unmapped classes out
+    — unbounded, `Type[_ORMModel]` would admit any class at all, which is looser
+    than the union it replaced.
+    """
+
+    __table__: ClassVar[FromClause]
+
+
+_ORMModel = TypeVar("_ORMModel", bound=_MappedClass)
 
 # A 2.0-style model's metaclass (`DeclarativeAttributeIntercept`) is *not* a
 # `DeclarativeMeta`, so the legacy member alone does not admit it.
@@ -659,10 +673,14 @@ def get_query(
     ...
 
 
+# Everything else `GenericTable` admits — a Core `Table`, and a legacy model
+# under 1.4, whose stubs do not declare `__table__` so it cannot match the bound
+# above. Row type unknown, but the call is still accepted: without this arm the
+# overloads would be narrower than the union they replaced.
 @overload
 def get_query(
     query_plan: Union[PlanResourcesResponse, response_pb2.PlanResourcesResponse],  # type: ignore (https://github.com/microsoft/pyright/issues/1035)
-    table: Table,
+    table: GenericTable,
     attr_map: Dict[str, GenericColumn],
     table_mapping: Union[List[Tuple[GenericTable, GenericExpression]], None] = ...,
     operator_override_fns: Union[OperatorFnMap, None] = ...,

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -51,20 +51,13 @@ try:  # SQLAlchemy >= 2.0
 except ImportError:  # SQLAlchemy 1.4 predates the class-based declarative base.
 
     class DeclarativeBase:  # type: ignore[no-redef]
-        """Stand-in so ``GenericTable`` stays constructible under SQLAlchemy 1.4.
-
-        Nothing subclasses it there, so including it in the union is inert; it
-        exists only to keep this module importable on the older release the
-        package still supports.
-        """
+        """Stand-in so ``GenericTable`` stays constructible under SQLAlchemy 1.4."""
 
 
 _ORMModel = TypeVar("_ORMModel")
 
-# A model declared the 2.0 way subclasses `DeclarativeBase`, whose metaclass
-# (`DeclarativeAttributeIntercept`) is *not* a `DeclarativeMeta`, so the legacy
-# `declarative_base()` member alone does not admit it. Both spellings are
-# accepted, alongside a Core `Table`.
+# A 2.0-style model's metaclass (`DeclarativeAttributeIntercept`) is *not* a
+# `DeclarativeMeta`, so the legacy member alone does not admit it.
 GenericTable = Union[Table, DeclarativeMeta, Type[DeclarativeBase]]
 GenericColumn = Union[Column, InstrumentedAttribute]
 GenericExpression = Union[BinaryExpression, ColumnOperators]
@@ -615,8 +608,7 @@ _allow_types = frozenset(
 
 def _get_table_name(t: GenericTable) -> str:
     try:
-        # ORM model, declared either way: both `DeclarativeMeta` and
-        # `DeclarativeBase` styles carry the mapped `Table` on `__table__`.
+        # ORM model — both declarative styles carry the mapped `Table` here
         return t.__table__.name
     except AttributeError:
         # Core `Table` type
@@ -654,8 +646,7 @@ def _variables_outside_overrides(
 
 
 # An ORM model class carries its row type; a Core `Table` does not. Overloading on
-# that distinction lets `session.execute(...).scalars()` infer the model instead of
-# `Any`, without asking the caller to annotate the result.
+# that distinction lets callers infer the model rather than annotate the result.
 @overload
 def get_query(
     query_plan: Union[PlanResourcesResponse, response_pb2.PlanResourcesResponse],  # type: ignore (https://github.com/microsoft/pyright/issues/1035)

--- a/sqlalchemy/tests/conftest.py
+++ b/sqlalchemy/tests/conftest.py
@@ -63,6 +63,67 @@ class Resource(Base):
     creator = relationship("User", foreign_keys=[createdBy])
 
 
+# The SQLAlchemy 2.0 declarative style, mapped onto parallel tables holding the
+# same rows. `DeclarativeBase` subclasses are not `DeclarativeMeta` instances, so
+# they exercise a genuinely different arm of `GenericTable` — see
+# https://github.com/cerbos/query-plan-adapters/issues/181.
+try:
+    from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+    class ModernBase(DeclarativeBase):
+        pass
+
+    class ModernUser(ModernBase):
+        __tablename__ = "modern_user"
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+
+    class ModernResource(ModernBase):
+        __tablename__ = "modern_resource"
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+        name: Mapped[str] = mapped_column(String(30))
+        aBool: Mapped[bool] = mapped_column(Boolean)
+        aString: Mapped[str] = mapped_column(String)
+        aNumber: Mapped[int] = mapped_column(Integer)
+
+        ownedBy: Mapped[str] = mapped_column(String, ForeignKey("modern_user.id"))
+        createdBy: Mapped[str] = mapped_column(String, ForeignKey("modern_user.id"))
+
+    HAS_DECLARATIVE_BASE = True
+except ImportError:  # SQLAlchemy 1.4
+    ModernBase = ModernUser = ModernResource = None
+    HAS_DECLARATIVE_BASE = False
+
+
+_RESOURCE_ROWS = [
+    {
+        "name": "resource1",
+        "aBool": True,
+        "aString": "string",
+        "aNumber": 1,
+        "ownedBy": "1",
+        "createdBy": "1",
+    },
+    {
+        "name": "resource2",
+        "aBool": False,
+        "aString": "amIAString?",
+        "aNumber": 2,
+        "ownedBy": "1",
+        "createdBy": "2",
+    },
+    {
+        "name": "resource3",
+        "aBool": True,
+        "aString": "anotherString",
+        "aNumber": 3,
+        "ownedBy": "2",
+        "createdBy": "2",
+    },
+]
+
+
 @pytest.fixture(scope="module")
 def engine():
     # in-memory database
@@ -78,6 +139,8 @@ def engine():
 
     # generate tables from sqla metadata
     Base.metadata.create_all(engine)
+    if HAS_DECLARATIVE_BASE:
+        ModernBase.metadata.create_all(engine)
 
     # Populate with test data
     with engine.connect() as conn:
@@ -88,35 +151,14 @@ def engine():
                 {"id": "2", "name": "user2", "role": "user"},
             ],
         )
-        conn.execute(
-            insert(Resource.__table__),
-            [
-                {
-                    "name": "resource1",
-                    "aBool": True,
-                    "aString": "string",
-                    "aNumber": 1,
-                    "ownedBy": "1",
-                    "createdBy": "1",
-                },
-                {
-                    "name": "resource2",
-                    "aBool": False,
-                    "aString": "amIAString?",
-                    "aNumber": 2,
-                    "ownedBy": "1",
-                    "createdBy": "2",
-                },
-                {
-                    "name": "resource3",
-                    "aBool": True,
-                    "aString": "anotherString",
-                    "aNumber": 3,
-                    "ownedBy": "2",
-                    "createdBy": "2",
-                },
-            ],
-        )
+        conn.execute(insert(Resource.__table__), _RESOURCE_ROWS)
+
+        if HAS_DECLARATIVE_BASE:
+            conn.execute(
+                insert(ModernUser.__table__),
+                [{"id": "1"}, {"id": "2"}],
+            )
+            conn.execute(insert(ModernResource.__table__), _RESOURCE_ROWS)
 
         if not _is_sqla_14():
             conn.commit()
@@ -138,6 +180,20 @@ def user_table():
 @pytest.fixture
 def resource_table():
     return Resource
+
+
+@pytest.fixture
+def modern_user_table():
+    if not HAS_DECLARATIVE_BASE:
+        pytest.skip("DeclarativeBase requires SQLAlchemy >= 2.0")
+    return ModernUser
+
+
+@pytest.fixture
+def modern_resource_table():
+    if not HAS_DECLARATIVE_BASE:
+        pytest.skip("DeclarativeBase requires SQLAlchemy >= 2.0")
+    return ModernResource
 
 
 @contextmanager

--- a/sqlalchemy/tests/conftest.py
+++ b/sqlalchemy/tests/conftest.py
@@ -182,17 +182,31 @@ def resource_table():
     return Resource
 
 
+def _require_declarative_base() -> None:
+    """Skip on 1.4, but fail loudly if 2.0 could not build the models.
+
+    Keyed on the installed version rather than on `HAS_DECLARATIVE_BASE`: were it
+    keyed on the import result, a typo or an upstream rename would turn the whole
+    2.0 leg into silent skips and CI would stay green with the models never
+    exercised.
+    """
+    if _is_sqla_14():
+        pytest.skip("DeclarativeBase requires SQLAlchemy >= 2.0")
+    assert HAS_DECLARATIVE_BASE, (
+        "SQLAlchemy >= 2.0 is installed but the DeclarativeBase models failed to "
+        "import — the 2.0 declarative tests would otherwise skip silently"
+    )
+
+
 @pytest.fixture
 def modern_user_table():
-    if not HAS_DECLARATIVE_BASE:
-        pytest.skip("DeclarativeBase requires SQLAlchemy >= 2.0")
+    _require_declarative_base()
     return ModernUser
 
 
 @pytest.fixture
 def modern_resource_table():
-    if not HAS_DECLARATIVE_BASE:
-        pytest.skip("DeclarativeBase requires SQLAlchemy >= 2.0")
+    _require_declarative_base()
     return ModernResource
 
 

--- a/sqlalchemy/tests/conftest.py
+++ b/sqlalchemy/tests/conftest.py
@@ -64,9 +64,8 @@ class Resource(Base):
 
 
 # The SQLAlchemy 2.0 declarative style, mapped onto parallel tables holding the
-# same rows. `DeclarativeBase` subclasses are not `DeclarativeMeta` instances, so
-# they exercise a genuinely different arm of `GenericTable` — see
-# https://github.com/cerbos/query-plan-adapters/issues/181.
+# same rows. These are not `DeclarativeMeta` instances, so they exercise a
+# different arm of `GenericTable` (#181).
 try:
     from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -185,10 +184,9 @@ def resource_table():
 def _require_declarative_base() -> None:
     """Skip on 1.4, but fail loudly if 2.0 could not build the models.
 
-    Keyed on the installed version rather than on `HAS_DECLARATIVE_BASE`: were it
-    keyed on the import result, a typo or an upstream rename would turn the whole
-    2.0 leg into silent skips and CI would stay green with the models never
-    exercised.
+    Keyed on the installed version, not on `HAS_DECLARATIVE_BASE`: keyed on the
+    import result, a rename upstream would turn the whole 2.0 leg into silent
+    skips and leave CI green with the models never exercised.
     """
     if _is_sqla_14():
         pytest.skip("DeclarativeBase requires SQLAlchemy >= 2.0")

--- a/sqlalchemy/tests/test_query.py
+++ b/sqlalchemy/tests/test_query.py
@@ -1701,10 +1701,9 @@ class TestDeclarativeStyles:
         )
 
     def test_declarative_base_is_not_a_declarative_meta(self, modern_resource_table):
-        # Pins *why* `GenericTable` needs the extra member. If SQLAlchemy ever
+        # Pins *why* `GenericTable` needs the extra member: if SQLAlchemy ever
         # folds the 2.0 metaclass back under `DeclarativeMeta`, this fails and
-        # the union member becomes removable — rather than the two spellings
-        # quietly collapsing and leaving an untested branch behind.
+        # the member becomes removable.
         from sqlalchemy.orm import DeclarativeBase, DeclarativeMeta
 
         assert issubclass(modern_resource_table, DeclarativeBase)
@@ -1717,24 +1716,6 @@ class TestDeclarativeStyles:
             {"request.resource.attr.aBool": modern_resource_table.aBool},
         )
         assert {row.name for row in conn.execute(query)} == {"resource1", "resource3"}
-
-    def test_declarative_base_always_allowed_and_denied(
-        self, modern_resource_table, conn
-    ):
-        allow = PlanResourcesResponse(
-            filter=PlanResourcesFilter.from_dict(
-                {"kind": PlanResourcesFilterKind.ALWAYS_ALLOWED}
-            ),
-            **_default_resp_params(),
-        )
-        deny = PlanResourcesResponse(
-            filter=PlanResourcesFilter.from_dict(
-                {"kind": PlanResourcesFilterKind.ALWAYS_DENIED}
-            ),
-            **_default_resp_params(),
-        )
-        assert len(conn.execute(get_query(allow, modern_resource_table, {})).all()) == 3
-        assert len(conn.execute(get_query(deny, modern_resource_table, {})).all()) == 0
 
     def test_declarative_base_cross_table_mapping(
         self, modern_resource_table, modern_user_table, conn

--- a/sqlalchemy/tests/test_query.py
+++ b/sqlalchemy/tests/test_query.py
@@ -10,7 +10,7 @@ from cerbos.sdk.model import (
 from google.protobuf.json_format import MessageToDict
 
 from cerbos_sqlalchemy import get_query
-from sqlalchemy import DateTime, String, any_, column, func, literal, table
+from sqlalchemy import Boolean, DateTime, String, any_, column, func, literal, table
 from sqlalchemy.dialects import postgresql
 
 
@@ -1677,3 +1677,120 @@ class TestKnownValueCollections:
             operator_override_fns={"exists": lambda c, v: literal(True)},
         )
         assert [row.name for row in conn.execute(query)] == ["resource1"]
+
+
+class TestDeclarativeStyles:
+    """`get_query` accepts a model declared either declarative way, plus a Core `Table`.
+
+    SQLAlchemy 2.0's `DeclarativeBase` is not a `declarative_base()` model in
+    disguise: its metaclass sits outside the `DeclarativeMeta` hierarchy, so a
+    2.0-style model is a distinct arm of `GenericTable` rather than a relabelled
+    one (cerbos/query-plan-adapters#181).
+    """
+
+    @staticmethod
+    def _eq_bool_plan():
+        return _conditional_plan(
+            {
+                "operator": "eq",
+                "operands": [
+                    {"variable": "request.resource.attr.aBool"},
+                    {"value": True},
+                ],
+            }
+        )
+
+    def test_declarative_base_is_not_a_declarative_meta(self, modern_resource_table):
+        # Pins *why* `GenericTable` needs the extra member. If SQLAlchemy ever
+        # folds the 2.0 metaclass back under `DeclarativeMeta`, this fails and
+        # the union member becomes removable — rather than the two spellings
+        # quietly collapsing and leaving an untested branch behind.
+        from sqlalchemy.orm import DeclarativeBase, DeclarativeMeta
+
+        assert issubclass(modern_resource_table, DeclarativeBase)
+        assert not isinstance(modern_resource_table, DeclarativeMeta)
+
+    def test_declarative_base_model_filters(self, modern_resource_table, conn):
+        query = get_query(
+            self._eq_bool_plan(),
+            modern_resource_table,
+            {"request.resource.attr.aBool": modern_resource_table.aBool},
+        )
+        assert {row.name for row in conn.execute(query)} == {"resource1", "resource3"}
+
+    def test_declarative_base_always_allowed_and_denied(
+        self, modern_resource_table, conn
+    ):
+        allow = PlanResourcesResponse(
+            filter=PlanResourcesFilter.from_dict(
+                {"kind": PlanResourcesFilterKind.ALWAYS_ALLOWED}
+            ),
+            **_default_resp_params(),
+        )
+        deny = PlanResourcesResponse(
+            filter=PlanResourcesFilter.from_dict(
+                {"kind": PlanResourcesFilterKind.ALWAYS_DENIED}
+            ),
+            **_default_resp_params(),
+        )
+        assert len(conn.execute(get_query(allow, modern_resource_table, {})).all()) == 3
+        assert len(conn.execute(get_query(deny, modern_resource_table, {})).all()) == 0
+
+    def test_declarative_base_cross_table_mapping(
+        self, modern_resource_table, modern_user_table, conn
+    ):
+        # Exercises `_get_table_name` on both sides of the mapping: the root
+        # model and the joined one are both 2.0-style.
+        plan = _conditional_plan(
+            {
+                "operator": "eq",
+                "operands": [
+                    {"variable": "request.resource.attr.ownerId"},
+                    {"value": 1},
+                ],
+            }
+        )
+        query = get_query(
+            plan,
+            modern_resource_table,
+            {"request.resource.attr.ownerId": modern_user_table.id},
+            [
+                (
+                    modern_user_table,
+                    modern_resource_table.ownedBy == modern_user_table.id,
+                )
+            ],
+        )
+        assert {row.name for row in conn.execute(query)} == {"resource1", "resource2"}
+
+    def test_declarative_base_missing_table_mapping_still_fails_closed(
+        self, modern_resource_table, modern_user_table
+    ):
+        plan = _conditional_plan(
+            {
+                "operator": "eq",
+                "operands": [
+                    {"variable": "request.resource.attr.ownerId"},
+                    {"value": 1},
+                ],
+            }
+        )
+        with pytest.raises(TypeError, match="table_mapping"):
+            get_query(
+                plan,
+                modern_resource_table,
+                {"request.resource.attr.ownerId": modern_user_table.id},
+            )
+
+    def test_core_table_still_supported(self, conn):
+        core_resource = table(
+            "resource",
+            column("name", String),
+            column("aBool", Boolean),
+        )
+        query = get_query(
+            self._eq_bool_plan(),
+            core_resource,
+            {"request.resource.attr.aBool": core_resource.c.aBool},
+        )
+        assert {row.name for row in conn.execute(query)} == {"resource1", "resource3"}

--- a/sqlalchemy/tests/typing/check_types.py
+++ b/sqlalchemy/tests/typing/check_types.py
@@ -1,0 +1,65 @@
+"""Static conformance for `get_query`'s public signature.
+
+Checked by pyright (see `sqlalchemy/pyrightconfig.json`), not by pytest — the
+claims in this file are about what a *type checker* infers, so the runtime suite
+cannot prove any of them. Every assertion here failed at least one way before
+the signature it pins was written.
+
+The negative case carries a `pyright: ignore`, and `reportUnnecessaryTypeIgnore
+Comment` is on: if `get_query` ever stops rejecting an unmapped class, the
+suppression becomes unnecessary and pyright fails the file. A negative test that
+silently stops testing anything is the failure mode this guards.
+
+Run against SQLAlchemy >= 2.0 only. 1.4 ships no `DeclarativeBase` and does not
+declare `__table__` on mapped classes, so none of these inferences hold there —
+1.4 callers get the untyped `Select[Any]` overload, exactly as before #181.
+"""
+
+from typing import Any, Tuple, cast
+
+from cerbos.sdk.model import PlanResourcesResponse
+from typing_extensions import assert_type
+
+from cerbos_sqlalchemy import get_query
+from sqlalchemy import Column, Integer, MetaData, String, Table
+from sqlalchemy.orm import DeclarativeBase, declarative_base
+from sqlalchemy.sql import Select
+
+LegacyBase = declarative_base()
+
+
+class LegacyModel(LegacyBase):
+    __tablename__ = "legacy"
+
+    id = Column(Integer, primary_key=True)
+
+
+class ModernBase(DeclarativeBase):
+    pass
+
+
+class ModernModel(ModernBase):
+    __tablename__ = "modern"
+
+    id = Column(Integer, primary_key=True)
+
+
+core_table = Table("core", MetaData(), Column("id", Integer), Column("name", String))
+
+plan = cast(PlanResourcesResponse, None)
+
+
+# A 2.0 `DeclarativeBase` model is accepted and keeps its row type (#181).
+assert_type(get_query(plan, ModernModel, {}), Select[Tuple[ModernModel]])
+
+# So is a legacy `declarative_base()` model — the two share no base class, which
+# is why the bound is structural.
+assert_type(get_query(plan, LegacyModel, {}), Select[Tuple[LegacyModel]])
+
+# A Core `Table` carries no row type, so it resolves to the untyped overload.
+assert_type(get_query(plan, core_table, {}), Select[Any])
+
+# An unmapped class must NOT be accepted. Before the TypeVar was bounded, an
+# unconstrained `Type[_ORMModel]` admitted every class and inferred
+# `Select[Tuple[str]]` — looser than the union the overloads replaced.
+get_query(plan, str, {})  # pyright: ignore[reportCallIssue, reportArgumentType]


### PR DESCRIPTION
Closes #181.

## What

`get_query`'s `table` argument was typed `Union[Table, DeclarativeMeta]`. That excludes every model declared the SQLAlchemy 2.0 way: a `DeclarativeBase` subclass is **not** a `DeclarativeMeta` instance — its metaclass is `DeclarativeAttributeIntercept`, which sits outside that hierarchy — so passing one was a type error even though it has always worked at runtime.

The return type was a bare `Select`, which erases the row type and forces callers to annotate results by hand.

## Changes

- `GenericTable` gains `Type[DeclarativeBase]`, imported behind a `try/except ImportError` so the module still imports on SQLAlchemy 1.4, where the class does not exist and the union member is inert.
- `get_query` is overloaded: an ORM model resolves to `Select[Tuple[Model]]`, everything else `GenericTable` admits to `Select[Any]`. The model overload's TypeVar is bounded on a `_MappedClass` protocol requiring `__table__`, so unmapped classes are rejected rather than silently accepted.
- `from __future__ import annotations` keeps the subscripted `Select[...]` form lazy, so nothing evaluates it on 1.4.
- README documents the accepted model styles and what each returns.
- CI runs the suite against **both SQLAlchemy 1.4 and 2.x**, and type-checks the public signature with pyright.

## Affected adapters

sqlalchemy only. **No behaviour change** — this is a typing fix. `_get_table_name` already read `__table__`, which both declarative styles carry, so the runtime path was correct all along; only the declared type disagreed.

## Contract, before and after

| caller passes | before | after |
|---|---|---|
| 2.0 `DeclarativeBase` model | type error | `Select[Tuple[Model]]` |
| legacy `declarative_base()` model, 2.x | `Select` | `Select[Tuple[Model]]` |
| legacy `declarative_base()` model, 1.4 | `Select` | `Select[Any]` (unchanged in practice) |
| Core `Table` | `Select` | `Select[Any]` |
| unmapped class (e.g. `str`) | rejected | rejected |

Nothing that used to type-check stops doing so.

## Tests

`tests/conftest.py` gains 2.0-style `DeclarativeBase` models on parallel tables holding the same rows (skipped on 1.4). `TestDeclarativeStyles` covers filtering through a 2.0-style model, cross-table `table_mapping` with 2.0-style models on both sides (the `_get_table_name` path), the fail-closed `TypeError` when that mapping is missing, and a Core `Table` still translating — plus a pin that the 2.0 metaclass really is outside `DeclarativeMeta`, so the extra union member cannot go quietly untested if SQLAlchemy ever collapses the two.

`tests/typing/check_types.py` is checked by **pyright**, not pytest: the overloads are a static contract the runtime suite cannot reach, which is exactly why the first version of them shipped with an unbounded TypeVar that accepted `get_query(plan, str, {})`. `assert_type` pins the inferred return for each accepted shape, and the unmapped-class rejection is pinned by a `pyright: ignore` under `reportUnnecessaryTypeIgnoreComment` — if the rejection ever stops happening, the suppression becomes unnecessary and the file fails. Verified by removing the bound: pyright fails with exactly those two errors.

No conformance-corpus change: this touches no operator, condition or expression translation.

## CI: both supported SQLAlchemy lines

`pyproject.toml` declares `sqlalchemy>=1.4`, but the workflow only ever ran the version pinned in `pdm.lock` (2.0.25) — so half the supported range was unproven, and this PR adds handling for a class that exists on exactly one side of that split.

`sqlalchemy_pr.yaml` is now a matrix:

- **2.x** installs from the committed lockfile, unchanged, and additionally runs pyright.
- **1.4** re-resolves under a `sqlalchemy<2` constraint into a throwaway lockfile (`pdm install --override … --lockfile …`), so `pdm.lock` stays the single pinned source of truth and there is no second lockfile to keep in step.
- A version assertion runs between install and test, so a constraint that failed to apply fails the job instead of quietly running 2.x twice.

The `DeclarativeBase` test skip is keyed on the **installed version**, not on whether the model import succeeded — keyed on the import, a rename upstream would turn the whole 2.x leg into silent skips and leave CI green with the models never exercised.

**Worth a reviewer's opinion:** the 1.4 leg deliberately re-resolves its whole dependency graph rather than installing a pinned one, so an unrelated upstream release can turn it red. That is arguably the right signal — `pdm.lock` is a dev lockfile, the published wheel only declares `sqlalchemy>=1.4`, so a fresh resolve is what a 1.4 consumer actually gets — but if you would rather have determinism, the alternative is committing a second `pdm.sqla14.lock` that renovate will not maintain.

## Verification

| SQLAlchemy | Result |
|---|---|
| 1.4.54 | 277 passed, 4 skipped |
| 2.0.25 (locked) | 281 passed |
| 2.1.0b3 | 281 passed |

```
npx pyright                                 # 0 errors
pdm run format                              # isort + black clean
../conformance/scripts/validate-corpus.sh   # Corpus valid: 127 actions, 20 seeds
```

## Note for the reviewer: SQLAlchemy 2.1

`Select[Tuple[T]]` is correct for every stable release — 2.1 is still beta (latest stable is 2.0.51). In 2.1, `Select` becomes `TypedReturnsRows[Unpack[_Ts]]`, so the correct spelling there is `Select[T]` and the two cannot be satisfied by one annotation.

Nothing to do now: the runtime suite already passes on 2.1.0b3 (annotations are lazy under `from __future__ import annotations`, so the mismatch is static-only). When 2.1 ships stable this needs a deliberate call — raise the floor and switch to `Select[T]`, or drop back to `Select[Any]` — alongside the rest of the 2.1 compatibility pass.