### PR TITLE
fix(conformance): guard the absent to-one parent on every chained operator

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -140,18 +140,33 @@ resource row, where an absent parent and a childless parent produce the same emp
 | `!mainCategory.subCategories.exists(s, …)` | deny | no rows → `!false` → **over-grants** |
 | `size(mainCategory.subCategories) == 0` | deny | count 0 → **over-grants** |
 | `size(mainCategory.subCategories) >= 0` | deny | count 0 → **over-grants** |
+| `!("finance" in mainCategory.subNames)` | deny | no rows → `!false` → **over-grants** |
+| `!hasIntersection(mainCategory.subNames, […])` | deny | no rows → `!false` → **over-grants** |
+| `!(size(mainCategory.subCategories) > 0)` | deny | count 0 → `!false` → **over-grants** |
 
-Only a universal, a negated existential, or a lower-bound count discriminates them, which is why
+Only a universal, a negation, or a zero/lower-bound count discriminates them, which is why
 `w1-exists-chain`, `w1-size-chain` and `w1-in-chain` passed everywhere while the bug was live
-(cerbos/query-plan-adapters#309). `w1-all-chain`, `w1-not-exists-chain`, `w1-size-zero-chain` and
-`w1-size-nonneg-chain` are the four that discriminate.
+(cerbos/query-plan-adapters#309). `w1-all-chain`, `w1-not-exists-chain`, `w1-size-zero-chain`,
+`w1-size-nonneg-chain`, `w1-not-in-chain`, `w1-not-hasint-chain` and `w1-not-size-chain` are the
+seven that discriminate.
 
 The fix is in the translation, not in the classification: **a chained collection must require its
 intermediate hop to exist**, so an absent parent stays excluded under both polarities instead of
-collapsing onto the empty-collection case. `w1-size-zero-chain` has an empty oracle by
-construction (no seed holds a parent with zero children) and therefore stays out of the degeneracy
-guard; `w1-all-chain`, `w1-not-exists-chain` and `w1-size-nonneg-chain` all have non-degenerate
-oracles and carry the anti-vacuity assertion for the group.
+collapsing onto the empty-collection case. `w1-size-zero-chain` and `w1-not-size-chain` have empty
+oracles by construction (no seed holds a parent with zero children) and therefore stay out of the
+degeneracy guard; `w1-all-chain`, `w1-not-exists-chain`, `w1-size-nonneg-chain`,
+`w1-not-in-chain` and `w1-not-hasint-chain` all have non-degenerate oracles and carry the
+anti-vacuity assertion for the group.
+
+**Put the guard in the shared relation-scope construction, not in each operator.** The #309 round
+guarded the collection macros, which left every sibling operator reached through the same chain
+unguarded — membership and `hasIntersection` (#315), and the negated count spelling `!(size > 0)`,
+which takes a different branch from `size == 0` because the planner emits the negation verbatim
+rather than normalising it (#316). ent and pgx needed no change in either round: their membership
+routes through the same guarded tri-state existence construction as everything else. Adapters with
+no UNKNOWN to represent (Prisma filters, Mongo query documents) get the same result by requiring
+the hops **outside** the negation rather than inside it, so the negation cannot flip the
+requirement along with the predicate.
 
 ### The degeneracy guard
 
@@ -192,7 +207,7 @@ These are part of the shared contract. Do not replace them with adapter-specific
 4. Run `scripts/regenerate-wire-fixtures.sh` and commit the new fixture alongside the policy change.
 5. Every adapter harness picks up the new action automatically from `actions.json` on next run;
    triage any divergence into a per-adapter fix issue rather than special-casing it in the harness.
-6. Each harness pins the corpus size as a tripwire (e.g. `expect(MANIFEST_ACTIONS.size).toBe(140)`
+6. Each harness pins the corpus size as a tripwire (e.g. `expect(MANIFEST_ACTIONS.size).toBe(143)`
    in `prisma/src/adversarial.test.ts`, and the oracle/throwing counts in the convex and
    langchain-chromadb harnesses). Bump them deliberately — that assertion exists so a new action
    cannot slip past an adapter unnoticed.

--- a/conformance/actions.json
+++ b/conformance/actions.json
@@ -29,6 +29,7 @@
     "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
     "w1-exists-chain", "w1-size-chain", "w1-in-chain", "w2-outer-relation",
     "w1-all-chain", "w1-not-exists-chain", "w1-size-zero-chain", "w1-size-nonneg-chain",
+    "w1-not-in-chain", "w1-not-hasint-chain", "w1-not-size-chain",
     "like-bracket", "cs-eq",
     "arith-add-eq-frac", "arith-add-ne-frac", "arith-add-eq-frac-exact",
     "size-huge-gt", "size-huge-lt",
@@ -212,6 +213,9 @@
       { "action": "w1-exists-chain", "reason": "Chroma metadata is a flat scalar map with no relation or array-of-object model, and every comparison operand must be a bare field or literal, so the plan's collection lambda cannot be translated" },
       { "action": "w1-size-chain", "reason": "Chroma metadata is a flat scalar map with no relation model and no count function, so a size(...) collection-count operand cannot be translated" },
       { "action": "w1-in-chain", "reason": "Chroma's $in tests a metadata field against a literal list; it cannot test whether a literal is a member of a list-valued metadata field, and Chroma metadata values are scalars anyway" },
+      { "action": "w1-not-in-chain", "reason": "Same literal-in-field limitation as w1-in-chain, reached under a negation: the adapter rejects the membership direction before the negation is even considered" },
+      { "action": "w1-not-hasint-chain", "reason": "Chroma has no operator that intersects a list-valued metadata field with a literal list, so hasIntersection has no Where equivalent to negate; the adapter refuses to invert it" },
+      { "action": "w1-not-size-chain", "reason": "Chroma comparison operands must be a bare field or literal, so the negated size(...) collection count is rejected as a nested expression — the same missing relation model and count function as w1-size-zero-chain" },
       { "action": "w2-outer-relation", "reason": "Chroma metadata is a flat scalar map with no relation model and no count function, so a size(...) collection-count operand cannot be translated" },
       { "action": "like-bracket", "reason": "Chroma metadata filters expose only scalar comparison and membership operators ($eq/$ne/$lt/$lte/$gt/$gte/$in/$nin) \u2014 there is no prefix, substring, or pattern operator \u2014 so startsWith has no faithful Where equivalent and the adapter rejects it" },
       { "action": "arith-add-eq-frac", "reason": "Chroma metadata filters compare a stored field against a literal only \u2014 there is no computed-value or column-arithmetic operand \u2014 so the plan's arithmetic expression cannot be translated" },
@@ -350,7 +354,10 @@
       { "action": "w1-all-chain", "reason": "Elasticsearch does not index empty nested arrays, so a positive all over a chained collection cannot distinguish an absent to-one parent (CEL error, denies) from an empty collection (vacuously true)" },
       { "action": "w1-not-exists-chain", "reason": "Elasticsearch does not index empty nested arrays, so a negated exists over a chained collection cannot distinguish an absent to-one parent from an empty collection" },
       { "action": "w1-size-zero-chain", "reason": "Same missing-versus-empty ambiguity as w1-not-exists-chain, reached through a zero-count emptiness check" },
-      { "action": "w1-size-nonneg-chain", "reason": "Elasticsearch Query DSL expresses only emptiness checks over nested collections, not arbitrary count thresholds, so a >= 0 threshold — which is TRUE exactly when the to-one parent exists — has no equivalent" }
+      { "action": "w1-size-nonneg-chain", "reason": "Elasticsearch Query DSL expresses only emptiness checks over nested collections, not arbitrary count thresholds, so a >= 0 threshold — which is TRUE exactly when the to-one parent exists — has no equivalent" },
+      { "action": "w1-not-in-chain", "reason": "Same missing-versus-empty ambiguity as w1-not-exists-chain, reached through negated membership: a bool must_not over a nested collection matches a document with no nested array at all, and Elasticsearch cannot tell that from a document whose array holds no match" },
+      { "action": "w1-not-hasint-chain", "reason": "Same missing-versus-empty ambiguity as w1-not-in-chain, reached through hasIntersection over the same operand" },
+      { "action": "w1-not-size-chain", "reason": "Same missing-versus-empty ambiguity as w1-size-zero-chain, reached through the negated positive-count spelling rather than the direct zero-count one" }
     ]
   },
   "adapterSupportedExpected": {

--- a/conformance/policies/adversarial.yaml
+++ b/conformance/policies/adversarial.yaml
@@ -922,6 +922,55 @@ resourcePolicy:
         match:
           expr: 'size(R.attr.mainCategory.subCategories) >= 0'
 
+    # -- the same hazard through MEMBERSHIP (cerbos/query-plan-adapters#315) --
+    # w1-in-chain above is the only membership probe over the chain and it is POSITIVE, so
+    # "parent absent" and "parent present, no match" both exclude the row and agree for the
+    # wrong reason — the identical blind spot the #309 additions closed for the collection
+    # macros. Membership is not a collection macro in most adapters, so the per-macro guard
+    # never reached it: the guard belongs one level lower, in the shared relation-scope
+    # construction every operator builds on (which is why ent and pgx were already aligned).
+    #
+    # Both oracles are a8 ("tech") and c1 ("Finance") — the present-parent-no-match witnesses.
+    # An unguarded NOT EXISTS wrongly adds the 16 parentless seeds. Non-degenerate, so both
+    # belong in the degeneracy guard.
+
+    # Negated membership over the chained string list.
+    - actions: ["w1-not-in-chain"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!("finance" in R.attr.mainCategory.subNames)'
+
+    # The same operand under a sibling operator: hasIntersection reaches the chain through a
+    # different translation branch in every adapter, so it discriminates the guard separately.
+    - actions: ["w1-not-hasint-chain"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!hasIntersection(R.attr.mainCategory.subNames, ["finance"])'
+
+    # -- the same hazard through the NEGATED count spelling (#316) --
+    # The planner does NOT normalise `!(size(...) > 0)` into `size(...) == 0` — it emits the
+    # negation verbatim — so the two spellings are different wire shapes hitting different
+    # branches. An adapter that special-cases a positive count into an existence check before
+    # the hop guard applies negates that check and readmits every parentless row, even though
+    # w1-size-zero-chain passes. Guarding the COUNT EXPRESSION instead makes `== 0`, `> 0`,
+    # `>= N` and their negations all inherit it.
+    #
+    # Every seed that HAS a mainCategory has at least one subCategory, and the 16 without it
+    # are CEL missing-path errors, so the oracle is EMPTY by construction — like
+    # w1-size-zero-chain it therefore stays OUT of the degeneracy guard, which asserts a
+    # non-empty non-total oracle; w1-all-chain, w1-not-exists-chain and w1-size-nonneg-chain
+    # carry the anti-vacuity assertion for this group.
+    - actions: ["w1-not-size-chain"]
+      effect: EFFECT_ALLOW
+      roles: ["USER"]
+      condition:
+        match:
+          expr: '!(size(R.attr.mainCategory.subCategories) > 0)'
+
     # ==================== root relation inside a lambda body (W2) ====================
     # The inner R.attr.tags.exists(...) is planned INSIDE the categories lambda; its subquery
     # must correlate the ROOT entity (owner of "tags"), not the category join the lambda scope

--- a/conformance/wire-fixtures/w1-not-hasint-chain.json
+++ b/conformance/wire-fixtures/w1-not-hasint-chain.json
@@ -1,0 +1,29 @@
+{
+  "action": "w1-not-hasint-chain",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "not",
+        "operands": [
+          {
+            "expression": {
+              "operator": "hasIntersection",
+              "operands": [
+                {
+                  "variable": "request.resource.attr.mainCategory.subNames"
+                },
+                {
+                  "value": [
+                    "finance"
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/conformance/wire-fixtures/w1-not-in-chain.json
+++ b/conformance/wire-fixtures/w1-not-in-chain.json
@@ -1,0 +1,27 @@
+{
+  "action": "w1-not-in-chain",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "not",
+        "operands": [
+          {
+            "expression": {
+              "operator": "in",
+              "operands": [
+                {
+                  "value": "finance"
+                },
+                {
+                  "variable": "request.resource.attr.mainCategory.subNames"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/conformance/wire-fixtures/w1-not-size-chain.json
+++ b/conformance/wire-fixtures/w1-not-size-chain.json
@@ -1,0 +1,34 @@
+{
+  "action": "w1-not-size-chain",
+  "resourceKind": "adversarial",
+  "filter": {
+    "kind": "KIND_CONDITIONAL",
+    "condition": {
+      "expression": {
+        "operator": "not",
+        "operands": [
+          {
+            "expression": {
+              "operator": "gt",
+              "operands": [
+                {
+                  "expression": {
+                    "operator": "size",
+                    "operands": [
+                      {
+                        "variable": "request.resource.attr.mainCategory.subCategories"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "value": 0
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/convex/README.md
+++ b/convex/README.md
@@ -110,7 +110,7 @@ The adapter is differentially tested with 20 hostile seed documents against Cerb
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 128 of the 130 reference conformance actions, plus `matches()`, list indexing/`get-field`, `timestamp()`, and `int()`/`double()` cast plans that the Spring Data reference adapter rejects — the post-filter reimplements CEL cast semantics exactly (whole-string parse, truncation toward zero), so the SQL divergences do not apply (134 actions total) |
+| Oracle-tested | 131 of the 133 reference conformance actions, plus `matches()`, list indexing/`get-field`, `timestamp()`, and `int()`/`double()` cast plans that the Spring Data reference adapter rejects — the post-filter reimplements CEL cast semantics exactly (whole-string parse, truncation toward zero), so the SQL divergences do not apply (137 actions total) |
 | Fail-closed | `filter()`/`map()` used as a condition (they return a list, not a boolean) and a constant zero divisor whose sign the JSON hop into a Convex function discards (4 actions). All four throw during translation, before any filter exists; unknown operators and invalid expression structures still throw |
 | Explicit opt-in | Any plan that cannot be represented entirely as a Convex database filter requires `allowPostFilter: true` |
 | Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`. Under the default it already returns the empty set the PDP demands *when the document omits the field for a NULL value*, which is what the conformance harness seeds; a deployment that stores explicit nulls while omitting the attribute would over-grant |

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -447,10 +447,10 @@ describe("adversarial conformance corpus", () => {
         ].filter(Boolean).length !== 1,
     );
 
-    expect(allActions.size).toBe(140);
+    expect(allActions.size).toBe(143);
     expect(CONVEX_UNSUPPORTED).toHaveLength(2);
     expect(CONVEX_SUPPORTED_EXPECTED).toHaveLength(6);
-    expect(ORACLE_ACTIONS).toHaveLength(134);
+    expect(ORACLE_ACTIONS).toHaveLength(137);
     expect(THROWING_ACTIONS).toHaveLength(4);
     expect(misclassified).toEqual([]);
   });
@@ -590,13 +590,15 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    // The #309/#312/#311 additions. w1-size-zero-chain and the two string-cast actions are
-    // deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
-    // parent with zero children; every seed's aString raises in int()/double()), so they
-    // cannot satisfy this guard. cast-int-double is the cast group's non-degenerate
-    // stand-in, and the w1/cr actions below carry it for their groups.
+    // The #309/#312/#311/#315/#316 additions. w1-size-zero-chain, w1-not-size-chain and the
+    // two string-cast actions are deliberately absent: their oracles are empty by
+    // CONSTRUCTION (no seed holds a to-one parent with zero children; every seed's aString
+    // raises in int()/double()), so they cannot satisfy this guard. cast-int-double is the
+    // cast group's non-degenerate stand-in, and the w1/cr actions below carry it for their
+    // groups.
     for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
       "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+      "w1-not-in-chain", "w1-not-hasint-chain",
       "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
       "cast-int-double"]) {
       const ids = await oracleAllowedIds(action);

--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -45,7 +45,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 128 reference conformance actions |
+| Oracle-tested | 131 reference conformance actions |
 | Fail-closed corpus shapes | Sub-millisecond `now()` thresholds, regex `matches()`, ordered list indexing/`get-field`, `timestamp()` over an untyped string field, `int()`/`double()` casts (SQL `CAST` reads a numeric prefix where CEL demands the whole string, and rounds where CEL truncates toward zero) and `filter()`/`map()` used as a condition (both return a list, not a boolean) (10 actions) |
 | Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -3,7 +3,17 @@ import * as path from "path";
 
 import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
 import { GRPC as Cerbos } from "@cerbos/grpc";
-import type { Principal, Resource, Value } from "@cerbos/core";
+import {
+  PlanExpression,
+  PlanExpressionValue,
+  PlanExpressionVariable,
+} from "@cerbos/core";
+import type {
+  PlanExpressionOperand,
+  Principal,
+  Resource,
+  Value,
+} from "@cerbos/core";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
@@ -604,7 +614,7 @@ describe("adversarial conformance corpus", () => {
       return classificationCount !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(140);
+    expect(MANIFEST_ACTIONS.size).toBe(143);
     expect(NULL_REPRESENTATION_OMITTED).toHaveLength(1);
     expect(misclassified).toEqual([]);
     expect(
@@ -723,14 +733,78 @@ describe("adversarial conformance corpus", () => {
     expect(await adapterFilteredIds(action)).toEqual(allIds);
   });
 
+  // The corpus pins two count spellings over the chain — `size(...) == 0` and
+  // `!(size(...) > 0)` — but the guard has to be a property of the chain rather than of the
+  // two spellings that happen to be pinned. These synthesise the remaining
+  // threshold/polarity combinations onto the same seeded store and assert the parentless rows
+  // stay out of every one, including an arbitrary-N threshold neither corpus action reaches
+  // (cerbos/query-plan-adapters#316). This adapter guards the COUNT expression itself, so it
+  // was already aligned — the assertion pins that it stays that way.
+  test("every count threshold over the chain inherits the absent-parent guard", async () => {
+    const chain = new PlanExpressionVariable(
+      "request.resource.attr.mainCategory.subCategories"
+    );
+    const size = new PlanExpression("size", [chain]);
+    const compare = (operator: string, threshold: number) =>
+      new PlanExpression(operator, [size, new PlanExpressionValue(threshold)]);
+    const negate = (condition: PlanExpressionOperand) =>
+      new PlanExpression("not", [condition]);
+
+    const filteredIdsFor = (condition: PlanExpressionOperand): string[] => {
+      const result = queryPlanToDrizzle({
+        queryPlan: {
+          kind: PlanKind.CONDITIONAL,
+          condition,
+          cerbosCallId: "synthetic",
+          requestId: "synthetic",
+          validationErrors: [],
+          metadata: undefined,
+        },
+        mapper: MAPPER,
+      });
+      expect(result.kind).toBe(PlanKind.CONDITIONAL);
+      const rows = db
+        .select({ id: adversarialResources.id })
+        .from(adversarialResources)
+        .where(result.kind === PlanKind.CONDITIONAL ? result.filter : undefined)
+        .all();
+      return rows.map((row) => row.id).sort();
+    };
+
+    // Every seed that HAS a mainCategory holds at least one subCategory, and the 16 without
+    // it are CEL missing-path errors — so each of these is empty unless the guard leaks.
+    const emptyByConstruction: [string, PlanExpressionOperand][] = [
+      ["size(chain) == 0", compare("eq", 0)],
+      ["size(chain) <= 0", compare("le", 0)],
+      ["size(chain) >= 2", compare("ge", 2)],
+      ["!(size(chain) > 0)", negate(compare("gt", 0))],
+      ["!(size(chain) >= 1)", negate(compare("ge", 1))],
+      ["!(size(chain) < 2)", negate(compare("lt", 2))],
+    ];
+
+    for (const [shape, condition] of emptyByConstruction) {
+      expect([shape, filteredIdsFor(condition)]).toEqual([shape, []]);
+    }
+
+    // The mirror image, so the loop above cannot pass by denying everything: `>= 0` and `< 2`
+    // are TRUE for exactly the rows that HAVE the parent.
+    const withParent = await oracleAllowedIds("w1-size-nonneg-chain");
+    expect(withParent.length).toBeGreaterThan(0);
+    expect(withParent.length).toBeLessThan(SEEDS.length);
+    expect(filteredIdsFor(compare("ge", 0))).toEqual(withParent);
+    expect(filteredIdsFor(compare("lt", 2))).toEqual(withParent);
+  });
+
   test("oracle is not degenerate", async () => {
     // Guard the guard: at least one action must produce a non-empty, non-total oracle set,
     // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
-    // w1-size-zero-chain is deliberately absent: its oracle is empty by construction (no
-    // seed holds a to-one parent with zero children), so it cannot satisfy this guard. Its
-    // three siblings below carry the anti-vacuity assertion for that group.
+    // w1-size-zero-chain and w1-not-size-chain are deliberately absent: their oracles are
+    // empty by construction (no seed holds a to-one parent with zero children), so they
+    // cannot satisfy this guard. Their siblings below carry the anti-vacuity assertion for
+    // that group.
     for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
       "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+      "w1-not-in-chain", "w1-not-hasint-chain",
       "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne"]) {
       const ids = await oracleAllowedIds(action);
       expect(ids.length).toBeGreaterThan(0);

--- a/drizzle/src/index.ts
+++ b/drizzle/src/index.ts
@@ -465,6 +465,32 @@ const requireLeadingHops = (
   return sql`(case when ${hopsExist} then ${inner} end)`;
 };
 
+/**
+ * Evaluate `filter` over a whole relation chain reached from the root: the correlated
+ * EXISTS of `wrapWithRelations`, made UNKNOWN rather than FALSE when an intermediate to-one
+ * hop is absent.
+ *
+ * Every operator that reaches a collection through a dotted path must go through here
+ * rather than calling `wrapWithRelations` directly. The collection macros used to carry the
+ * hop guard themselves, which left the sibling operators built on the same chain — plain
+ * membership and `hasIntersection` — unguarded: a bare `NOT EXISTS` over an absent parent is
+ * TRUE, so `!("x" in R.attr.parent.names)` returned every parentless row
+ * (cerbos/query-plan-adapters#315). Guarding the chain construction instead of each operator
+ * is what ent and pgx already do, and is why they never had the hole.
+ */
+const wrapRelationChain = (
+  relations: RelationMapping[],
+  filter: SQL,
+  reference: string,
+  options?: BuildFilterOptions
+): SQL =>
+  requireLeadingHops(
+    relations.slice(0, -1),
+    wrapWithRelations(relations, filter, reference, options),
+    reference,
+    options
+  );
+
 const wrapWithRelations = (
   relations: RelationMapping[],
   filter: SQL,
@@ -1357,7 +1383,7 @@ const buildVariableMembershipFilter = (
   if (!match) {
     throw new Error("Unable to combine variable membership conditions");
   }
-  return wrapWithRelations(
+  return wrapRelationChain(
     collection.relations,
     match,
     collectionOperand.name,
@@ -1567,7 +1593,7 @@ const buildHasIntersectionFilter = (
     if (!normalized.relations.length) {
       return filter;
     }
-    const wrapped = wrapWithRelations(
+    const wrapped = wrapRelationChain(
       normalized.relations,
       filter,
       reference,
@@ -2646,7 +2672,7 @@ const buildFilterFromExpression = (
         valueOperand.value
       );
       const filter = resolved.relations.length
-        ? wrapWithRelations(
+        ? wrapRelationChain(
             resolved.relations,
             comparison,
             fieldOperand.name,

--- a/elasticsearch-java/README.md
+++ b/elasticsearch-java/README.md
@@ -374,7 +374,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 | Classification | Coverage |
 | --- | --- |
 | Oracle-tested | 41 reference conformance actions plus regex and timestamp probes (43 actions) |
-| Fail-closed | 89 reference actions plus ordered list indexing/`get-field`, `int()`/`double()` casts and `filter()`/`map()` used as a condition (95 actions total) |
+| Fail-closed | 92 reference actions plus ordered list indexing/`get-field`, `int()`/`double()` casts and `filter()`/`map()` used as a condition (98 actions total) |
 | Representation-independent | `null-eq-missing` — rejected like every other null-selecting comparison, so no NULL-representation option is required |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for indexed attributes instead of `has(R.attr.x)` |
 

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -197,7 +197,7 @@ class ElasticsearchAdversarialConformanceTest {
                 "adapterUnsupported.elasticsearch-java contains non-conformance actions");
         assertTrue(expected.containsAll(supportedExpected),
                 "adapterSupportedExpected.elasticsearch-java contains non-expected actions");
-        assertEquals(89, unsupported.size(),
+        assertEquals(92, unsupported.size(),
                 "Elasticsearch unsupported coverage changed without updating the ledger assertion");
         assertEquals(2, supportedExpected.size(),
                 "Elasticsearch supported-expected coverage changed without updating the ledger assertion");
@@ -225,9 +225,9 @@ class ElasticsearchAdversarialConformanceTest {
         manifest.addAll(nullRepresentationOmittedActions);
         manifest.addAll(divergences);
         assertEquals(43, oracleActions.size());
-        assertEquals(95, throwingActions.size());
+        assertEquals(98, throwingActions.size());
         assertEquals(1, nullRepresentationOmittedActions.size());
-        assertEquals(140, classified.size());
+        assertEquals(143, classified.size());
         assertEquals(manifest, classified, "every manifest action must be classified locally");
     }
 

--- a/ent/README.md
+++ b/ent/README.md
@@ -110,7 +110,7 @@ assumed. The Spring Data adapter defines the reference semantics for this compat
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 130 reference conformance actions — every conformance shape in the corpus, on SQLite, PostgreSQL and MySQL |
+| Oracle-tested | 133 reference conformance actions — every conformance shape in the corpus, on SQLite, PostgreSQL and MySQL |
 | Fail-closed corpus shapes | Regex `matches()`, ordered list indexing/`get-field`, `timestamp()` over an untyped string field, `int()`/`double()` casts (SQL `CAST` reads a numeric prefix where CEL demands the whole string, and rounds where CEL truncates toward zero) and `filter()`/`map()` used as a condition (both return a list, not a boolean) (8 actions) |
 | Representation-dependent | `null-eq-missing` — rejected under `NullOmitted`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
@@ -159,7 +159,10 @@ at once. Treat them as constraints on the policies you write.
 Two gaps listed here previously are now closed and pinned by the corpus rather than documented as
 constraints: an absent to-one parent is no longer indistinguishable from an empty collection (the
 chain requires its intermediate hop, `w1-all-chain`/`w1-not-exists-chain`/`w1-size-zero-chain`/
-`w1-size-nonneg-chain`), and `int()`/`double()` no longer lower to SQL `CAST` at all — they fail
+`w1-size-nonneg-chain`/`w1-not-in-chain`/`w1-not-hasint-chain`/`w1-not-size-chain` — membership
+and the negated count spelling route through the same guarded existence construction as the
+macros, which is why this adapter needed no change when those holes were found elsewhere), and
+`int()`/`double()` no longer lower to SQL `CAST` at all — they fail
 closed, because CEL reads a whole string or raises where `CAST` reads a numeric prefix, and CEL
 truncates toward zero where PostgreSQL and MySQL round (`cast-int-string`, `cast-double-string`,
 `cast-int-double`).

--- a/ent/adversarial_test.go
+++ b/ent/adversarial_test.go
@@ -673,7 +673,7 @@ func runConformance(t *testing.T, h *harness) {
 		}
 		// Corpus-size tripwire: bump deliberately when the corpus grows, so a new hostile shape
 		// cannot slip past this adapter unnoticed.
-		require.Len(t, seen, 140, "corpus size changed; triage the new action(s) before bumping")
+		require.Len(t, seen, 143, "corpus size changed; triage the new action(s) before bumping")
 		require.Len(t, h.corpus.Seeds.Seeds, 20, "seed count changed")
 	})
 
@@ -738,15 +738,16 @@ func runConformance(t *testing.T, h *harness) {
 		// The comparison above can pass vacuously if the oracle itself is trivial. Assert that a
 		// representative spread of actions has an oracle that is neither empty nor the full seed
 		// set — without this, a silently broken PDP connection would still pass every case.
-		// w1-size-zero-chain, cast-int-string and cast-double-string are deliberately absent:
-		// their oracles are empty by CONSTRUCTION (no seed holds a to-one parent with zero
-		// children; every seed's aString raises in int()/double()), so they cannot satisfy this
-		// guard. cast-int-double stands in for the cast group.
+		// w1-size-zero-chain, w1-not-size-chain, cast-int-string and cast-double-string are
+		// deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
+		// parent with zero children; every seed's aString raises in int()/double()), so they
+		// cannot satisfy this guard. cast-int-double stands in for the cast group.
 		representative := []string{
 			"vf-le", "in-single", "like-percent", "exists-on-empty", "not-exists",
 			"nary-and", "field-to-field", "ternary-cmp", "arith-add", "size-threshold",
 			"hier-ancestor-cf", "pv-exists", "in-null-elem-mixed", "null-eq", "cs-eq",
 			"w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+			"w1-not-in-chain", "w1-not-hasint-chain",
 			"cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
 			"cast-int-double",
 		}

--- a/langchain-chromadb/README.md
+++ b/langchain-chromadb/README.md
@@ -97,7 +97,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 | Classification | Coverage |
 | --- | --- |
 | Oracle-tested | 15 reference actions: directional and inequality comparisons, single/empty membership, Unicode and empty strings, negative numbers, n-ary/double/triple negation, membership on an optional resource field, mapped nested-field equality, and case-sensitive equality |
-| Fail-closed | 115 reference conformance actions plus regex, ordered indexing/`get-field`, timestamp, cast and non-boolean-macro probes (123 actions total) |
+| Fail-closed | 118 reference conformance actions plus regex, ordered indexing/`get-field`, timestamp, cast and non-boolean-macro probes (126 actions total) |
 | Representation-independent | `null-eq-missing` — rejected like every other null comparison operand, so no `nullAttributeRepresentation` option is required |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 

--- a/langchain-chromadb/src/adversarial.test.ts
+++ b/langchain-chromadb/src/adversarial.test.ts
@@ -578,7 +578,7 @@ async function adapterFilteredIds(action: string): Promise<string[]> {
 }
 
 describe("adversarial conformance corpus", () => {
-  test("manifest assigns all 140 policy actions exactly one Chroma outcome", () => {
+  test("manifest assigns all 143 policy actions exactly one Chroma outcome", () => {
     const oracle = new Set(CHROMA_SUPPORTED_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map(({ action }) => action));
     const nullOmitted = new Set(
@@ -594,12 +594,12 @@ describe("adversarial conformance corpus", () => {
       return classificationCount !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(140);
+    expect(MANIFEST_ACTIONS.size).toBe(143);
     expect(CHROMA_SUPPORTED_ACTIONS).toHaveLength(15);
     expect(oracle.size).toBe(CHROMA_SUPPORTED_ACTIONS.length);
-    expect(CHROMA_UNSUPPORTED).toHaveLength(115);
+    expect(CHROMA_UNSUPPORTED).toHaveLength(118);
     expect(CHROMA_SUPPORTED_EXPECTED).toHaveLength(0);
-    expect(THROWING_ACTIONS).toHaveLength(123);
+    expect(THROWING_ACTIONS).toHaveLength(126);
     expect(misclassified).toEqual([]);
   });
 
@@ -662,11 +662,12 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    // #309/#312/#311. w1-size-zero-chain and the two string-cast actions are deliberately
-    // absent: their oracles are empty by CONSTRUCTION, so they cannot satisfy this guard;
-    // cast-int-double is the cast group's non-degenerate stand-in.
+    // #309/#312/#311/#315/#316. w1-size-zero-chain, w1-not-size-chain and the two string-cast
+    // actions are deliberately absent: their oracles are empty by CONSTRUCTION, so they
+    // cannot satisfy this guard; cast-int-double is the cast group's non-degenerate stand-in.
     for (const action of ["vf-le", "nary-and", "p-in-null-multi", "pv-exists", "pv-all", "null-eq", "null-ne",
       "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+      "w1-not-in-chain", "w1-not-hasint-chain",
       "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
       "cast-int-double"]) {
       const ids = await oracleAllowedIds(action);

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -70,7 +70,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 94 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (97 actions) |
+| Oracle-tested | 97 reference conformance actions plus regex, ordered indexing/`get-field`, and timestamp probes (100 actions) |
 | Fail-closed | 36 reference actions plus the 5 reference-unsupported shapes (41 actions total) |
 | Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`. Under the default it already returns the empty set the PDP demands, because `nullable: true` on a mapper entry declares per-attribute that a stored null is a missing Cerbos attribute; the global option is the backstop for mappings that do not declare it |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute documents. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -2,7 +2,17 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { afterAll, beforeAll, describe, expect, test } from "@jest/globals";
-import type { Principal, Resource, Value } from "@cerbos/core";
+import {
+  PlanExpression,
+  PlanExpressionValue,
+  PlanExpressionVariable,
+} from "@cerbos/core";
+import type {
+  PlanExpressionOperand,
+  Principal,
+  Resource,
+  Value,
+} from "@cerbos/core";
 import { GRPC as Cerbos } from "@cerbos/grpc";
 import mongoose, { model, Schema } from "mongoose";
 
@@ -747,7 +757,7 @@ function planCarriesNullLiteral(operand: unknown): boolean {
 }
 
 describe("adversarial conformance corpus", () => {
-  test("manifest assigns all 140 actions exactly one Mongoose outcome", () => {
+  test("manifest assigns all 143 actions exactly one Mongoose outcome", () => {
     const oracle = new Set(ORACLE_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map((entry) => entry.action));
     const nullOmitted = new Set(
@@ -763,10 +773,10 @@ describe("adversarial conformance corpus", () => {
       return count !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(140);
+    expect(MANIFEST_ACTIONS.size).toBe(143);
     expect(unsupportedEntries).toHaveLength(36);
     expect(supportedExpectedEntries).toHaveLength(3);
-    expect(ORACLE_ACTIONS).toHaveLength(97);
+    expect(ORACLE_ACTIONS).toHaveLength(100);
     expect(THROWING_ACTIONS).toHaveLength(41);
     expect(misclassified).toEqual([]);
     expect(
@@ -888,14 +898,80 @@ describe("adversarial conformance corpus", () => {
     expect(await adapterFilteredIds(action)).toEqual(allIds);
   });
 
+  // The corpus pins two count spellings over the chain — `size(...) == 0` and
+  // `!(size(...) > 0)` — but the guard has to be a property of the chain rather than of the
+  // two spellings that happen to be pinned. These synthesise the remaining
+  // threshold/polarity combinations onto the same seeded collection and assert the parentless
+  // documents stay out of every one, including an arbitrary-N threshold neither corpus action
+  // reaches (cerbos/query-plan-adapters#316).
+  test("every count threshold over the chain inherits the absent-parent guard", async () => {
+    const chain = new PlanExpressionVariable(
+      "request.resource.attr.mainCategory.subCategories"
+    );
+    const size = new PlanExpression("size", [chain]);
+    const compare = (operator: string, threshold: number) =>
+      new PlanExpression(operator, [size, new PlanExpressionValue(threshold)]);
+    const negate = (condition: PlanExpressionOperand) =>
+      new PlanExpression("not", [condition]);
+
+    const filteredIdsFor = async (
+      condition: PlanExpressionOperand
+    ): Promise<string[]> => {
+      const result = queryPlanToMongoose({
+        queryPlan: {
+          kind: PlanKind.CONDITIONAL,
+          condition,
+          cerbosCallId: "synthetic",
+          requestId: "synthetic",
+          validationErrors: [],
+          metadata: undefined,
+        },
+        mapper: MAPPER,
+      });
+      expect(result.kind).toBe(PlanKind.CONDITIONAL);
+      const rows = await AdversarialResource.find(
+        result.kind === PlanKind.CONDITIONAL ? result.filters : {}
+      )
+        .select({ resourceId: 1, _id: 0 })
+        .lean()
+        .exec();
+      return rows.map((row) => row.resourceId).sort();
+    };
+
+    // Every seed that HAS a mainCategory holds at least one subCategory, and the 16 without
+    // it are CEL missing-path errors — so each of these is empty unless the guard leaks.
+    const emptyByConstruction: [string, PlanExpressionOperand][] = [
+      ["size(chain) == 0", compare("eq", 0)],
+      ["size(chain) <= 0", compare("le", 0)],
+      ["size(chain) >= 2", compare("ge", 2)],
+      ["!(size(chain) > 0)", negate(compare("gt", 0))],
+      ["!(size(chain) >= 1)", negate(compare("ge", 1))],
+      ["!(size(chain) < 2)", negate(compare("lt", 2))],
+    ];
+
+    for (const [shape, condition] of emptyByConstruction) {
+      expect([shape, await filteredIdsFor(condition)]).toEqual([shape, []]);
+    }
+
+    // The mirror image, so the loop above cannot pass by denying everything: `>= 0` and `< 2`
+    // are TRUE for exactly the documents that HAVE the parent.
+    const withParent = await oracleAllowedIds("w1-size-nonneg-chain");
+    expect(withParent.length).toBeGreaterThan(0);
+    expect(withParent.length).toBeLessThan(SEEDS.length);
+    expect(await filteredIdsFor(compare("ge", 0))).toEqual(withParent);
+    expect(await filteredIdsFor(compare("lt", 2))).toEqual(withParent);
+  });
+
   test("oracle is not degenerate", async () => {
-    // The #309/#312/#311 additions. w1-size-zero-chain and the two string-cast actions are
-    // deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
-    // parent with zero children; every seed's aString raises in int()/double()), so they
-    // cannot satisfy this guard. cast-int-double is the cast group's non-degenerate
-    // stand-in, and the w1/cr actions below carry it for their groups.
+    // The #309/#312/#311/#315/#316 additions. w1-size-zero-chain, w1-not-size-chain and the
+    // two string-cast actions are deliberately absent: their oracles are empty by
+    // CONSTRUCTION (no seed holds a to-one parent with zero children; every seed's aString
+    // raises in int()/double()), so they cannot satisfy this guard. cast-int-double is the
+    // cast group's non-degenerate stand-in, and the w1/cr actions below carry it for their
+    // groups.
     for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
       "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+      "w1-not-in-chain", "w1-not-hasint-chain",
       "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
       "cast-int-double"]) {
       const ids = await oracleAllowedIds(action);

--- a/mongoose/src/index.ts
+++ b/mongoose/src/index.ts
@@ -394,6 +394,55 @@ const referencesNullableField = (
     isNullableReference(name, mapper)
   );
 
+/**
+ * "Every to-one parent this expression dots through is present", as a Mongoose filter, or
+ * undefined when it dots through none.
+ *
+ * CEL cannot dot through a list, so each intermediate segment of `a.b.c` is a to-ONE parent:
+ * absent, the application sends no attribute at all and CEL raises a missing-path error,
+ * which denies. The flattened `a.b` path a Mongo filter matches against cannot see that — an
+ * absent parent and a childless parent both fail the match — so any `$nor` over it is TRUE
+ * for a parentless document and returns rows the PDP denies.
+ *
+ * `requiresParent` already carried this for the `$size` aggregation (#309); membership,
+ * `hasIntersection` and the negated count spelling reach the same chain without ever passing
+ * through it (cerbos/query-plan-adapters#315, #316). Requiring the parent OUTSIDE the `$nor`
+ * fixes all of them at once, and is unconditionally faithful to CEL rather than a
+ * per-operator patch: a missing parent denies under BOTH polarities regardless of which
+ * operator sits above the chain.
+ *
+ * `<parent>.0` exists exactly when the parent array is non-empty, which is how the document
+ * model spells "the to-one parent was serialised" — the same test the `$size` guard makes
+ * with `$ifNull`. That `$size` guard alone is not enough: it makes the count `null`, and BSON
+ * orders `null` BELOW every number, so `$eq`/`$gt`/`$gte` against it are false but `$lte`/`$lt`
+ * are TRUE — `size(chain) <= 0` admitted every parentless document. A filter-level conjunct
+ * has no such ordering to get wrong.
+ *
+ * `requiresParent` only ever appears on a top-level mapping, so the paths produced here are
+ * always rooted at the document. A nested `fields` entry that declared one would need its
+ * path rebased onto the enclosing `$elemMatch` scope instead.
+ */
+const buildRequiredParentsFilter = (
+  operand: PlanExpressionOperand,
+  mapper: Mapper
+): MongooseFilter | undefined => {
+  const parents = new Set<string>();
+  for (const name of collectVariableNames(operand)) {
+    const parentPath = resolveFieldReference(name, mapper).relation
+      ?.requiresParent;
+    if (parentPath !== undefined) {
+      parents.add(parentPath);
+    }
+  }
+  if (parents.size === 0) {
+    return undefined;
+  }
+  const clauses = [...parents].map((parentPath) => ({
+    [`${parentPath}.0`]: { $exists: true },
+  }));
+  return clauses.length === 1 ? clauses[0]! : { $and: clauses };
+};
+
 const buildNestedObject = (path: string[], value: any) =>
   path.reduceRight(
     (acc: any, key: string, index: number) =>
@@ -932,9 +981,16 @@ const withEvaluationGuards = (
   const guards = operands
     .flatMap(collectGuardedExpressions)
     .map((expression) => buildEvaluationGuard(expression, mapper));
-  return guards.length === 0
+  // The absent to-one parent is the other way an operand can be undefined, and it belongs
+  // here with the rest: a filter-level conjunct applies to whatever `filter` already is, so
+  // both the plain comparison and the `$nor` a negation wraps it in inherit it (#315, #316).
+  const requiredParents = operands
+    .map((operand) => buildRequiredParentsFilter(operand, mapper))
+    .filter((parents): parents is MongooseFilter => parents !== undefined);
+  const conjuncts = [...guards, ...requiredParents];
+  return conjuncts.length === 0
     ? guardedFilter
-    : { $and: [...guards, guardedFilter] };
+    : { $and: [...conjuncts, guardedFilter] };
 };
 
 const getOperandAt = (
@@ -1401,6 +1457,9 @@ const buildMongooseFilterFromCerbosExpression = (
           ),
         ],
       };
+      // withEvaluationGuards ANDs its conjuncts OUTSIDE this $nor, which is where the
+      // absent-parent requirement has to sit: inside, the negation would flip it along with
+      // the predicate and readmit every parentless document (#315, #316).
       return withEvaluationGuards(negatedFilter, [operand], mapper);
     }
 

--- a/pgx/README.md
+++ b/pgx/README.md
@@ -96,7 +96,7 @@ semantics for this compatibility snapshot.
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 130 reference conformance actions — every conformance shape in the corpus |
+| Oracle-tested | 133 reference conformance actions — every conformance shape in the corpus |
 | Fail-closed corpus shapes | Regex `matches()`, ordered list indexing/`get-field`, `timestamp()` over an untyped string field, `int()`/`double()` casts (SQL `CAST` reads a numeric prefix where CEL demands the whole string, and rounds where CEL truncates toward zero) and `filter()`/`map()` used as a condition (both return a list, not a boolean) (8 actions) |
 | Representation-dependent | `null-eq-missing` — rejected under `NullOmitted`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
@@ -127,7 +127,10 @@ at once. Treat them as constraints on the policies you write.
 Two gaps listed here previously are now closed and pinned by the corpus rather than documented as
 constraints: an absent to-one parent is no longer indistinguishable from an empty collection (the
 chain requires its intermediate hop, and `w1-all-chain`/`w1-not-exists-chain`/`w1-size-zero-chain`/
-`w1-size-nonneg-chain` are oracle-compared here), and `int()`/`double()` no longer lower to SQL
+`w1-size-nonneg-chain`/`w1-not-in-chain`/`w1-not-hasint-chain`/`w1-not-size-chain` are
+oracle-compared here — membership and the negated count spelling route through the same guarded
+existence construction as the macros, which is why this adapter needed no change when those holes
+were found elsewhere), and `int()`/`double()` no longer lower to SQL
 `CAST` at all — they fail closed, because CEL reads a whole string or raises where `CAST` reads a
 numeric prefix, and CEL truncates toward zero where PostgreSQL rounds (`cast-int-string`,
 `cast-double-string`, `cast-int-double`).

--- a/pgx/adversarial_test.go
+++ b/pgx/adversarial_test.go
@@ -449,7 +449,7 @@ func TestAdversarialConformance(t *testing.T) {
 		}
 		// Corpus-size tripwire: bump deliberately when the corpus grows, so a new hostile shape
 		// cannot slip past this adapter unnoticed.
-		require.Len(t, seen, 140, "corpus size changed; triage the new action(s) before bumping")
+		require.Len(t, seen, 143, "corpus size changed; triage the new action(s) before bumping")
 		require.Len(t, h.corpus.Seeds.Seeds, 20, "seed count changed")
 	})
 
@@ -513,15 +513,16 @@ func TestAdversarialConformance(t *testing.T) {
 		// The comparison above can pass vacuously if the oracle itself is trivial. Assert that a
 		// representative spread of actions has an oracle that is neither empty nor the full seed
 		// set — without this, a silently broken PDP connection would still pass every case.
-		// w1-size-zero-chain, cast-int-string and cast-double-string are deliberately absent:
-		// their oracles are empty by CONSTRUCTION (no seed holds a to-one parent with zero
-		// children; every seed's aString raises in int()/double()), so they cannot satisfy this
-		// guard. cast-int-double stands in for the cast group.
+		// w1-size-zero-chain, w1-not-size-chain, cast-int-string and cast-double-string are
+		// deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
+		// parent with zero children; every seed's aString raises in int()/double()), so they
+		// cannot satisfy this guard. cast-int-double stands in for the cast group.
 		representative := []string{
 			"vf-le", "in-single", "like-percent", "exists-on-empty", "not-exists",
 			"nary-and", "field-to-field", "ternary-cmp", "arith-add", "size-threshold",
 			"hier-ancestor-cf", "pv-exists", "in-null-elem-mixed", "null-eq", "cs-eq",
 			"w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+			"w1-not-in-chain", "w1-not-hasint-chain",
 			"cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
 			"cast-int-double",
 		}

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -134,7 +134,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 91 reference actions |
+| Oracle-tested | 94 reference actions |
 | Fail-closed | 39 reference actions plus the 8 reference-unsupported shapes (47 actions total) |
 | Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `checkResource` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -2,7 +2,17 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { GRPC as Cerbos } from "@cerbos/grpc";
-import type { Principal, Resource, Value } from "@cerbos/core";
+import {
+  PlanExpression,
+  PlanExpressionValue,
+  PlanExpressionVariable,
+} from "@cerbos/core";
+import type {
+  PlanExpressionOperand,
+  Principal,
+  Resource,
+  Value,
+} from "@cerbos/core";
 
 import { queryPlanToPrisma, PlanKind, MapperConfig } from ".";
 import { prisma } from "./test-setup.adversarial";
@@ -543,7 +553,7 @@ describe("adversarial conformance corpus", () => {
     ).not.toContain(promotedAction);
   });
 
-  test("manifest assigns all 140 policy actions exactly one Prisma outcome", () => {
+  test("manifest assigns all 143 policy actions exactly one Prisma outcome", () => {
     const oracle = new Set(ORACLE_ACTIONS);
     const throwing = new Set(THROWING_ACTIONS.map(([action]) => action));
     const nullOmitted = new Set(
@@ -559,7 +569,7 @@ describe("adversarial conformance corpus", () => {
       return classificationCount !== 1;
     });
 
-    expect(MANIFEST_ACTIONS.size).toBe(140);
+    expect(MANIFEST_ACTIONS.size).toBe(143);
     expect(misclassified).toEqual([]);
     expect(
       [...PRISMA_SUPPORTED_EXPECTED].filter(
@@ -679,16 +689,83 @@ describe("adversarial conformance corpus", () => {
     expect(await adapterFilteredIds(action)).toEqual(allIds);
   });
 
+  // The corpus pins two count spellings over the chain — `size(...) == 0` and
+  // `!(size(...) > 0)` — and CEL's type checker rules out a third that a real policy could
+  // reach through the planner (`>= 1` and `<= 0` are the only other thresholds this adapter
+  // can express, and no policy needs both spellings). The guard must nonetheless be a
+  // property of the chain rather than of the two spellings that happen to be pinned, so
+  // these synthesise the remaining threshold/polarity combinations directly onto the same
+  // seeded store and assert the parentless rows stay out of every one
+  // (cerbos/query-plan-adapters#316).
+  test("every count threshold over the chain inherits the absent-parent guard", async () => {
+    const chain = new PlanExpressionVariable(
+      "request.resource.attr.mainCategory.subCategories"
+    );
+    const size = new PlanExpression("size", [chain]);
+    const compare = (operator: string, threshold: number) =>
+      new PlanExpression(operator, [size, new PlanExpressionValue(threshold)]);
+    const negate = (condition: PlanExpressionOperand) =>
+      new PlanExpression("not", [condition]);
+
+    const filteredIdsFor = async (
+      condition: PlanExpressionOperand
+    ): Promise<string[]> => {
+      const result = queryPlanToPrisma({
+        queryPlan: {
+          kind: PlanKind.CONDITIONAL,
+          condition,
+          cerbosCallId: "synthetic",
+          requestId: "synthetic",
+          validationErrors: [],
+          metadata: undefined,
+        },
+        mapper: MAPPER,
+        model: "AdversarialResource",
+      });
+      expect(result.kind).toBe(PlanKind.CONDITIONAL);
+      const where = result.kind === PlanKind.CONDITIONAL ? result.filters : {};
+      const rows = await prisma.adversarialResource.findMany({
+        where,
+        select: { id: true },
+      });
+      return rows.map((row) => row.id).sort();
+    };
+
+    // Each of these is TRUE for a row with no mainCategory only if the guard leaks: an
+    // absent to-one parent is a CEL missing-path error, so the PDP denies it outright.
+    const emptyByConstruction: [string, PlanExpressionOperand][] = [
+      ["size(chain) == 0", compare("eq", 0)],
+      ["size(chain) <= 0", compare("le", 0)],
+      ["size(chain) < 1", compare("lt", 1)],
+      ["!(size(chain) >= 1)", negate(compare("ge", 1))],
+      ["!(size(chain) > 0)", negate(compare("gt", 0))],
+    ];
+
+    for (const [shape, condition] of emptyByConstruction) {
+      expect([shape, await filteredIdsFor(condition)]).toEqual([shape, []]);
+    }
+
+    // The mirror image, so the loop above cannot pass by denying everything: the negation of
+    // an emptiness check is TRUE for exactly the rows that HAVE the parent.
+    const withParent = await oracleAllowedIds("w1-size-nonneg-chain");
+    expect(withParent.length).toBeGreaterThan(0);
+    expect(withParent.length).toBeLessThan(SEEDS.length);
+    expect(await filteredIdsFor(negate(compare("eq", 0)))).toEqual(withParent);
+    expect(await filteredIdsFor(negate(compare("lt", 1)))).toEqual(withParent);
+  });
+
   test("oracle is not degenerate", async () => {
     // Guard the guard: at least one action must produce a non-empty, non-total oracle set,
     // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
-    // The #309/#312/#311 additions. w1-size-zero-chain and the two string-cast actions are
-    // deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
-    // parent with zero children; every seed's aString raises in int()/double()), so they
-    // cannot satisfy this guard. cast-int-double is the cast group's non-degenerate
-    // stand-in, and the w1/cr actions below carry it for their groups.
+    // The #309/#312/#311/#315/#316 additions. w1-size-zero-chain, w1-not-size-chain and the
+    // two string-cast actions are deliberately absent: their oracles are empty by
+    // CONSTRUCTION (no seed holds a to-one parent with zero children; every seed's aString
+    // raises in int()/double()), so they cannot satisfy this guard. cast-int-double is the
+    // cast group's non-degenerate stand-in, and the w1/cr actions below carry it for their
+    // groups.
     for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
       "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+      "w1-not-in-chain", "w1-not-hasint-chain",
       "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
       "cast-int-double"]) {
       const ids = await oracleAllowedIds(action);

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -1149,6 +1149,79 @@ function buildLeadingHopsExistFilter(
   return { [head.name]: { [getPrismaRelationOperator(head)]: inner } };
 }
 
+/**
+ * "Every intermediate to-one hop this expression dots through exists", as a Prisma filter,
+ * or undefined when it dots through none.
+ *
+ * Prisma has no UNKNOWN: a chained relation filter is exact under the POSITIVE polarity —
+ * `categories: { some: { subCategories: { some: P } } }` cannot hold without the category —
+ * but `NOT` inverts the hop requirement along with the predicate, so every operator built on
+ * a chain readmits the parentless rows once negated. #309 fixed that inside the collection
+ * macros, which left the sibling operators reached through the same chain unguarded:
+ * membership and `hasIntersection` (cerbos/query-plan-adapters#315), and the negated count
+ * spelling `!(size(chain) > 0)` (#316), all of which the macros' guard never saw.
+ *
+ * Requiring the hops OUTSIDE the negation is what fixes all of them at once, and it is
+ * unconditionally faithful to CEL rather than a per-operator patch: a missing hop is a
+ * missing-path error, which denies under BOTH polarities, so the requirement never depends
+ * on which operator sits above the chain.
+ *
+ * Lambda bodies are deliberately not walked — their references resolve against a scoped
+ * mapper, and a negated macro carries its own guard through buildNegatedCollectionFilter.
+ */
+function buildExpressionHopsExistFilter(
+  operand: PlanExpressionOperand,
+  mapper: Mapper
+): PrismaFilter | undefined {
+  const hops: PrismaFilter[] = [];
+  const seen = new Set<string>();
+
+  const visit = (expr: PlanExpressionOperand): void => {
+    if (isNamedOperand(expr)) {
+      if (seen.has(expr.name)) {
+        return;
+      }
+      seen.add(expr.name);
+      const { relations } = resolveFieldReference(expr.name, mapper);
+      if (!relations || relations.length < 2) {
+        return;
+      }
+      const head = assertDefined(relations[0], "Relation mapping is missing");
+      const hopFilter = buildLeadingHopsExistFilter(head, relations.slice(1));
+      if (hopFilter !== undefined) {
+        hops.push(hopFilter);
+      }
+      return;
+    }
+    if (!isOperatorOperand(expr) || expr.operator === "lambda") {
+      return;
+    }
+    expr.operands.forEach(visit);
+  };
+
+  visit(operand);
+
+  if (hops.length === 0) {
+    return undefined;
+  }
+  return hops.length === 1
+    ? assertDefined(hops[0], "Leading-hops filter is missing")
+    : { AND: hops };
+}
+
+/**
+ * `{ NOT: filter }`, with every to-one hop `operand` dots through required OUTSIDE the
+ * negation so an absent parent stays denied (see buildExpressionHopsExistFilter).
+ */
+function negateRequiringHops(
+  operand: PlanExpressionOperand,
+  filter: PrismaFilter,
+  mapper: Mapper
+): PrismaFilter {
+  const hops = buildExpressionHopsExistFilter(operand, mapper);
+  return hops === undefined ? { NOT: filter } : { AND: [hops, { NOT: filter }] };
+}
+
 function buildNestedRelationFilter(
   relations: RelationConfig[],
   fieldFilter: any
@@ -1448,6 +1521,26 @@ function containsCollectionOperator(expr: PlanExpressionOperand): boolean {
 }
 
 /**
+ * Whether `expr` dots through at least one intermediate to-one hop, so negating it needs the
+ * hop requirement of buildExpressionHopsExistFilter.
+ */
+function referencesChainedRelation(
+  expr: PlanExpressionOperand,
+  mapper: Mapper
+): boolean {
+  if (isNamedOperand(expr)) {
+    const { relations } = resolveFieldReference(expr.name, mapper);
+    return relations !== undefined && relations.length > 1;
+  }
+  if (!isOperatorOperand(expr) || expr.operator === "lambda") {
+    return false;
+  }
+  return expr.operands.some((operand) =>
+    referencesChainedRelation(operand, mapper)
+  );
+}
+
+/**
  * Builds the filter for `!expr`. Plain field predicates negate correctly with Prisma's NOT
  * (SQL three-valued logic keeps NULL rows excluded under both polarities), but relation
  * subqueries collapse UNKNOWN to false at the EXISTS boundary, so `NOT(some(P))` would
@@ -1474,12 +1567,23 @@ function buildNegatedFilter(
     if (!relations || relations.length === 0) {
       return buildFieldEqualsFilter(fieldRef, false);
     }
-    return {
-      NOT: buildPrismaFilterFromCerbosExpression(operand, mapper),
-    };
+    return negateRequiringHops(
+      operand,
+      buildPrismaFilterFromCerbosExpression(operand, mapper),
+      mapper
+    );
   }
 
-  if (isOperatorOperand(operand) && containsCollectionOperator(operand)) {
+  // `and`/`or` must be pushed through with De Morgan whenever a branch can be UNKNOWN, so
+  // CEL's error absorption survives: `!(A && B)` with A erroring and B false is TRUE in CEL,
+  // and `OR[!A, !B]` reproduces that where a single outer NOT over the conjunction — with the
+  // hop requirement ANDed outside it — would deny. A chained relation is the second source of
+  // UNKNOWN besides the collection macros, so it opens the same push-down.
+  if (
+    isOperatorOperand(operand) &&
+    (containsCollectionOperator(operand) ||
+      referencesChainedRelation(operand, mapper))
+  ) {
     switch (operand.operator) {
       case "and":
         return {
@@ -1510,9 +1614,11 @@ function buildNegatedFilter(
     }
   }
 
-  return {
-    NOT: buildPrismaFilterFromCerbosExpression(operand, mapper),
-  };
+  return negateRequiringHops(
+    operand,
+    buildPrismaFilterFromCerbosExpression(operand, mapper),
+    mapper
+  );
 }
 
 function getTernaryOperands(operands: PlanExpressionOperand[]): {

--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -286,7 +286,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 128 of the 130 reference conformance actions |
+| Oracle-tested | 131 of the 133 reference conformance actions |
 | Fail-closed corpus shapes | Regex `matches()`, ordered list indexing/`get-field`, `timestamp()` over an ambiguous string column, `int()`/`double()` casts, `filter()`/`map()` used as a condition, and arithmetic composed on a division whose denominator may be zero (10 actions) |
 | Representation-dependent | `null-eq-missing` — rejected under `NullAttributeRepresentation.OMITTED`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute rows; this is pinned separately as an upstream divergence |

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -2137,21 +2137,26 @@ public final class SpringDataQueryPlanAdapter {
                     boolean empty = ("eq".equals(cmpOp) && numValue == 0L)
                             || ("le".equals(cmpOp) && numValue == 0L)
                             || ("lt".equals(cmpOp) && numValue == 1L);
-                    if (nonEmpty) {
-                        // A non-empty count already implies the hop, so no guard is needed.
+                    // The EXISTS emptiness shortcuts below are TWO-valued, so a chain must not
+                    // take them: `NOT EXISTS` is TRUE for an absent to-one parent, which is why
+                    // `!(size(chain) > 0)` readmitted every parentless row even though
+                    // `size(chain) == 0` — guarded by a separate AND — did not
+                    // (cerbos/query-plan-adapters#316). Guarding the COUNT EXPRESSION instead of
+                    // each comparison shortcut is what makes `== 0`, `> 0`, `>= N` and all their
+                    // negations inherit the guard: the count is SQL NULL without the hop, so
+                    // every comparison built on it is UNKNOWN under BOTH polarities.
+                    boolean chained = leadingHopsExist(scope, ref) != null;
+                    if (nonEmpty && !chained) {
                         return existsSubquery(scope, ref, (sub, tailJoin, rebased) -> cb.conjunction());
                     }
-                    if (empty) {
-                        // `size(chain) == 0` is TRUE over an empty count, which is exactly what an
-                        // absent to-one parent produces — require the hop separately (#309).
-                        Predicate emptyTail = tri.not(existsSubquery(scope, ref,
+                    if (empty && !chained) {
+                        return tri.not(existsSubquery(scope, ref,
                                 (sub, tailJoin, rebased) -> cb.conjunction()));
-                        Predicate hops = leadingHopsExist(scope, ref);
-                        return hops == null ? emptyTail : cb.and(hops, emptyTail);
                     }
-                    // Arbitrary N → correlated (SELECT COUNT(...)) <op> N. For a multi-hop chain
-                    // the COUNT joins through every hop, so it counts the FLATTENED tail
-                    // elements — the same element set the EXISTS shortcuts range over.
+                    // Arbitrary N (and every threshold over a chain) → correlated
+                    // (SELECT COUNT(...)) <op> N. For a multi-hop chain the COUNT joins through
+                    // every hop, so it counts the FLATTENED tail elements — the same element set
+                    // the EXISTS shortcuts range over.
                     return compareCount(
                             requireLeadingHops(scope, ref, countSubquery(scope, ref).sub(), Long.class),
                             cmpOp, numValue);
@@ -2293,7 +2298,9 @@ public final class SpringDataQueryPlanAdapter {
          *   <li>NULL scalar vs no null element → FALSE (the equality is UNKNOWN and the
          *       IS NULL conjunct fails on the member side, so no subquery row qualifies).</li>
          * </ul>
-         * EXISTS itself is two-valued, so {@code tri.not} composes exactly. Like field-to-field
+         * A direct relation's EXISTS is two-valued, so {@code tri.not} composes exactly; over a
+         * CHAIN the membership goes through {@link #chainContains}, which is UNKNOWN for an
+         * absent to-one parent so that the negation cannot readmit it. Like field-to-field
          * comparisons, there is no (field, value) pair — {@link OperatorFunction} overrides are
          * not consulted.
          */
@@ -2310,7 +2317,7 @@ public final class SpringDataQueryPlanAdapter {
             // Resolve the member OUTSIDE the subquery first so an unknown/Relation-valued
             // member reports its own resolution error rather than a subquery-build failure.
             scope.resolvePath(memberVar);
-            return existsSubquery(scope, ref, (sub, tailJoin, rebased) -> {
+            return chainContains(scope, ref, (sub, tailJoin, rebased) -> {
                 Path<?> element = Scope.memberPath(tailJoin, ref.tail(), null);
                 // The outer scalar resolves through the REBASED scope so the produced path is
                 // a legal correlation reference inside the subquery.
@@ -2499,7 +2506,7 @@ public final class SpringDataQueryPlanAdapter {
             // attribute → CEL error; see handleMapIntersection.)
             List<?> nonNull = values.stream().filter(Objects::nonNull).toList();
             boolean hasNull = nonNull.size() < values.size();
-            return existsSubquery(scope, ref, (sub, tailJoin, rebased) -> {
+            return chainContains(scope, ref, (sub, tailJoin, rebased) -> {
                 Path<?> field = Scope.memberPath(tailJoin, ref.tail(), null);
                 if (!hasNull) {
                     return values.size() == 1 ? cb.equal(field, values.get(0)) : field.in(values);
@@ -2964,6 +2971,32 @@ public final class SpringDataQueryPlanAdapter {
             cs.sub().select(cb.literal(1));
             cs.sub().where(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()));
             return cb.exists(cs.sub());
+        }
+
+        /**
+         * "Some element of the chain satisfies the body", as a THREE-valued predicate: UNKNOWN
+         * rather than FALSE when an intermediate to-one hop is absent.
+         *
+         * <p>Every operator whose whole answer is an existence test over a chain must build it
+         * here rather than calling {@link #existsSubquery} directly. {@code EXISTS} is
+         * two-valued, so {@code NOT EXISTS} over an absent to-one parent is TRUE and readmits
+         * every parentless row — which is how {@code !("x" in R.attr.parent.names)} and its
+         * {@code hasIntersection} sibling kept over-granting after the collection macros were
+         * fixed (cerbos/query-plan-adapters#315). Counting instead of testing existence lets the
+         * guard live on the count EXPRESSION, so both polarities inherit it.
+         *
+         * <p>A direct relation keeps the plain {@code EXISTS}: it has no hop to require, and its
+         * empty-collection semantics are already correct under both polarities.
+         */
+        private Predicate chainContains(Scope scope, Scope.ResolvedRelation ref,
+                                        SubqueryBodyBuilder bodyBuilder) {
+            if (leadingHopsExist(scope, ref) == null) {
+                return existsSubquery(scope, ref, bodyBuilder);
+            }
+            ChainSubquery<Long> cs = countSubquery(scope, ref);
+            cs.sub().where(bodyBuilder.build(cs.sub(), cs.tailJoin(), cs.rebasedOuter()));
+            return cb.greaterThan(
+                    requireLeadingHops(scope, ref, cs.sub(), Long.class), 0L);
         }
     }
 

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -3,7 +3,10 @@ package dev.cerbos.queryplan.springdata;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter;
+import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter.Expression;
 import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter.Expression.Operand;
+import dev.cerbos.api.v1.response.Response.PlanResourcesResponse;
 import dev.cerbos.queryplan.springdata.testmodel.CategoryEntity;
 import dev.cerbos.queryplan.springdata.testmodel.LabelEntity;
 import dev.cerbos.queryplan.springdata.testmodel.ResourceEntity;
@@ -889,6 +892,85 @@ class AdversarialConformanceTest {
     }
 
     /**
+     * The corpus pins two count spellings over the chain — {@code size(...) == 0} and
+     * {@code !(size(...) > 0)} — but the guard has to be a property of the COUNT rather than
+     * of the two spellings that happen to be pinned. These synthesise the remaining
+     * threshold/polarity combinations onto the same seeded store and assert the parentless
+     * rows stay out of every one, including an arbitrary-N threshold that neither corpus
+     * action reaches (cerbos/query-plan-adapters#316).
+     */
+    @Test
+    void everyCountThresholdOverTheChainInheritsTheAbsentParentGuard() {
+        Operand chain = Operand.newBuilder()
+                .setVariable("request.resource.attr.mainCategory.subCategories").build();
+        Operand size = expression("size", chain);
+
+        // Every seed that HAS a mainCategory holds exactly one subCategory, and the 16 without
+        // it are CEL missing-path errors — so each of these is empty unless the guard leaks.
+        Map<String, Operand> emptyByConstruction = new LinkedHashMap<>();
+        emptyByConstruction.put("size(chain) == 0", compare("eq", size, 0));
+        emptyByConstruction.put("size(chain) <= 0", compare("le", size, 0));
+        emptyByConstruction.put("size(chain) < 1", compare("lt", size, 1));
+        emptyByConstruction.put("size(chain) >= 2", compare("ge", size, 2));
+        emptyByConstruction.put("!(size(chain) > 0)", expression("not", compare("gt", size, 0)));
+        emptyByConstruction.put("!(size(chain) >= 1)", expression("not", compare("ge", size, 1)));
+        emptyByConstruction.put("!(size(chain) < 2)", expression("not", compare("lt", size, 2)));
+        emptyByConstruction.forEach((shape, condition) ->
+                assertEquals(List.of(), filteredIdsFor(condition),
+                        "absent-parent guard leaked for " + shape));
+
+        // The mirror image, so the loop above cannot pass by denying everything: `>= 0` and
+        // `< 2` are TRUE for exactly the rows that HAVE the parent.
+        List<String> withParent = oracleAllowedIds("w1-size-nonneg-chain");
+        assertFalse(withParent.isEmpty(), "sanity: some seed must carry a mainCategory");
+        assertTrue(withParent.size() < SEEDS.size(), "sanity: not every seed carries one");
+        assertEquals(withParent, filteredIdsFor(compare("ge", size, 0)));
+        assertEquals(withParent, filteredIdsFor(compare("lt", size, 2)));
+    }
+
+    private static Operand expression(String operator, Operand... operands) {
+        Expression.Builder e = Expression.newBuilder().setOperator(operator);
+        for (Operand operand : operands) {
+            e.addOperands(operand);
+        }
+        return Operand.newBuilder().setExpression(e).build();
+    }
+
+    private static Operand compare(String operator, Operand left, double threshold) {
+        return expression(operator, left,
+                Operand.newBuilder().setValue(Value.newBuilder().setNumberValue(threshold)).build());
+    }
+
+    /** Translate a synthesised CONDITIONAL plan and execute it against the seeded store. */
+    private static List<String> filteredIdsFor(Operand condition) {
+        PlanResourcesResponse response = PlanResourcesResponse.newBuilder()
+                .setFilter(PlanResourcesFilter.newBuilder()
+                        .setKind(PlanResourcesFilter.Kind.KIND_CONDITIONAL)
+                        .setCondition(condition))
+                .build();
+        Result<ResourceEntity> result =
+                SpringDataQueryPlanAdapter.toSpecification(response, MAPPING, Map.of());
+        Specification<ResourceEntity> spec =
+                ((Result.Conditional<ResourceEntity>) result).specification();
+
+        EntityManager em = emf.createEntityManager();
+        try {
+            CriteriaBuilder cb = em.getCriteriaBuilder();
+            CriteriaQuery<String> cq = cb.createQuery(String.class);
+            Root<ResourceEntity> root = cq.from(ResourceEntity.class);
+            cq.select(root.get("id")).distinct(true);
+            Predicate p = spec.toPredicate(root, cq, cb);
+            if (p != null) {
+                cq.where(p);
+            }
+            cq.orderBy(cb.asc(root.get("id")));
+            return em.createQuery(cq).getResultList();
+        } finally {
+            em.close();
+        }
+    }
+
+    /**
      * Corpus-size tripwire and exactly-once partition. A corpus edit must bump the pinned
      * counts in the same change — without this, a new hostile action silently joins the
      * oracle run, and a group dropped by the {@code ActionsFile} parser above would make its
@@ -927,7 +1009,7 @@ class AdversarialConformanceTest {
                         .filter(Boolean::booleanValue).count() != 1)
                 .toList();
 
-        assertEquals(140, manifest.size(),
+        assertEquals(143, manifest.size(),
                 "corpus size changed; triage the new action(s) before bumping this pin");
         assertEquals(20, SEEDS.size(), "seed count changed");
         assertEquals(List.of(), misclassified,
@@ -949,13 +1031,16 @@ class AdversarialConformanceTest {
         samples.put("all-on-empty", oracleAllowedIds("all-on-empty"));
         samples.put("null-eq", oracleAllowedIds("null-eq"));
         samples.put("null-ne", oracleAllowedIds("null-ne"));
-        // #309/#312/#311. w1-size-zero-chain and the two string-cast actions are deliberately
-        // absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one parent with
-        // zero children; every seed's aString raises in int()/double()), so they cannot satisfy
-        // this guard. cast-int-double is the cast group's non-degenerate stand-in.
+        // #309/#312/#311/#315/#316. w1-size-zero-chain, w1-not-size-chain and the two
+        // string-cast actions are deliberately absent: their oracles are empty by CONSTRUCTION
+        // (no seed holds a to-one parent with zero children; every seed's aString raises in
+        // int()/double()), so they cannot satisfy this guard. cast-int-double is the cast
+        // group's non-degenerate stand-in.
         samples.put("w1-all-chain", oracleAllowedIds("w1-all-chain"));
         samples.put("w1-not-exists-chain", oracleAllowedIds("w1-not-exists-chain"));
         samples.put("w1-size-nonneg-chain", oracleAllowedIds("w1-size-nonneg-chain"));
+        samples.put("w1-not-in-chain", oracleAllowedIds("w1-not-in-chain"));
+        samples.put("w1-not-hasint-chain", oracleAllowedIds("w1-not-hasint-chain"));
         samples.put("cr-div-neg-zero", oracleAllowedIds("cr-div-neg-zero"));
         samples.put("cr-div-other-column", oracleAllowedIds("cr-div-other-column"));
         samples.put("cr-div-then-add", oracleAllowedIds("cr-div-then-add"));

--- a/sqlalchemy/README.md
+++ b/sqlalchemy/README.md
@@ -43,7 +43,7 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 
 | Classification | Coverage |
 | --- | --- |
-| Oracle-tested | 126 reference conformance actions |
+| Oracle-tested | 129 reference conformance actions |
 | Fail-closed corpus shapes | Nanosecond `now()` thresholds, regex `matches()`, ordered list indexing/`get-field`, `timestamp()` over an ambiguous string column, `int()`/`double()` casts (SQL `CAST` reads a numeric prefix where CEL demands the whole string, and rounds where CEL truncates toward zero) and `filter()`/`map()` used as a condition (both return a list, not a boolean), and a constant zero divisor whose sign the HTTP transport discards (12 actions) |
 | Representation-dependent | `null-eq-missing` — raises under `null_attribute_representation="omitted"`; translated as `IS NULL` under the default, which over-grants if the caller omits attributes for NULL columns |
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute rows. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -384,6 +384,12 @@ def _require_hops(rel: _Relation, expr: Any):
     The CASE has no ELSE on purpose: a missing hop yields NULL, and NOT NULL is
     still NULL, so the row stays excluded under BOTH polarities — matching CEL
     treating the missing path as an error (a deny).
+
+    EVERY operator whose answer comes off a chain has to go through here, not
+    just the collection macros. A bare ``_exists_where`` is two-valued, so it is
+    FALSE for an absent to-one parent and its negation is TRUE — which is how
+    membership and ``hasIntersection`` kept readmitting every parentless row
+    after the macros were fixed (cerbos/query-plan-adapters#315).
     """
     guard = _hop_exists(rel)
     if guard is None:
@@ -474,17 +480,23 @@ def _has_intersection_fn(mapped: Any, values: Any):
             raise ValueError(
                 f"hasIntersection over relation without member field: {mapped!r}"
             )
-        return _exists_where(mapped, _scalar_membership(mapped.member_field, values))
+        return _require_hops(
+            mapped,
+            _exists_where(mapped, _scalar_membership(mapped.member_field, values)),
+        )
 
     # hasIntersection(map(coll, x), list): map errors on any erroring element
     # (no absorption), so the error guard comes FIRST.
     if not (isinstance(mapped, tuple) and mapped[0] == "map"):
         raise ValueError(f"hasIntersection over unsupported operand: {mapped!r}")
     _, rel, projected = mapped
-    return case(
-        (_exists_where(rel, projected.is_(None)), null()),
-        (_exists_where(rel, _scalar_membership(projected, values)), true()),
-        else_=false(),
+    return _require_hops(
+        rel,
+        case(
+            (_exists_where(rel, projected.is_(None)), null()),
+            (_exists_where(rel, _scalar_membership(projected, values)), true()),
+            else_=false(),
+        ),
     )
 
 
@@ -512,7 +524,7 @@ def _relation_membership(relation: _Relation, value: Any):
         )
     else:
         predicate = member == value
-    return _exists_where(relation, predicate)
+    return _require_hops(relation, _exists_where(relation, predicate))
 
 
 def _in_fn(column: Any, value: Any):
@@ -809,7 +821,7 @@ class TestAdversarialConformance:
 
         # Deliberate tripwires: a corpus edit must bump these in the same
         # change, so a new hostile action cannot join (or vanish) silently.
-        assert len(MANIFEST_ACTIONS) == 140
+        assert len(MANIFEST_ACTIONS) == 143
         assert len(SEEDS) == 20
         assert misclassified == []
         assert SQLALCHEMY_SUPPORTED_EXPECTED <= {
@@ -980,12 +992,15 @@ class TestAdversarialConformance:
             "pv-all",
             "null-eq",
             "null-ne",
-            # #309/#312/#311. w1-size-zero-chain and the two string casts are absent
-            # on purpose: their oracles are empty by CONSTRUCTION, so they cannot
-            # satisfy this guard; cast-int-double stands in for the cast group.
+            # #309/#312/#311/#315/#316. w1-size-zero-chain, w1-not-size-chain and
+            # the two string casts are absent on purpose: their oracles are empty by
+            # CONSTRUCTION, so they cannot satisfy this guard; cast-int-double stands
+            # in for the cast group.
             "w1-all-chain",
             "w1-not-exists-chain",
             "w1-size-nonneg-chain",
+            "w1-not-in-chain",
+            "w1-not-hasint-chain",
             "cr-div-neg-zero",
             "cr-div-other-column",
             "cr-div-then-add",


### PR DESCRIPTION
Closes #315
Closes #316

## Summary

The #309 round put the absent-to-one-parent guard **inside the collection macros**, which left
every sibling operator reached through the same chain unguarded. Two shapes fell through:

- `!("finance" in R.attr.mainCategory.subNames)` and its `hasIntersection` sibling returned the
  16 parentless seeds on top of the oracle (#315).
- `!(size(chain) > 0)` did the same (#316) even though `size(chain) == 0` did not — the planner
  emits the negation verbatim rather than normalising the two spellings, so they hit different
  branches.

Both are over-grants: rows the PDP denies come back.

The fix is one move rather than five patches — **put the guard in the shared relation-scope
construction, not in each operator**. That is what ent and pgx already did, which is why neither
needed a change in either round.

## Measured, then classified

Corpus first, per `CLAUDE.md`. The three actions went into
`conformance/policies/adversarial.yaml`, the wire fixtures were regenerated (the diff adds only
those three — no existing fixture moved), and every adapter's suite was run **before** anything
was classified.

| adapter | `w1-not-in-chain` | `w1-not-hasint-chain` | `w1-not-size-chain` |
| --- | --- | --- | --- |
| prisma | +16 parentless | +16 parentless | +16 parentless |
| mongoose | +16 parentless | +16 parentless | +16 parentless |
| spring-data | +16 parentless | +16 parentless | +16 parentless |
| drizzle | +16 parentless | +16 parentless | aligned |
| sqlalchemy | +16 parentless | +16 parentless | aligned |
| ent, pgx, convex | aligned | aligned | aligned |
| langchain-chromadb, elasticsearch-java | throws | throws | throws |

This reproduces both issues exactly. Oracles: `[a8, c1]` for the two membership shapes (the
present-parent-no-match witnesses), empty by construction for the count shape.

## What changed per adapter

| adapter | change |
| --- | --- |
| **drizzle** | `wrapRelationChain` — `wrapWithRelations` plus the hop requirement, used by every operator that reaches a chain from the root |
| **sqlalchemy** | `_require_hops` now wraps the membership and `hasIntersection` overrides, not just the macros |
| **spring-data** | `chainContains` counts instead of testing `EXISTS`, so the guard lives on the count expression; the two-valued emptiness shortcuts are skipped for a chain, and `== 0` / `> 0` / `>= N` and their negations all inherit it |
| **prisma** | No UNKNOWN to represent, so the hops are required **outside** the negation. De Morgan is now pushed through `and`/`or` for chain-carrying subtrees so CEL's error absorption survives |
| **mongoose** | Same outside-the-negation placement, folded into `withEvaluationGuards` so the plain comparison and the `$nor` both inherit it |
| **ent, pgx, convex** | unchanged — already aligned |
| **langchain-chromadb, elasticsearch-java** | classified `adapterUnsupported`, each reason naming the mechanism it actually throws on |

## A second over-grant the new tests found

#316's acceptance criteria asked for a test proving a *third* comparison shape inherits the
guard. Writing it surfaced a live bug the corpus never probed:

mongoose's `$size` guard makes the count `null`, and **BSON orders `null` below every number**.
So `$eq`/`$gt`/`$gte` against it were correctly false, but `$lte`/`$lt` were TRUE —
`size(chain) <= 0` admitted every parentless document. The requirement is now a filter-level
conjunct, which has no ordering to get wrong.

prisma, drizzle, mongoose and spring-data each gained that synthetic-threshold test, so the guard
is pinned as a property of the chain rather than of the two spellings the corpus happens to pin.

## Note on #316's wording

"Guard the count expression" is met literally where a count expression exists (spring-data,
drizzle, sqlalchemy, mongoose's `$size`). Prisma has none — it throws on `>= N` — so the
equivalent there is requiring hops outside the negation, which makes every threshold **and** both
polarities inherit the guard. Called out rather than papered over.

## Deliberately out of scope

Two sibling spots still use a two-valued conjunction. Neither is reachable by any corpus action,
and `CLAUDE.md` is explicit that a translation change starts in the corpus:

- #333 — spring-data's fractional-threshold collapse
- #334 — prisma's ternary false-branch

## Conformance contract

Corpus 140 → 143 actions. `w1-not-in-chain` and `w1-not-hasint-chain` join the degeneracy guard;
`w1-not-size-chain` stays out, like `w1-size-zero-chain`, because its oracle is empty by
construction. Every harness tripwire, per-adapter count and README contract table is updated in
the same commit.

No consumer-visible break: no shape that used to return a filter now throws. The filters that
changed were returning rows the PDP denies.

## Verification

All ten adapters, locally:

| adapter | result |
| --- | --- |
| prisma | 207 unit + 148 adversarial, on **both** Prisma 6 and 7 |
| drizzle | 123 unit + 147 adversarial |
| mongoose | 104 unit + 147 adversarial |
| convex | 115 unit + 147 adversarial |
| langchain-chromadb | 54 unit + 145 adversarial |
| sqlalchemy | 297 |
| ent | 520, `golangci-lint` clean |
| pgx | 242, `golangci-lint` clean |
| spring-data | 539 (`gradle build`) |
| elasticsearch-java | 332 (`gradle build`) |

Plus `conformance/scripts/validate-corpus.sh` and every TypeScript `npm run typecheck`.

**Reproducing locally** needs Docker (testcontainers for the Go and Java harnesses), a local
Cerbos CLI, MongoDB on 27017 (`npm run mongo`), a Convex backend (`npm run convex:up` plus
`convex deploy`/`codegen`), and ChromaDB on 8234.