### PR TITLE
fix: make fail-closed shapes throw at translation, and prove it across every harness

### DIFF
--- a/conformance/actions.json
+++ b/conformance/actions.json
@@ -366,7 +366,10 @@
     "convex": [
       { "action": "p-index", "reason": "Convex queries can apply the adapter's explicit post-filter for list indexing" },
       { "action": "p-matches", "reason": "Convex queries can apply the adapter's explicit post-filter for regular-expression matching" },
-      { "action": "p-timestamp", "reason": "Convex queries can apply the adapter's explicit post-filter for timestamp comparisons" }
+      { "action": "p-timestamp", "reason": "Convex queries can apply the adapter's explicit post-filter for timestamp comparisons" },
+      { "action": "cast-int-string", "reason": "The adapter's explicit post-filter reimplements CEL int() over strings exactly (whole-string parse or error-deny), so the SQL leading-digits divergence does not apply" },
+      { "action": "cast-double-string", "reason": "The adapter's explicit post-filter reimplements CEL double() over strings exactly (whole-string parse or error-deny), so the SQL leading-digits divergence does not apply" },
+      { "action": "cast-int-double", "reason": "The adapter's explicit post-filter reimplements CEL int() truncation toward zero, so the SQL CAST round-to-nearest divergence does not apply" }
     ]
   },
   "expectedUnsupported": [

--- a/conformance/scripts/validate-corpus.sh
+++ b/conformance/scripts/validate-corpus.sh
@@ -133,24 +133,46 @@ for action in ts-window ts-vf; do
   fi
 done
 
-# CERBOS_VERSION is the single source of truth for the pinned PDP: every workflow reads it,
-# as does spring-data's CerbosTestImage. A Compose file cannot read another file, so the two
-# spring-data copies are asserted to agree instead of de-duplicated.
+# CERBOS_VERSION is the single source of truth for the pinned PDP: every workflow and test
+# harness reads it. Some files cannot read another file (Compose files, echo strings, go.mod
+# requirements), so every hardcoded restatement anywhere in the repository is asserted to
+# agree instead of de-duplicated. A repo-wide scan rather than a fixed path list: the fixed
+# list once missed spring-data/example/docker-compose.yml running `latest` in CI.
 pinned_version="$(tr -d '[:space:]' <CERBOS_VERSION)"
+REPO_ROOT="$(cd "${CONFORMANCE_DIR}/.." && pwd)"
 
-compose_version="$(sed -n 's|^[[:space:]]*image:[[:space:]]*ghcr\.io/cerbos/cerbos:\([^@[:space:]]*\).*|\1|p' \
-  ../spring-data/docker-compose.yml)"
-if [[ "${compose_version}" != "${pinned_version}" ]]; then
-  echo "spring-data/docker-compose.yml pins Cerbos ${compose_version:-<none>}, expected ${pinned_version} (conformance/CERBOS_VERSION)"
+version_drift=0
+while IFS=: read -r file _ match; do
+  # Extract the tag: everything after the last `cerbos:` up to a digest/quote/space/paren.
+  tag="$(printf '%s' "${match}" | sed -n 's|.*ghcr\.io/cerbos/cerbos:\([^@)"'\''[:space:]]*\).*|\1|p')"
+  [[ -z "${tag}" ]] && continue
+  # Workflow/script interpolations (`cerbos:${CERBOS_VERSION}` and language equivalents)
+  # read the pinned file at runtime and cannot drift.
+  case "${tag}" in
+    '$'*|'%'*|'{'*) continue ;;
+  esac
+  if [[ "${tag}" != "${pinned_version}" ]]; then
+    echo "${file#"${REPO_ROOT}"/} pins Cerbos '${tag}', expected ${pinned_version} (conformance/CERBOS_VERSION)"
+    version_drift=1
+  fi
+done < <(grep -rn 'ghcr\.io/cerbos/cerbos:' "${REPO_ROOT}" \
+  --include='*.yml' --include='*.yaml' --include='*.sh' \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.claude --exclude-dir=lib \
+  --exclude-dir=build --exclude-dir=.venv --exclude-dir=.gradle --exclude-dir=bin || true)
+if [[ "${version_drift}" -ne 0 ]]; then
   exit 1
 fi
 
-e2e_version="$(sed -n 's|.*ghcr\.io/cerbos/cerbos:\([0-9][^@)"[:space:]]*\).*|\1|p' \
-  ../spring-data/scripts/run-e2e.sh | sort -u)"
-if [[ "${e2e_version}" != "${pinned_version}" ]]; then
-  echo "spring-data/scripts/run-e2e.sh names Cerbos ${e2e_version:-<none>}, expected ${pinned_version} (conformance/CERBOS_VERSION)"
-  exit 1
-fi
+# The Go modules pin the Cerbos wire gencode (cerbos/api/genpb) separately from the PDP
+# image; a CERBOS_VERSION bump that leaves a stale genpb would silently test new planner
+# output against old generated types.
+for gomod in "${REPO_ROOT}"/ent/go.mod "${REPO_ROOT}"/pgx/go.mod; do
+  genpb_version="$(sed -n 's|.*github\.com/cerbos/cerbos/api/genpb v\([^[:space:]]*\).*|\1|p' "${gomod}")"
+  if [[ -n "${genpb_version}" && "${genpb_version}" != "${pinned_version}" ]]; then
+    echo "${gomod#"${REPO_ROOT}"/} pins cerbos/api/genpb v${genpb_version}, expected ${pinned_version} (conformance/CERBOS_VERSION)"
+    exit 1
+  fi
+done
 
 seed_count="$(jq '.seeds | length' seeds.json)"
 unique_seed_count="$(jq -r '.seeds[].id' seeds.json | sort -u | wc -l | tr -d '[:space:]')"

--- a/convex/README.md
+++ b/convex/README.md
@@ -110,8 +110,8 @@ The adapter is differentially tested with 20 hostile seed documents against Cerb
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 128 of the 130 reference conformance actions, plus `matches()`, list indexing/`get-field`, and `timestamp()` plans that the Spring Data reference adapter rejects (131 actions total) |
-| Fail-closed | `int()`/`double()` casts and `filter()`/`map()` used as a condition, plus a constant zero divisor whose sign the JSON hop into a Convex function discards (7 actions); unknown operators and invalid expression structures still throw |
+| Oracle-tested | 128 of the 130 reference conformance actions, plus `matches()`, list indexing/`get-field`, `timestamp()`, and `int()`/`double()` cast plans that the Spring Data reference adapter rejects — the post-filter reimplements CEL cast semantics exactly (whole-string parse, truncation toward zero), so the SQL divergences do not apply (134 actions total) |
+| Fail-closed | `filter()`/`map()` used as a condition (they return a list, not a boolean) and a constant zero divisor whose sign the JSON hop into a Convex function discards (4 actions). All four throw during translation, before any filter exists; unknown operators and invalid expression structures still throw |
 | Explicit opt-in | Any plan that cannot be represented entirely as a Convex database filter requires `allowPostFilter: true` |
 | Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`. Under the default it already returns the empty set the PDP demands *when the document omits the field for a NULL value*, which is what the conformance harness seeds; a deployment that stores explicit nulls while omitting the attribute would over-grant |
 | Known planner divergence | `has()` on a missing attribute is currently folded by the Cerbos planner to `ALWAYS_ALLOWED`; `checkResource` still denies documents where the attribute is missing. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |

--- a/convex/convex/adversarial.ts
+++ b/convex/convex/adversarial.ts
@@ -44,7 +44,9 @@ const document = {
   mainCategory: v.optional(mainCategory),
 };
 
-const MAPPER: Mapper = {
+// Exported so the adversarial throw suite can invoke translation with the exact mapper the
+// backend uses — a duplicated copy would be a projection that can drift.
+export const MAPPER: Mapper = {
   "request.resource.attr.aBool": { field: "aBool" },
   "request.resource.attr.aString": { field: "aString" },
   "request.resource.attr.aNumber": { field: "aNumber" },

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -7,7 +7,8 @@ import { GRPC as Cerbos } from "@cerbos/grpc";
 import { ConvexHttpClient } from "convex/browser";
 
 import { api } from "../convex/_generated/api.js";
-import { PlanKind } from ".";
+import { MAPPER } from "../convex/adversarial";
+import { PlanKind, queryPlanToConvex } from ".";
 
 const CONVEX_URL = process.env["CONVEX_URL"] ?? "http://127.0.0.1:3210";
 const convex = new ConvexHttpClient(CONVEX_URL);
@@ -152,6 +153,10 @@ const isActionsFile = (value: unknown): value is ActionsFile =>
   isAdapterMap(value["adapterSupportedExpected"]) &&
   Array.isArray(value["expectedUnsupported"]) &&
   value["expectedUnsupported"].every(isExpectedUnsupported) &&
+  // Every group the interface declares must be validated: a group this predicate does not
+  // name is the projection trap the corpus README warns about.
+  Array.isArray(value["nullRepresentationOmitted"]) &&
+  value["nullRepresentationOmitted"].every(isAdapterOutcome) &&
   Array.isArray(value["knownDivergences"]) &&
   value["knownDivergences"].every(isKnownDivergence);
 
@@ -201,7 +206,11 @@ const MANIFEST_ACTIONS = new Set([
   ...actionsFile.conformance,
   ...actionsFile.expectedUnsupported.map((entry) => entry.action),
   ...NULL_REPRESENTATION_OMITTED.map((entry) => entry.action),
-  ...KNOWN_DIVERGENCES,
+  // ALL divergences, not just Convex's: a divergence registered solely for another adapter
+  // must still enter this manifest, so the size tripwire and the classified-exactly-once
+  // check flag it for triage here instead of letting the action silently vanish from this
+  // harness. Classification/skipping still uses the Convex-filtered KNOWN_DIVERGENCES.
+  ...actionsFile.knownDivergences.map((entry) => entry.action),
 ]);
 
 function doubleFor(seed: Seed): number | null {
@@ -440,11 +449,51 @@ describe("adversarial conformance corpus", () => {
 
     expect(allActions.size).toBe(140);
     expect(CONVEX_UNSUPPORTED).toHaveLength(2);
-    expect(CONVEX_SUPPORTED_EXPECTED).toHaveLength(3);
-    expect(ORACLE_ACTIONS).toHaveLength(131);
-    expect(THROWING_ACTIONS).toHaveLength(7);
+    expect(CONVEX_SUPPORTED_EXPECTED).toHaveLength(6);
+    expect(ORACLE_ACTIONS).toHaveLength(134);
+    expect(THROWING_ACTIONS).toHaveLength(4);
     expect(misclassified).toEqual([]);
   });
+
+  // The message each throwing action must fail with. Pinning the message is what proves the
+  // rejection happens for the DECLARED mechanism — a bare "it threw" is satisfied just as
+  // happily by a mapper typo or a transport error, and the corpus README calls that a silent
+  // pass. A new throwing action must add its message here or the coverage assertion fails.
+  const THROWING_MESSAGES: Record<string, RegExp> = {
+    "cr-div-neg-zero": /sign is indeterminate/,
+    "nan-ord-inf": /sign is indeterminate/,
+    "filter-as-condition": /returns a list, not a boolean/,
+    "map-as-condition": /returns a list, not a boolean/,
+  };
+
+  test("every throwing action pins the message that names its mechanism", () => {
+    expect(Object.keys(THROWING_MESSAGES).sort()).toEqual(
+      [...THROWING_ACTIONS].sort(),
+    );
+  });
+
+  // The invariant is that an inexpressible shape must throw BEFORE its filter can be used, so
+  // the assertion wraps translation only: the plan is fetched outside it (a PDP failure fails
+  // the test instead of passing it), and no query executes (a store rejecting a wrongly
+  // emitted filter cannot masquerade as the adapter refusing to translate).
+  test.each(THROWING_ACTIONS)(
+    "%s fails during translation, before any filter exists",
+    async (action) => {
+      const queryPlan = await cerbos.planResources({
+        principal: seedsFile.principal,
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+      expect(() =>
+        queryPlanToConvex({
+          queryPlan,
+          mapper: MAPPER,
+          allowPostFilter: true,
+        }),
+      ).toThrow(THROWING_MESSAGES[action]);
+    },
+  );
 
   test.each(ORACLE_ACTIONS)("%s matches the check() oracle", async (action) => {
     const [oracle, filtered] = await Promise.all([
@@ -512,8 +561,13 @@ describe("adversarial conformance corpus", () => {
       try {
         await adapterFilteredIds(action, "omitted");
         notRejected.push(action);
-      } catch {
-        // expected: the shape must be rejected under this representation
+      } catch (error) {
+        // The rejection must be the null-operand check talking, not an incidental failure —
+        // a transport error or mapper typo counting as the required rejection is the silent
+        // pass the corpus README warns about.
+        if (!/missing-attribute error/.test(String(error))) {
+          notRejected.push(`${action} (rejected for the wrong reason: ${String(error)})`);
+        }
       }
     }
     expect(notRejected).toEqual([]);

--- a/convex/src/index.ts
+++ b/convex/src/index.ts
@@ -244,6 +244,17 @@ const canPushToDb = (
   }
 };
 
+// IEEE-754 keeps the sign of a zero, so `n / -0.0` is the OPPOSITE infinity from `n / 0.0`.
+// The planner does ship the sign — the wire operand for -0.0 is `-0` — but a plan reaching a
+// Convex function is JSON-encoded on the way in, and `JSON.stringify(-0)` is `"0"`, so the sign
+// bit is already gone by the time the adapter sees it. Guessing returns rows the PDP denies, so
+// fail closed instead (cerbos/query-plan-adapters#312). A zero numerator is unaffected: 0/0 is
+// NaN under either sign.
+const INDETERMINATE_ZERO_DIVISOR_MESSAGE =
+  "division by a constant zero whose sign is indeterminate: a query plan is " +
+  "JSON-encoded on its way into a Convex function and JSON has no -0, so the " +
+  "adapter cannot tell +Infinity from -Infinity";
+
 const validateStructure = (expression: PlanExpressionOperand): void => {
   if (isValue(expression) || isVariable(expression)) return;
   if (!isExpression(expression)) {
@@ -251,6 +262,22 @@ const validateStructure = (expression: PlanExpressionOperand): void => {
   }
   if (!ALL_KNOWN_OPERATORS.has(expression.operator)) {
     throw new Error(`Unsupported operator: ${expression.operator}`);
+  }
+  if (expression.operator === "div") {
+    // Reject at translation, not at post-filter evaluation: by the time the evaluator sees the
+    // zero the filter already exists, and the invariant is that an inexpressible shape must
+    // throw before its filter can be used. The evaluator keeps the same check as a backstop for
+    // zeros that are only computed at evaluation time.
+    const numerator = expression.operands[0];
+    const denominator = expression.operands[1];
+    if (
+      denominator !== undefined &&
+      isValue(denominator) &&
+      denominator.value === 0 &&
+      !(numerator !== undefined && isValue(numerator) && numerator.value === 0)
+    ) {
+      throw new Error(INDETERMINATE_ZERO_DIVISOR_MESSAGE);
+    }
   }
   if (expression.operator === "matches") {
     const pattern = expression.operands[1];
@@ -887,18 +914,9 @@ const evaluateExpression = (
         return EVALUATION_ERROR;
       }
       if (operator === "div" && right === 0 && left !== 0) {
-        // IEEE-754 keeps the sign of a zero, so `n / -0.0` is the OPPOSITE infinity from
-        // `n / 0.0`. The planner does ship the sign — the wire operand for -0.0 is `-0` —
-        // but a plan reaching a Convex function is JSON-encoded on the way in, and
-        // `JSON.stringify(-0)` is `"0"`, so the sign bit is already gone by the time the
-        // adapter sees it. Guessing returns rows the PDP denies, so fail closed instead
-        // (cerbos/query-plan-adapters#312). A zero numerator is unaffected: 0/0 is NaN
-        // under either sign.
-        throw new Error(
-          "division by a constant zero whose sign is indeterminate: a query plan is " +
-            "JSON-encoded on its way into a Convex function and JSON has no -0, so the " +
-            "adapter cannot tell +Infinity from -Infinity"
-        );
+        // Backstop for zeros only computed at evaluation time; constant zero divisors are
+        // already rejected during translation by validateStructure.
+        throw new Error(INDETERMINATE_ZERO_DIVISOR_MESSAGE);
       }
       switch (operator) {
         case "add":
@@ -1129,6 +1147,21 @@ export function queryPlanToConvex<Q = unknown, R = unknown>({
     case PlanKind.ALWAYS_DENIED:
       return { kind: PlanKind.ALWAYS_DENIED };
     case PlanKind.CONDITIONAL: {
+      // A `filter()` or `map()` at the ROOT of the condition returns a list, not a boolean.
+      // CEL raises for a non-boolean condition (deny), and the post-filter's `=== true`
+      // coercion would happen to agree — but silently, by coercing a list to false. That is
+      // an emitted filter for a shape with no boolean meaning, which the conformance
+      // contract forbids: throw instead. Nested inside size() they remain translatable.
+      const root = queryPlan.condition;
+      if (
+        isExpression(root) &&
+        (root.operator === "filter" || root.operator === "map")
+      ) {
+        throw new Error(
+          `${root.operator}() returns a list, not a boolean, so it cannot be a condition ` +
+            "on its own; only size() over its result has a boolean meaning",
+        );
+      }
       if (nullAttributeRepresentation === "omitted") {
         assertNoNullComparisonOperands(queryPlan.condition);
       }

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -139,7 +139,7 @@ const MANIFEST_ACTIONS = new Set([
   // must still enter this manifest, so the size tripwire and the classified-exactly-once
   // check flag it for triage here instead of letting the action silently vanish from this
   // harness. Classification/skipping still uses the Drizzle-filtered set.
-  ...actionsFile.knownDivergences.map((entry) => entry.action),
+  ...(actionsFile.knownDivergences ?? []).map((entry) => entry.action),
 ]);
 
 /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -135,7 +135,11 @@ const MANIFEST_ACTIONS = new Set([
   ...actionsFile.expectedUnsupported.map((entry) => entry.action),
   ...NULL_REPRESENTATION_OMITTED.map(([action]) => action),
   ...DRIZZLE_SUPPORTED_EXPECTED,
-  ...DRIZZLE_DIVERGENCES,
+  // ALL divergences, not just Drizzle's: a divergence registered solely for another adapter
+  // must still enter this manifest, so the size tripwire and the classified-exactly-once
+  // check flag it for triage here instead of letting the action silently vanish from this
+  // harness. Classification/skipping still uses the Drizzle-filtered set.
+  ...actionsFile.knownDivergences.map((entry) => entry.action),
 ]);
 
 /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
@@ -622,11 +626,26 @@ describe("adversarial conformance corpus", () => {
   );
 
   // Shapes the adapter does not support must fail during translation, never produce a
-  // silently-wrong filter.
+  // silently-wrong filter. The plan is fetched OUTSIDE the assertion so a PDP failure fails
+  // the test instead of passing it, and no query executes — SQLite rejecting a wrongly
+  // emitted filter afterwards must not be able to masquerade as the adapter refusing to
+  // translate.
   test.each(THROWING_ACTIONS)(
-    "%s fails loudly instead of silently mistranslating (%s)",
+    "%s fails during translation, before any filter exists (%s)",
     async (action) => {
-      await expect(adapterFilteredIds(action)).rejects.toThrow();
+      const queryPlan = await cerbos.planResources({
+        principal: principal(),
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+      expect(() =>
+        queryPlanToDrizzle({
+          queryPlan,
+          mapper: MAPPER,
+          nullAttributeRepresentation: "explicit",
+        })
+      ).toThrow();
     }
   );
 

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -40,6 +40,7 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,11 +66,17 @@ class ElasticsearchAdversarialConformanceTest {
             Map.entry("request.resource.attr.obj.inner", "obj.inner"),
             Map.entry("request.resource.attr.tags", "tags"),
             Map.entry("request.resource.attr.tagNames", "tagNames"),
+            // `categories` must be mapped even though every action touching it is fail-closed:
+            // an unmapped field makes those actions throw "Unknown attribute" instead of the
+            // mechanism their actions.json reasons name, so the throw tests pass for the wrong
+            // reason and the claimed limitation is never actually exercised.
+            Map.entry("request.resource.attr.categories", "categories"),
             Map.entry("request.resource.attr.mainCategory.subCategories", "mainCategory.subCategories"),
             Map.entry("request.resource.attr.mainCategory.subNames", "mainCategory.subNames"));
 
     private static final Set<String> NESTED_PATHS = Set.of(
-            "tags", "mainCategory.subCategories");
+            "tags", "mainCategory.subCategories",
+            "categories", "categories.subCategories", "categories.subCategories.labels");
 
     private static Path conformanceDir() {
         return Path.of(System.getProperty("user.dir"), "..", "conformance").normalize();
@@ -462,9 +469,22 @@ class ElasticsearchAdversarialConformanceTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("throwingActions")
-    void unsupportedShapesThrow(String action) {
-        assertThrows(IllegalArgumentException.class, () -> adapterFilteredIds(action),
+    void unsupportedShapesThrow(String action) throws Exception {
+        // The plan is fetched OUTSIDE the assertion (a PDP failure fails the test rather than
+        // passing it) and no search executes: the invariant is that an inexpressible shape
+        // must throw during translation, before any query exists.
+        PlanResourcesResult plan = client.plan(
+                principal(), Resource.newInstance(seedsFile.resourceKind()), action);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> ElasticsearchQueryPlanAdapter.toElasticsearchQuery(plan, FIELD_MAP, NESTED_PATHS),
                 "unsupported action must fail during translation: " + action);
+        // "Unknown attribute" is the one rejection that indicts the HARNESS (a FIELD_MAP gap)
+        // rather than the adapter: an unmapped `categories` once let six actions throw here
+        // while never reaching the mechanism their actions.json reasons claim. Every real
+        // limitation throws a different message, so pin the distinction.
+        assertFalse(ex.getMessage().startsWith("Unknown attribute:"),
+                "action '" + action + "' was rejected by an unmapped field, not the declared "
+                        + "mechanism: " + ex.getMessage());
     }
 
     /**

--- a/ent/adversarial_test.go
+++ b/ent/adversarial_test.go
@@ -695,9 +695,20 @@ func runConformance(t *testing.T, h *harness) {
 	t.Run("unsupported shapes fail loudly", func(t *testing.T) {
 		for _, entry := range h.corpus.ThrowingActions {
 			t.Run(entry.Action, func(t *testing.T) {
-				_, err := h.adapterFilteredIDs(t, entry.Action)
+				// Translate directly rather than through adapterFilteredIDs: the plan is
+				// fetched with its own error check and no query executes, so the database
+				// rejecting a wrongly emitted predicate cannot masquerade as the adapter
+				// refusing to translate.
+				plan, err := h.client.PlanResources(t.Context(), h.principal(),
+					cerbos.NewResource(h.corpus.Seeds.ResourceKind, ""), entry.Action)
+				require.NoError(t, err, "planning %s", entry.Action)
+
+				_, err = cerbosent.Translate(plan.PlanResourcesResponse, resourceTable, h.mapper,
+					cerbosent.WithDialect(h.target.dialect))
 				require.Error(t, err,
 					"%s must fail translation rather than emit a predicate (%s)", entry.Action, entry.Reason)
+				require.ErrorIs(t, err, cerbosent.ErrUnsupported,
+					"%s must be refused as unsupported, not fail incidentally", entry.Action)
 			})
 		}
 	})

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -784,10 +784,26 @@ describe("adversarial conformance corpus", () => {
     expect(filtered).toEqual(oracle);
   });
 
+  // The plan is fetched OUTSIDE the assertion so a PDP failure fails the test instead of
+  // passing it, and no query executes — the invariant is that the shape throws BEFORE a
+  // filter exists, so MongoDB aborting a wrongly emitted pipeline at query time must not be
+  // able to masquerade as the adapter refusing to translate.
   test.each(THROWING_ACTIONS)(
-    "$action fails loudly instead of silently mistranslating ($reason)",
+    "$action fails during translation, before any filter exists ($reason)",
     async ({ action }) => {
-      await expect(adapterFilteredIds(action)).rejects.toThrow();
+      const queryPlan = await cerbos.planResources({
+        principal: seedsFile.principal,
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+      expect(() =>
+        queryPlanToMongoose({
+          queryPlan,
+          mapper: MAPPER,
+          nullAttributeRepresentation: "explicit",
+        })
+      ).toThrow();
     }
   );
 

--- a/pgx/adversarial_test.go
+++ b/pgx/adversarial_test.go
@@ -471,9 +471,19 @@ func TestAdversarialConformance(t *testing.T) {
 	t.Run("unsupported shapes fail loudly", func(t *testing.T) {
 		for _, entry := range h.corpus.ThrowingActions {
 			t.Run(entry.Action, func(t *testing.T) {
-				_, err := h.adapterFilteredIDs(t, entry.Action)
+				// Translate directly rather than through adapterFilteredIDs: the plan is
+				// fetched with its own error check and no query executes, so Postgres
+				// rejecting a wrongly emitted filter cannot masquerade as the adapter
+				// refusing to translate.
+				plan, err := h.client.PlanResources(t.Context(), h.principal(),
+					cerbos.NewResource(h.corpus.Seeds.ResourceKind, ""), entry.Action)
+				require.NoError(t, err, "planning %s", entry.Action)
+
+				_, err = cerbospgx.Translate(plan.PlanResourcesResponse, resourceTable, h.mapper)
 				require.Error(t, err,
 					"%s must fail translation rather than emit a filter (%s)", entry.Action, entry.Reason)
+				require.ErrorIs(t, err, cerbospgx.ErrUnsupported,
+					"%s must be refused as unsupported, not fail incidentally", entry.Action)
 			})
 		}
 	})

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -148,7 +148,7 @@ const MANIFEST_ACTIONS = new Set([
   // must still enter this manifest, so the size tripwire and the classified-exactly-once
   // check flag it for triage here instead of letting the action silently vanish from this
   // harness. Classification/skipping still uses the Prisma-filtered set.
-  ...actionsFile.knownDivergences.map((entry) => entry.action),
+  ...(actionsFile.knownDivergences ?? []).map((entry) => entry.action),
 ]);
 
 function doubleFor(seed: Seed): number | null {

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -144,7 +144,11 @@ const MANIFEST_ACTIONS = new Set([
   ...actionsFile.conformance,
   ...EXPECTED_UNSUPPORTED_ACTIONS,
   ...NULL_REPRESENTATION_OMITTED.map(([action]) => action),
-  ...PRISMA_KNOWN_DIVERGENCES,
+  // ALL divergences, not just Prisma's: a divergence registered solely for another adapter
+  // must still enter this manifest, so the size tripwire and the classified-exactly-once
+  // check flag it for triage here instead of letting the action silently vanish from this
+  // harness. Classification/skipping still uses the Prisma-filtered set.
+  ...actionsFile.knownDivergences.map((entry) => entry.action),
 ]);
 
 function doubleFor(seed: Seed): number | null {
@@ -577,11 +581,27 @@ describe("adversarial conformance corpus", () => {
 
   // Shapes the adapter does not support (globally unsupported planner shapes plus Prisma's
   // declared adapterUnsupported list): translation must fail loudly, never produce a
-  // silently-wrong filter.
+  // silently-wrong filter. The plan is fetched OUTSIDE the assertion so a PDP failure fails
+  // the test instead of passing it, and no query executes — the invariant is that the shape
+  // throws BEFORE a filter exists, so SQLite rejecting a wrongly emitted filter afterwards
+  // must not be able to masquerade as the adapter refusing to translate.
   test.each(THROWING_ACTIONS)(
-    "%s fails loudly instead of silently mistranslating (%s)",
+    "%s fails during translation, before any filter exists (%s)",
     async (action) => {
-      await expect(adapterFilteredIds(action)).rejects.toThrow();
+      const queryPlan = await cerbos.planResources({
+        principal: principal(),
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      expect(queryPlan.kind).toBe(PlanKind.CONDITIONAL);
+      expect(() =>
+        queryPlanToPrisma({
+          queryPlan,
+          mapper: MAPPER,
+          model: "AdversarialResource",
+          nullAttributeRepresentation: "explicit",
+        })
+      ).toThrow();
     }
   );
 

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -613,6 +613,18 @@ export function queryPlanToPrisma({
           "A constant-false conditional predicate must be folded by the Cerbos planner"
         );
       }
+      // A `map()` at the ROOT of the condition returns a list, not a boolean. Translating it
+      // produces a projection filter that is not a valid Prisma `where` clause — the shape
+      // must be refused HERE rather than left for findMany to reject at query time, because
+      // a projection that happened to coerce would be a silently-wrong filter. (`filter()`
+      // as a condition is already rejected inside handleCollectionOperator with its own
+      // message; nested inside a comparison or size() both remain translatable.)
+      if (isOperatorOperand(condition) && condition.operator === "map") {
+        throw new Error(
+          "map() returns a list, not a boolean, so it cannot be a condition on its own; " +
+            "only comparisons or size() over its result have a boolean meaning"
+        );
+      }
       return {
         kind: PlanKind.CONDITIONAL,
         filters: buildPrismaFilterFromCerbosExpression(condition, mapper),

--- a/spring-data/example/docker-compose.yml
+++ b/spring-data/example/docker-compose.yml
@@ -6,7 +6,10 @@
 #   docker compose down
 services:
   cerbos:
-    image: ghcr.io/cerbos/cerbos:latest
+    # Pinned to conformance/CERBOS_VERSION — validate-corpus.sh asserts the tag agrees.
+    # Deliberately not `latest`: this compose runs in CI (example smoke tests), and the
+    # PDP an adapter is proved against must change only through a deliberate version bump.
+    image: ghcr.io/cerbos/cerbos:0.54.0@sha256:211c261f6031675522a35c6055b13fd719c4aff13747307e4bcb6907326537ef
     container_name: cerbos-photos-example
     command:
       - "server"

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -160,11 +160,22 @@ class AdversarialConformanceTest {
     private record AdapterUnsupported(String action, String reason) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
+    private record KnownDivergence(String action, String reason, List<String> adapters) {}
+
+    /**
+     * Every group in actions.json must be named here: Jackson silently drops a field this
+     * record does not declare, and a dropped group makes its actions vanish from every count
+     * and every parameterised case at once — the projection trap conformance/README.md warns
+     * about. The manifest tripwire test below is what makes an undropped group load-bearing.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private record ActionsFile(
             List<String> conformance,
             Map<String, List<AdapterUnsupported>> adapterUnsupported,
+            Map<String, List<AdapterUnsupported>> adapterSupportedExpected,
             List<UnsupportedShape> expectedUnsupported,
-            List<NullRepresentationOmitted> nullRepresentationOmitted) {}
+            List<NullRepresentationOmitted> nullRepresentationOmitted,
+            List<KnownDivergence> knownDivergences) {}
 
     /** The corpus key for this adapter — its directory name, as every other harness uses. */
     private static final String ADAPTER = "spring-data";
@@ -188,10 +199,24 @@ class AdversarialConformanceTest {
                 : actionsFile.adapterUnsupported().getOrDefault(ADAPTER, List.of());
     }
 
+    /** Reference-unsupported shapes this adapter deliberately translates anyway (normally empty). */
+    private static List<AdapterUnsupported> adapterSupportedExpected() {
+        return actionsFile.adapterSupportedExpected() == null
+                ? List.of()
+                : actionsFile.adapterSupportedExpected().getOrDefault(ADAPTER, List.of());
+    }
+
+    private static Set<String> adapterSupportedExpectedActions() {
+        return adapterSupportedExpected().stream()
+                .map(AdapterUnsupported::action).collect(java.util.stream.Collectors.toSet());
+    }
+
     static Stream<String> conformanceActions() {
         Set<String> unsupported = adapterUnsupported().stream()
                 .map(AdapterUnsupported::action).collect(java.util.stream.Collectors.toSet());
-        return actionsFile.conformance().stream().filter(a -> !unsupported.contains(a));
+        return Stream.concat(
+                actionsFile.conformance().stream().filter(a -> !unsupported.contains(a)),
+                adapterSupportedExpectedActions().stream().sorted());
     }
 
     static Stream<Arguments> adapterUnsupportedActions() {
@@ -199,8 +224,10 @@ class AdversarialConformanceTest {
     }
 
     static Stream<Arguments> unsupportedShapes() {
+        Set<String> promoted = adapterSupportedExpectedActions();
         return actionsFile.expectedUnsupported().stream()
                 .filter(u -> !u.action().equals("p-timestamp"))
+                .filter(u -> !promoted.contains(u.action()))
                 .map(u -> Arguments.of(u.action(), u.springDataMessage()));
     }
 
@@ -859,6 +886,57 @@ class AdversarialConformanceTest {
         assertEquals(allIds, adapterFilteredIds("p-has"),
                 "the adapter is expected to translate KIND_ALWAYS_ALLOWED faithfully into all "
                         + "rows — if this fails the adapter started second-guessing plan kinds");
+    }
+
+    /**
+     * Corpus-size tripwire and exactly-once partition. A corpus edit must bump the pinned
+     * counts in the same change — without this, a new hostile action silently joins the
+     * oracle run, and a group dropped by the {@code ActionsFile} parser above would make its
+     * actions vanish from every parameterised case with nothing failing.
+     */
+    @Test
+    void manifestAssignsEveryActionExactlyOneOutcome() {
+        Set<String> supportedExpected = adapterSupportedExpectedActions();
+        Set<String> oracle = conformanceActions().collect(java.util.stream.Collectors.toSet());
+        Set<String> throwing = adapterUnsupported().stream()
+                .map(AdapterUnsupported::action)
+                .collect(java.util.stream.Collectors.toCollection(java.util.HashSet::new));
+        actionsFile.expectedUnsupported().stream()
+                .map(UnsupportedShape::action)
+                .filter(a -> !supportedExpected.contains(a))
+                .forEach(throwing::add);
+        Set<String> nullOmitted = actionsFile.nullRepresentationOmitted().stream()
+                .map(NullRepresentationOmitted::action)
+                .collect(java.util.stream.Collectors.toSet());
+        Set<String> skipped = actionsFile.knownDivergences().stream()
+                .filter(d -> d.adapters().contains(ADAPTER))
+                .map(KnownDivergence::action)
+                .collect(java.util.stream.Collectors.toSet());
+
+        Set<String> manifest = new java.util.TreeSet<>(actionsFile.conformance());
+        actionsFile.expectedUnsupported().forEach(u -> manifest.add(u.action()));
+        actionsFile.nullRepresentationOmitted().forEach(n -> manifest.add(n.action()));
+        actionsFile.knownDivergences().forEach(d -> manifest.add(d.action()));
+
+        List<String> misclassified = manifest.stream()
+                .filter(action -> Stream.of(
+                                oracle.contains(action),
+                                throwing.contains(action),
+                                nullOmitted.contains(action),
+                                skipped.contains(action))
+                        .filter(Boolean::booleanValue).count() != 1)
+                .toList();
+
+        assertEquals(140, manifest.size(),
+                "corpus size changed; triage the new action(s) before bumping this pin");
+        assertEquals(20, SEEDS.size(), "seed count changed");
+        assertEquals(List.of(), misclassified,
+                "every manifest action must have exactly one spring-data outcome");
+        assertTrue(actionsFile.expectedUnsupported().stream()
+                        .map(UnsupportedShape::action)
+                        .collect(java.util.stream.Collectors.toSet())
+                        .containsAll(supportedExpected),
+                "every promoted action must exist in expectedUnsupported");
     }
 
     @Test

--- a/sqlalchemy/src/cerbos_sqlalchemy/query.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/query.py
@@ -46,7 +46,12 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeMeta, InstrumentedAttribute
 from sqlalchemy.sql import Select
-from sqlalchemy.sql.expression import BinaryExpression, ColumnOperators, FromClause
+from sqlalchemy.sql.expression import (
+    BinaryExpression,
+    ColumnElement,
+    ColumnOperators,
+    FromClause,
+)
 
 try:  # SQLAlchemy >= 2.0
     from sqlalchemy.orm import DeclarativeBase
@@ -1167,7 +1172,21 @@ def get_query(
         # the operator handlers here are the leaf nodes of the recursion
         return get_operator_fn(operator, column, value)
 
-    q = select(table).where(traverse_and_map_operands(cond))
+    condition = traverse_and_map_operands(cond)
+    # The root of the plan must translate to a boolean SQL expression. A non-boolean root —
+    # filter()/map() as the whole condition, or an operator override's intermediate value that
+    # no enclosing override consumed — must be refused HERE, by the adapter, rather than left
+    # for SQLAlchemy's where() coercion to trip over: a value that happened to coerce would
+    # become a silently-wrong filter.
+    if not isinstance(condition, (ColumnElement, bool)):
+        raise ValueError(
+            f"the plan's condition translated to {type(condition).__name__!r}, which is not "
+            "a boolean SQL expression. filter() and map() return a list, so they cannot be a "
+            "condition on their own (only size(filter(...)) has a boolean meaning), and an "
+            "operator override returning an intermediate value must be consumed by an "
+            "enclosing override before the root"
+        )
+    q = select(table).where(condition)
 
     if table_mapping:
         q = q.select_from(table)

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -107,6 +107,22 @@ NULL_REPRESENTATION_OMITTED = [
     for item in ACTIONS_FILE["nullRepresentationOmitted"]
 ]
 
+# Every classified action across all four manifest groups. Read each group
+# explicitly: a group this expression does not name is dropped silently, and a
+# dropped group makes its actions vanish from every count at once (the
+# projection trap conformance/README.md warns about).
+MANIFEST_ACTIONS = (
+    set(ACTIONS_FILE["conformance"])
+    | {u["action"] for u in ACTIONS_FILE["expectedUnsupported"]}
+    | {n["action"] for n in ACTIONS_FILE["nullRepresentationOmitted"]}
+    | {d["action"] for d in ACTIONS_FILE["knownDivergences"]}
+)
+SQLALCHEMY_SKIPPED_DIVERGENCES = {
+    d["action"]
+    for d in ACTIONS_FILE["knownDivergences"]
+    if "sqlalchemy" in d["adapters"]
+}
+
 
 def _iso_for(seed: Dict[str, Any]) -> str:
     """Deterministic ISO instant per seed for the timestamp probe (see
@@ -775,6 +791,31 @@ def _adapter_filtered_ids(
 # one) — a silent-wrongness bug class, so escalate it to an error.
 @pytest.mark.filterwarnings("error::sqlalchemy.exc.SAWarning")
 class TestAdversarialConformance:
+    def test_manifest_assigns_every_action_exactly_one_outcome(self):
+        oracle = set(ORACLE_ACTIONS)
+        throwing = set(THROWING_ACTIONS)
+        null_omitted = {action for action, _ in NULL_REPRESENTATION_OMITTED}
+        misclassified = [
+            action
+            for action in sorted(MANIFEST_ACTIONS)
+            if [
+                action in oracle,
+                action in throwing,
+                action in null_omitted,
+                action in SQLALCHEMY_SKIPPED_DIVERGENCES,
+            ].count(True)
+            != 1
+        ]
+
+        # Deliberate tripwires: a corpus edit must bump these in the same
+        # change, so a new hostile action cannot join (or vanish) silently.
+        assert len(MANIFEST_ACTIONS) == 140
+        assert len(SEEDS) == 20
+        assert misclassified == []
+        assert SQLALCHEMY_SUPPORTED_EXPECTED <= {
+            u["action"] for u in ACTIONS_FILE["expectedUnsupported"]
+        }
+
     @pytest.mark.parametrize("action", ORACLE_ACTIONS)
     def test_matches_check_oracle(self, action, adv_cerbos_client, adv_conn):
         oracle = _oracle_allowed_ids(adv_cerbos_client, action)
@@ -782,11 +823,28 @@ class TestAdversarialConformance:
         assert sorted(filtered) == sorted(oracle)
 
     @pytest.mark.parametrize("action", THROWING_ACTIONS)
-    def test_fails_loudly(self, action, adv_cerbos_client, adv_conn):
-        # A loud failure — at translation or at query execution — is required;
-        # a silently-wrong filter is the only unacceptable outcome.
-        with pytest.raises(Exception):
-            _adapter_filtered_ids(adv_cerbos_client, adv_conn, action)
+    def test_fails_loudly(self, action, adv_cerbos_client):
+        # The plan is fetched OUTSIDE the assertion so a PDP failure fails the
+        # test instead of passing it, and nothing executes — the invariant is
+        # that the shape throws during translation, BEFORE a filter exists, so
+        # the database rejecting a wrongly emitted query afterwards cannot
+        # masquerade as the adapter refusing to translate.
+        plan = adv_cerbos_client.plan_resources(
+            action, _principal(), ResourceDesc(RESOURCE_KIND)
+        )
+        # The adapter's translation-time refusals: ValueError (unsupported
+        # operator/cast/timestamp shapes), KeyError (attribute missing from the
+        # map), TypeError (attribute needs an operator override to be
+        # expressible). Anything else — connection errors, SQLAlchemy runtime
+        # errors — must fail the test, not satisfy it.
+        with pytest.raises((ValueError, KeyError, TypeError)):
+            get_query(
+                plan,
+                AdvResource,
+                ATTR_MAP,
+                operator_override_fns=OPERATOR_OVERRIDES,
+                null_attribute_representation="explicit",
+            )
 
     # #302. `null-eq-missing` probes `aOptionalString == null`, and
     # `aOptionalString` follows the corpus default: a NULL column sends NO
@@ -820,14 +878,8 @@ class TestAdversarialConformance:
     def test_every_null_carrying_action_is_rejected_under_omitted(
         self, adv_cerbos_client, adv_conn
     ):
-        manifest = (
-            set(ACTIONS_FILE["conformance"])
-            | {u["action"] for u in ACTIONS_FILE["expectedUnsupported"]}
-            | {n["action"] for n in ACTIONS_FILE["nullRepresentationOmitted"]}
-            | {d["action"] for d in ACTIONS_FILE["knownDivergences"]}
-        )
         null_carrying = []
-        for action in sorted(manifest):
+        for action in sorted(MANIFEST_ACTIONS):
             plan = adv_cerbos_client.plan_resources(
                 action, _principal(), ResourceDesc(RESOURCE_KIND)
             )
@@ -853,8 +905,15 @@ class TestAdversarialConformance:
                     null_attribute_representation="omitted",
                 )
                 not_rejected.append(action)
-            except Exception:
-                pass  # expected: the shape must be rejected under this representation
+            except Exception as exc:  # noqa: BLE001 - triaged below
+                # The rejection must be the null-operand check talking, not an
+                # incidental failure: a transport error or attr-map typo counting
+                # as the required rejection is the silent pass the corpus README
+                # warns about.
+                if "missing-attribute" not in str(exc):
+                    not_rejected.append(
+                        f"{action} (rejected for the wrong reason: {exc})"
+                    )
         assert not_rejected == []
 
     # nan-ord-inf is absent: its 1.0/0.0 and -1.0/0.0 branches carry a CONSTANT zero


### PR DESCRIPTION
## Summary

Hardens the fail-closed half of the adversarial contract across the harnesses, which surfaced and fixes **three latent adapter bugs** where an "inexpressible" shape emitted a filter instead of throwing. Follows the 2026-08 harness audit; the remaining findings are tracked in the issues linked below.

**Affected adapters**: convex, prisma, sqlalchemy (behaviour); drizzle, mongoose, ent, pgx, elasticsearch-java, spring-data (tests only); conformance (corpus + scripts).

## Adapter fixes

- **convex** — its 7 fail-closed actions were counted but never tested. Adding the throw suite revealed: `filter()`/`map()` as a whole condition silently returned `[]` (now throws at translation); constant-zero divisors threw per-document at evaluation, after the filter existed (now at translation); and the `int()`/`double()` casts actually implement CEL semantics exactly — promoted to `adapterSupportedExpected` and **verified against the check() oracle** (oracle 131→134, fail-closed 7→4).
- **prisma** — `map()` as a whole condition translated into an invalid `where` (a `select` inside a filter) that only `findMany` rejected. Now refused at translation.
- **sqlalchemy** — `filter`/`map`-as-condition leaked an operator-override tuple into `select().where()`; SQLAlchemy's coercion error was what kept the old `pytest.raises(Exception)` green. `get_query` now requires the root to translate to a boolean `ColumnElement`.

## Harness hardening

- Throw assertions are **translation-scoped everywhere** (plan fetched outside the assertion, nothing executed), so a PDP flake or the store rejecting a bad filter can no longer masquerade as the adapter refusing to translate. Go additionally pins `errors.Is(err, ErrUnsupported)`.
- **elasticsearch-java**: `categories` is now mapped — six throwing actions previously passed on "Unknown attribute" (a FIELD_MAP gap) rather than the mechanism their `actions.json` reasons claim; the assertion now rejects that class outright. All six throw for real limitations.
- **spring-data**: parses all six `actions.json` groups (previously dropped `adapterSupportedExpected`/`knownDivergences` silently), wires promoted actions into its derivations, and gains the 140-action/20-seed manifest tripwire it was missing. **sqlalchemy** gains the same tripwires.
- prisma/drizzle/convex manifests now union **all** `knownDivergences`, so a divergence registered for another adapter trips the guards instead of vanishing.
- `validate-corpus.sh` scans the whole repo for Cerbos image pins (plus the `genpb` pins in both `go.mod`s); `spring-data/example/docker-compose.yml` no longer runs `cerbos:latest` in CI.

## Breaking change

`queryPlanToConvex` now **throws** for `filter()`/`map()` used as a whole condition, where it previously returned a postFilter that denied every document. The old result agreed with the PDP only by list→boolean coercion; per the conformance contract a shape with no boolean meaning must fail loudly. Prisma's and sqlalchemy's changes only move existing failures from query time to translation time with mechanism-naming messages.

## Related issues

Filed from the same audit. **Deliberately not `Closes`** — this PR does not resolve them; they track the follow-up work and should stay open after merge:

- Relates to #318 (seeds.json projection trap + shared derived-field tables)
- Relates to #319 (ent unit coverage, ent↔pgx translator sync)
- Relates to #320 (executed PostgreSQL/MySQL legs for drizzle and prisma)
- Relates to #321 (sqlalchemy gRPC / DeclarativeBase / async adversarial legs)
- Relates to #322 (digest-pin service images, ES text-mapping tripwire; this PR pins only the example compose)
- Relates to #323 (mapping-hazard decisions for prisma, drizzle, mongoose)
- Relates to #324 (per-adapter degeneracy-guard liveness)
- Relates to #325 (docs/CI drift sweep)
- Relates to #326 (per-action throw-message pinning — this PR lands the translation scoping that issue builds on)
- Relates to #327 (convex integration suite / pushdown coverage / null-rationale wording)

## Verification (all local)

| Suite | Result |
| --- | --- |
| convex adversarial + unit + typecheck | 144/144, 64-test unit suite, tsc clean |
| prisma adversarial + legacy + typecheck (v6+v7) | 144/144, 207/207 |
| sqlalchemy full (adversarial + legacy, http+grpc) | 294 passed |
| drizzle adversarial + typecheck | 143/143 |
| mongoose adversarial (Mongo 7) + typecheck | 143/143 |
| ent (sqlite leg) + golangci-lint | 169 passed; PG/MySQL legs in CI |
| pgx full (real Postgres) + golangci-lint | 237 passed |
| spring-data adversarial (H2 leg, Docker) | 144/0; PG/MySQL legs in CI |
| elasticsearch-java adversarial (Docker) | 141/0 |
| validate-corpus.sh | 140 actions, 20 seeds, repo-wide scan clean |

Reviewer reproduction needs Docker (convex backend, Mongo, testcontainers for Go/Java) and the cerbos CLI for the TS sidecars — same services as CI.
