### PR TITLE
fix(conformance): close the seeds.json projection trap and deduplicate the derived-field tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ Some adapters need additional services:
 ## Conformance
 
 `conformance/` is the shared adversarial corpus every adapter is proved against: one hostile policy
-suite, one set of hostile seed rows, one classification ledger, and golden planner wire fixtures.
+suite, one set of hostile seed rows, one derived-field table, one classification ledger, and golden
+planner wire fixtures.
 It exists because the same semantic bug — value-first operand inversion, LIKE metacharacter leaks,
 three-valued logic under negation — has historically shipped identically to more than one adapter.
 
@@ -166,11 +167,19 @@ attribute allowlist, a fixed column list). A projection silently drops anything 
 depends on, and because the same projected input feeds both the plan and the check() oracle, the
 two agree and the action passes vacuously. Pass corpus data through verbatim.
 
+Every harness declares the exact `seeds.json` keys and `derived-fields.json` fields it consumes and
+asserts set equality against the corpus, so adding a seed field fails all ten loudly instead of
+being dropped from both sides at once. Adding a field means updating those declarations
+deliberately — that is the point of the guard, not an obstacle to route around. The derived fields
+(`createdBy`, `aDouble`, `createdAt`, `scope`, `labels`) live in `conformance/derived-fields.json`;
+never recompute them in a harness.
+
 ## Working with Adapters
 
 - Edit only `src/` — never commit `lib/` until tests pass
 - Shared policies in `/policies/` affect all adapters; edit carefully
 - `conformance/` affects all adapters too: a change there re-runs every adapter's CI, and adding an action requires classifying it for all ten
+- Adding a seed row means adding its `conformance/derived-fields.json` entry in the same commit; adding a seed *field* also means widening every harness's declared key set — both are enforced, not optional
 - Regenerate build artifacts in the same commit as source changes
 - Changing what an adapter can translate means updating its `conformance/actions.json` entry and its README contract table in the same commit
 - When an adapter cannot express a shape, make it throw with a message naming the real mechanism — never emit a best-effort filter

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -190,10 +190,12 @@ how a transcription error becomes invisible: the same copy feeds the stored row 
 oracle, so a wrong value makes both sides of the differential agree for the wrong reason and
 nothing downstream can catch it (#318).
 
-`scripts/validate-corpus.sh` asserts that the file carries exactly one entry per seed id, that
-every entry carries exactly the fields it declares, and re-derives `createdBy`, `aDouble` and
-`createdAt` from `seeds.json` using the rules below — that re-derivation is the only independent
-restatement of the rules, and it is a checker, never an input to a harness.
+`scripts/validate-corpus.sh` asserts that the file carries exactly one entry per seed id and that
+every entry carries exactly the fields it declares, re-derives `createdBy`, `aDouble` and
+`createdAt` from `seeds.json` using the rules below, and diffs `scope` and `labels` — which have no
+rule to re-derive from — against a restatement of their tables. That check is the only independent
+statement of these values, and it is a checker, never an input to a harness: unlike the ten copies
+it replaced it can only fail loudly, never make both sides of a differential agree.
 
 The rules the file materialises:
 
@@ -221,7 +223,9 @@ check() oracle simultaneously, so the differential still agrees and the new fiel
 Every harness therefore declares the exact seed key set it consumes and asserts equality against
 the JSON — not merely that unknown keys are rejected, because that direction says nothing about a
 key the corpus stops carrying, which would decode to its zero value on both sides. `note` is the
-one permitted exclusion: it is corpus prose no harness reads.
+one permitted exclusion: it is corpus prose no harness reads. The same assertion covers `tags[]`,
+the one nested object array a seed carries; a key added inside an element is dropped just as
+silently as a top-level one.
 
 The same assertion covers `derived-fields.json`: each harness declares the five fields it consumes
 and fails if the file's `fields` list, or any entry's key set, differs. Concretely this is

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -24,7 +24,12 @@ rows, and one oracle recipe that every adapter's harness implements against its 
   metacharacters `% _ \`, unicode, duplicate/mirrored names) plus the fixed principal used
   throughout. This is the single source of truth an adapter's harness persists into its own
   schema (SQL rows, Prisma records, whatever) AND mirrors into check() oracle calls — see
-  "The oracle recipe" below.
+  "The oracle recipe" below. Every key except `note` must be consumed by every harness; that is
+  asserted, not assumed (see "Deterministic derived fields").
+- `derived-fields.json` — the five attributes derived from each seed (`createdBy`, `aDouble`,
+  `createdAt`, `scope`, `labels`), materialised once per seed id. Every harness reads this file
+  instead of restating the rules; `scripts/validate-corpus.sh` re-derives the rule-based fields
+  from `seeds.json` and fails on drift. See "Deterministic derived fields" below.
 - `actions.json` — every action in `policies/adversarial.yaml`, grouped into `conformance`
   (must match the check() oracle exactly), `adapterUnsupported` (per-adapter lists of conformance
   actions that adapter's query language genuinely cannot express — LIKE-wildcard escaping,
@@ -178,8 +183,19 @@ harness whose PDP connection or policy load silently failed would still pass eve
 
 ### Deterministic derived fields
 
-The corpus keeps raw relational rows compact; these resource attributes and stored columns are
-derived from each seed exactly as follows:
+The corpus keeps raw relational rows compact; five resource attributes and stored columns are
+derived from each seed. **The values live in `derived-fields.json`, one entry per seed id, and
+every harness reads them from there.** They used to be hand-transcribed once per harness, which is
+how a transcription error becomes invisible: the same copy feeds the stored row *and* the check()
+oracle, so a wrong value makes both sides of the differential agree for the wrong reason and
+nothing downstream can catch it (#318).
+
+`scripts/validate-corpus.sh` asserts that the file carries exactly one entry per seed id, that
+every entry carries exactly the fields it declares, and re-derives `createdBy`, `aDouble` and
+`createdAt` from `seeds.json` using the rules below — that re-derivation is the only independent
+restatement of the rules, and it is a checker, never an input to a harness.
+
+The rules the file materialises:
 
 - `createdBy`: `aNumber >= 2 ? "2024-06-01T00:00:00Z" : "2026-06-01T00:00:00Z"`.
 - `aDouble`: `a1 = -0.6`, `a2 = 0.25`, `a3 = NULL`/missing, otherwise `aNumber + 0.3`.
@@ -194,7 +210,30 @@ derived from each seed exactly as follows:
   `b4=50%:a_b`, `b5=dept.eng.platform2`, `b6=50%.a_b`, `c1=Dept.Eng`,
   `c2=dept.eng.`, `d1=[env]:prod:eu`, `d2=e:prod:eu`; all other seeds use NULL.
 
-These are part of the shared contract. Do not replace them with adapter-specific fixtures.
+These are part of the shared contract. Do not replace them with adapter-specific fixtures, and do
+not recompute them in a harness — read `derived-fields.json`.
+
+### Seed and derived-field coverage
+
+The projection trap this README documents for `actions.json` applies to the seeds too, and it is
+worse there: a seed key a harness does not consume is dropped from the stored row **and** the
+check() oracle simultaneously, so the differential still agrees and the new field tests nothing.
+Every harness therefore declares the exact seed key set it consumes and asserts equality against
+the JSON — not merely that unknown keys are rejected, because that direction says nothing about a
+key the corpus stops carrying, which would decode to its zero value on both sides. `note` is the
+one permitted exclusion: it is corpus prose no harness reads.
+
+The same assertion covers `derived-fields.json`: each harness declares the five fields it consumes
+and fails if the file's `fields` list, or any entry's key set, differs. Concretely this is
+`DisallowUnknownFields` plus a key-set assertion in Go, records without
+`@JsonIgnoreProperties(ignoreUnknown = true)` plus a key-set assertion in Java, and an explicit
+`assertKeys` in the TypeScript and Python harnesses. The TypeScript harnesses that rebuild each
+seed field by field (mongoose, langchain-chromadb) assert against the *raw* JSON — a rebuilt object
+can only ever report the keys the parser already names, so asserting on it would pass vacuously.
+
+Adding a field to a seed must fail every harness loudly. That is the acceptance test for this
+guard; run it before trusting it.
+
 ## Adding a new hostile shape
 
 1. Add the action + condition to `policies/adversarial.yaml`.
@@ -203,7 +242,10 @@ These are part of the shared contract. Do not replace them with adapter-specific
    NULL columns — with a comment in the policy explaining what it probes and which seed rows
    discriminate it (follow the existing comment style).
 3. If the shape needs new seed data to be non-degenerate, add a seed to `seeds.json` with a `note`
-   explaining what it witnesses (see `a9`, `b1`-`b6` for examples).
+   explaining what it witnesses (see `a9`, `b1`-`b6` for examples), and add its `derived-fields.json`
+   entry in the same commit — `scripts/validate-corpus.sh` names the expected values when it fails.
+   A seed field that is genuinely new (rather than a new row) has to be added to every harness's
+   consumed key set too; the guard described above makes that a loud failure, not a silent drop.
 4. Run `scripts/regenerate-wire-fixtures.sh` and commit the new fixture alongside the policy change.
 5. Every adapter harness picks up the new action automatically from `actions.json` on next run;
    triage any divergence into a per-adapter fix issue rather than special-casing it in the harness.
@@ -255,10 +297,15 @@ unsupported before you have watched it fail is how a translatable shape gets per
    name is dropped silently, and a dropped group makes its actions vanish from every count and
    every parameterised case at once. That is the projection trap, and it passes vacuously.
 
-3. **Persist the seeds exactly**, including the NULL conventions and the derived fields above.
-   `aOptionalString` is NULL for several seeds and `tags[].name` is NULL for others — those are
-   not incidental, they are what the three-valued-logic probes discriminate on. Getting them wrong
-   makes the oracle agree with the adapter for the wrong reason.
+3. **Persist the seeds exactly**, including the NULL conventions, and read the derived fields from
+   `derived-fields.json` rather than recomputing them. `aOptionalString` is NULL for several seeds
+   and `tags[].name` is NULL for others — those are not incidental, they are what the
+   three-valued-logic probes discriminate on. Getting them wrong makes the oracle agree with the
+   adapter for the wrong reason.
+
+   Declare the seed keys and derived fields the harness consumes and assert set equality against
+   the JSON, as "Seed and derived-field coverage" above describes. A harness without that guard
+   silently drops the next corpus field from both sides of its own differential.
 
 4. **Assert the degeneracy guard** (see above) and pin the corpus size, so a silently broken PDP
    connection or a newly added action cannot pass vacuously.

--- a/conformance/derived-fields.json
+++ b/conformance/derived-fields.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Deterministic derived fields for every seed in seeds.json. The corpus keeps the raw relational rows compact, so these five attributes are materialised here rather than restated as rules in each harness. Every harness reads this file for BOTH the stored columns and the check()-oracle attributes; a harness that recomputed them would feed the same transcription error to both sides of the differential and agree for the wrong reason. `null` means NULL column / missing attribute, per README.md's 'NULL is a missing attribute' convention; a `null` element of `labels` is a NULL label name. See README.md, 'Deterministic derived fields', for the rules these values materialise — validate-corpus.sh re-derives createdBy, aDouble and createdAt from seeds.json and fails on drift.",
+  "fields": ["createdBy", "aDouble", "createdAt", "scope", "labels"],
+  "derived": {
+    "a1": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": -0.6,  "createdAt": "2020-03-15T10:30:00Z",        "scope": "dept",                 "labels": ["gold", "silver"] },
+    "a2": { "createdBy": "2026-06-01T00:00:00Z", "aDouble": 0.25,  "createdAt": "2037-01-01T00:00:00Z",        "scope": "dept.eng",             "labels": [] },
+    "a3": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": null,  "createdAt": null,                          "scope": "dept.eng.platform",    "labels": [] },
+    "a4": { "createdBy": "2026-06-01T00:00:00Z", "aDouble": 1.3,   "createdAt": "2024-06-01T00:00:00Z",        "scope": "dept.eng.platform.obs", "labels": [] },
+    "a5": { "createdBy": "2026-06-01T00:00:00Z", "aDouble": -4.7,  "createdAt": "2020-03-15T10:30:00.123456Z", "scope": "dept.engineering",     "labels": [] },
+    "a6": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 3.3,   "createdAt": "2036-06-06T06:06:06Z",        "scope": "dept.sales",           "labels": [null, "silver"] },
+    "a7": { "createdBy": "2026-06-01T00:00:00Z", "aDouble": 0.3,   "createdAt": "2021-05-05T05:05:05Z",        "scope": null,                   "labels": [] },
+    "a8": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 2.3,   "createdAt": "2036-06-06T06:06:06Z",        "scope": "",                     "labels": ["silver"] },
+    "a9": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 4.3,   "createdAt": "2036-06-06T06:06:06Z",        "scope": "50%",                  "labels": [] },
+    "b1": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 7.3,   "createdAt": "2036-06-06T06:06:06Z",        "scope": "50%:a_b:x",            "labels": [] },
+    "b2": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 6.3,   "createdAt": "2036-06-06T06:06:06Z",        "scope": "50x:a_b:y",            "labels": [] },
+    "b3": { "createdBy": "2026-06-01T00:00:00Z", "aDouble": -3.7,  "createdAt": "2021-05-05T05:05:05Z",        "scope": "50%:aXb:y",            "labels": [] },
+    "b4": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 8.3,   "createdAt": "2036-06-06T06:06:06Z",        "scope": "50%:a_b",              "labels": [] },
+    "b5": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 9.3,   "createdAt": "2036-06-06T06:06:06Z",        "scope": "dept.eng.platform2",   "labels": [] },
+    "b6": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 10.3,  "createdAt": "2036-06-06T06:06:06Z",        "scope": "50%.a_b",              "labels": [] },
+    "c1": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 11.3,  "createdAt": "2036-06-06T06:06:06Z",        "scope": "Dept.Eng",             "labels": ["Gold"] },
+    "c2": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 12.3,  "createdAt": "2036-06-06T06:06:06Z",        "scope": "dept.eng.",            "labels": [] },
+    "d1": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 13.3,  "createdAt": "2036-06-06T06:06:06Z",        "scope": "[env]:prod:eu",        "labels": [] },
+    "d2": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 14.3,  "createdAt": "2036-06-06T06:06:06Z",        "scope": "e:prod:eu",            "labels": [] },
+    "e1": { "createdBy": "2024-06-01T00:00:00Z", "aDouble": 15.3,  "createdAt": "2036-06-06T06:06:06Z",        "scope": null,                   "labels": [] }
+  }
+}

--- a/conformance/scripts/validate-corpus.sh
+++ b/conformance/scripts/validate-corpus.sh
@@ -181,4 +181,81 @@ if [[ "${seed_count}" != "${unique_seed_count}" ]]; then
   exit 1
 fi
 
+# derived-fields.json materialises README.md's "Deterministic derived fields" rules once for every
+# harness. Nothing downstream can catch a wrong value there: each harness feeds the same entry to
+# both the stored row and the check() oracle, so a bad value makes both sides agree for the wrong
+# reason. These assertions are the only independent restatement of the rules.
+if ! jq -e '
+  (.fields | type) == "array"
+  and (.fields | length) > 0
+  and (.fields | length) == (.fields | unique | length)
+  and all(.fields[]; type == "string" and length > 0)
+' derived-fields.json >/dev/null; then
+  echo "derived-fields.json must declare a non-empty, duplicate-free fields list"
+  exit 1
+fi
+
+jq -r '.seeds[].id' seeds.json | sort >"${VALIDATION_TMP}/seed-ids"
+jq -r '.derived | keys[]' derived-fields.json | sort >"${VALIDATION_TMP}/derived-ids"
+if ! diff -u "${VALIDATION_TMP}/seed-ids" "${VALIDATION_TMP}/derived-ids"; then
+  echo "derived-fields.json must carry exactly one entry per seed id"
+  exit 1
+fi
+
+if ! jq -e '
+  (.fields | sort) as $fields
+  | all(.derived[]; keys == $fields)
+' derived-fields.json >/dev/null; then
+  echo "Every derived-fields.json entry must carry exactly the fields it declares"
+  exit 1
+fi
+
+if ! jq -e '
+  all(.derived[];
+    ((.createdBy | type) == "string")
+    and ((.aDouble | type) == "number" or .aDouble == null)
+    and ((.createdAt | type) == "string" or .createdAt == null)
+    and ((.scope | type) == "string" or .scope == null)
+    and ((.labels | type) == "array")
+    and all(.labels[]; type == "string" or . == null))
+' derived-fields.json >/dev/null; then
+  echo "derived-fields.json entries have the wrong value types"
+  exit 1
+fi
+
+derived_drift="$(jq -r -s '
+  .[1].derived as $derived
+  | .[0].seeds[]
+  | . as $seed
+  | $derived[$seed.id] as $entry
+  | [
+      (if $entry.createdBy != (
+         if $seed.aNumber >= 2 then "2024-06-01T00:00:00Z" else "2026-06-01T00:00:00Z" end
+       ) then "createdBy" else empty end),
+      (if $entry.aDouble != (
+         {"a1": -0.6, "a2": 0.25, "a3": null} as $fixed
+         | if ($fixed | has($seed.id)) then $fixed[$seed.id] else $seed.aNumber + 0.3 end
+       ) then "aDouble" else empty end),
+      (if $entry.createdAt != (
+         {
+           "a1": "2020-03-15T10:30:00Z",
+           "a2": "2037-01-01T00:00:00Z",
+           "a3": null,
+           "a4": "2024-06-01T00:00:00Z",
+           "a5": "2020-03-15T10:30:00.123456Z"
+         } as $fixed
+         | if ($fixed | has($seed.id)) then $fixed[$seed.id]
+           elif $seed.aNumber >= 2 then "2036-06-06T06:06:06Z"
+           else "2021-05-05T05:05:05Z" end
+       ) then "createdAt" else empty end)
+    ]
+  | select(length > 0)
+  | "  \($seed.id): \(join(", "))"
+' seeds.json derived-fields.json)"
+if [[ -n "${derived_drift}" ]]; then
+  echo "derived-fields.json disagrees with the derived-field rules in README.md:"
+  echo "${derived_drift}"
+  exit 1
+fi
+
 echo "Corpus valid: $(wc -l <"${VALIDATION_TMP}/policy-actions" | tr -d '[:space:]') actions, ${seed_count} seeds"

--- a/conformance/scripts/validate-corpus.sh
+++ b/conformance/scripts/validate-corpus.sh
@@ -258,4 +258,41 @@ if [[ -n "${derived_drift}" ]]; then
   exit 1
 fi
 
+# `scope` and `labels` are per-seed tables with no rule to re-derive from, so they are restated
+# here instead. A restatement inside a checker is not a second source of truth: unlike the ten
+# harness copies it replaced, it never feeds a stored row or an oracle, so it cannot make both
+# sides of a differential agree for the wrong reason — it can only fail loudly. Without it these
+# forty values, which drive the hier-* and label oracles on every adapter at once, are checked by
+# nothing.
+cat >"${VALIDATION_TMP}/expected-tables" <<'JSON'
+{
+  "a1": { "scope": "dept",                  "labels": ["gold", "silver"] },
+  "a2": { "scope": "dept.eng",              "labels": [] },
+  "a3": { "scope": "dept.eng.platform",     "labels": [] },
+  "a4": { "scope": "dept.eng.platform.obs", "labels": [] },
+  "a5": { "scope": "dept.engineering",      "labels": [] },
+  "a6": { "scope": "dept.sales",            "labels": [null, "silver"] },
+  "a7": { "scope": null,                    "labels": [] },
+  "a8": { "scope": "",                      "labels": ["silver"] },
+  "a9": { "scope": "50%",                   "labels": [] },
+  "b1": { "scope": "50%:a_b:x",             "labels": [] },
+  "b2": { "scope": "50x:a_b:y",             "labels": [] },
+  "b3": { "scope": "50%:aXb:y",             "labels": [] },
+  "b4": { "scope": "50%:a_b",               "labels": [] },
+  "b5": { "scope": "dept.eng.platform2",    "labels": [] },
+  "b6": { "scope": "50%.a_b",               "labels": [] },
+  "c1": { "scope": "Dept.Eng",              "labels": ["Gold"] },
+  "c2": { "scope": "dept.eng.",             "labels": [] },
+  "d1": { "scope": "[env]:prod:eu",         "labels": [] },
+  "d2": { "scope": "e:prod:eu",             "labels": [] },
+  "e1": { "scope": null,                    "labels": [] }
+}
+JSON
+jq -S '.derived | map_values({scope, labels})' derived-fields.json \
+  >"${VALIDATION_TMP}/actual-tables"
+if ! diff -u <(jq -S . "${VALIDATION_TMP}/expected-tables") "${VALIDATION_TMP}/actual-tables"; then
+  echo "derived-fields.json scope/labels disagree with the tables in README.md"
+  exit 1
+fi
+
 echo "Corpus valid: $(wc -l <"${VALIDATION_TMP}/policy-actions" | tr -d '[:space:]') actions, ${seed_count} seeds"

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -36,6 +36,20 @@ interface SeedsFile {
   seeds: Seed[];
 }
 
+/** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
+interface DerivedEntry {
+  createdBy: string;
+  aDouble: number | null;
+  createdAt: string | null;
+  scope: string | null;
+  labels: (string | null)[];
+}
+
+interface DerivedFile {
+  fields: string[];
+  derived: Record<string, DerivedEntry>;
+}
+
 interface ExpectedUnsupported {
   action: string;
 }
@@ -160,6 +174,76 @@ const isActionsFile = (value: unknown): value is ActionsFile =>
   Array.isArray(value["knownDivergences"]) &&
   value["knownDivergences"].every(isKnownDivergence);
 
+const isDerivedEntry = (value: unknown): value is DerivedEntry =>
+  isRecord(value) &&
+  typeof value["createdBy"] === "string" &&
+  (typeof value["aDouble"] === "number" || value["aDouble"] === null) &&
+  (typeof value["createdAt"] === "string" || value["createdAt"] === null) &&
+  (typeof value["scope"] === "string" || value["scope"] === null) &&
+  Array.isArray(value["labels"]) &&
+  value["labels"].every(
+    (label) => label === null || typeof label === "string",
+  );
+
+const isDerivedFile = (value: unknown): value is DerivedFile =>
+  isRecord(value) &&
+  isStringArray(value["fields"]) &&
+  isRecord(value["derived"]) &&
+  Object.values(value["derived"]).every(isDerivedEntry);
+
+// -- corpus coverage guards ---------------------------------------------------------------------
+//
+// The same parsed seed feeds the stored document AND the check() oracle, so a corpus field this
+// harness does not consume is dropped from both sides at once and the differential agrees for the
+// wrong reason — the projection trap conformance/README.md describes for actions.json, applied to
+// the seeds. Asserting set equality catches both directions: a corpus key nothing here reads, and a
+// key this harness reads that the corpus no longer carries.
+
+const SEED_KEYS = [
+  "id",
+  "aBool",
+  "aString",
+  "aNumber",
+  "aOptionalString",
+  "tags",
+  "subCategoryNames",
+] as const;
+
+/** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
+const SEED_NOTE_KEY = "note";
+
+const DERIVED_KEYS = [
+  "createdBy",
+  "aDouble",
+  "createdAt",
+  "scope",
+  "labels",
+] as const;
+
+function assertKeys(
+  label: string,
+  got: string[],
+  want: readonly string[],
+  optional: readonly string[] = [],
+): void {
+  const allowed = new Set<string>([...want, ...optional]);
+  for (const key of got) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `${label} carries "${key}", which this harness does not consume: an unconsumed corpus field is dropped from the stored document and the check() oracle at once`,
+      );
+    }
+  }
+  const present = new Set(got);
+  for (const key of want) {
+    if (!present.has(key)) {
+      throw new Error(
+        `${label} is missing "${key}", which this harness consumes`,
+      );
+    }
+  }
+}
+
 const parsedSeeds: unknown = JSON.parse(
   fs.readFileSync(path.join(CONFORMANCE_DIR, "seeds.json"), "utf8"),
 );
@@ -171,6 +255,37 @@ const parsedActions: unknown = JSON.parse(
 );
 if (!isActionsFile(parsedActions)) throw new Error("Invalid conformance actions");
 const actionsFile = parsedActions;
+
+const parsedDerived: unknown = JSON.parse(
+  fs.readFileSync(path.join(CONFORMANCE_DIR, "derived-fields.json"), "utf8"),
+);
+if (!isDerivedFile(parsedDerived)) {
+  throw new Error("Invalid conformance derived fields");
+}
+const derivedFile = parsedDerived;
+
+// seedsFile.seeds holds the parsed JSON rows verbatim, so Object.keys reports the corpus key set.
+// Keep it that way: a parser that rebuilt each row field by field could only ever report the keys
+// this harness already names, and the assertion would pass vacuously.
+seedsFile.seeds.forEach((seed, index) => {
+  assertKeys(`seeds.json seeds[${index}]`, Object.keys(seed), SEED_KEYS, [
+    SEED_NOTE_KEY,
+  ]);
+});
+
+assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);
+if (Object.keys(derivedFile.derived).length !== seedsFile.seeds.length) {
+  throw new Error(
+    `derived-fields.json has ${Object.keys(derivedFile.derived).length} entries for ${seedsFile.seeds.length} seeds`,
+  );
+}
+for (const seed of seedsFile.seeds) {
+  assertKeys(
+    `derived-fields.json derived["${seed.id}"]`,
+    Object.keys(derivedFor(seed)),
+    DERIVED_KEYS,
+  );
+}
 
 const CONVEX_UNSUPPORTED = actionsFile.adapterUnsupported["convex"] ?? [];
 const UNSUPPORTED_ACTIONS = new Set(
@@ -213,81 +328,39 @@ const MANIFEST_ACTIONS = new Set([
   ...actionsFile.knownDivergences.map((entry) => entry.action),
 ]);
 
-function doubleFor(seed: Seed): number | null {
-  switch (seed.id) {
-    case "a1":
-      return -0.6;
-    case "a2":
-      return 0.25;
-    case "a3":
-      return null;
-    default:
-      return seed.aNumber + 0.3;
+// -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
+//
+// Read from conformance/derived-fields.json rather than restated here. The same value feeds the
+// stored row and the check() oracle, so a transcription error would be self-consistent and
+// invisible to the differential; one machine-readable definition is what makes that impossible.
+
+function derivedFor(seed: Seed): DerivedEntry {
+  const entry = derivedFile.derived[seed.id];
+  if (entry === undefined) {
+    throw new Error(`derived-fields.json has no entry for seed "${seed.id}"`);
   }
+  return entry;
 }
 
+function doubleFor(seed: Seed): number | null {
+  return derivedFor(seed).aDouble;
+}
+
+/** Third-level label names. A null element is a NULL label name — a missing element attribute. */
 function labelsFor(seed: Seed): (string | null)[] {
-  switch (seed.id) {
-    case "a1":
-      return ["gold", "silver"];
-    case "a6":
-      return [null, "silver"];
-    case "a8":
-      return ["silver"];
-    case "c1":
-      return ["Gold"];
-    default:
-      return [];
-  }
+  return derivedFor(seed).labels;
 }
 
 function createdByFor(seed: Seed): string {
-  return seed.aNumber >= 2
-    ? "2024-06-01T00:00:00Z"
-    : "2026-06-01T00:00:00Z";
+  return derivedFor(seed).createdBy;
 }
 
 function timestampFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "2020-03-15T10:30:00Z";
-    case "a2":
-      return "2037-01-01T00:00:00Z";
-    case "a3":
-      return null;
-    case "a4":
-      return "2024-06-01T00:00:00Z";
-    case "a5":
-      return "2020-03-15T10:30:00.123456Z";
-    default:
-      return seed.aNumber >= 2
-        ? "2036-06-06T06:06:06Z"
-        : "2021-05-05T05:05:05Z";
-  }
+  return derivedFor(seed).createdAt;
 }
 
 function scopeFor(seed: Seed): string | null {
-  const scopes: Record<string, string> = {
-    a1: "dept",
-    a2: "dept.eng",
-    a3: "dept.eng.platform",
-    a4: "dept.eng.platform.obs",
-    a5: "dept.engineering",
-    a6: "dept.sales",
-    a8: "",
-    a9: "50%",
-    b1: "50%:a_b:x",
-    b2: "50x:a_b:y",
-    b3: "50%:aXb:y",
-    b4: "50%:a_b",
-    b5: "dept.eng.platform2",
-    b6: "50%.a_b",
-    c1: "Dept.Eng",
-    c2: "dept.eng.",
-    d1: "[env]:prod:eu",
-    d2: "e:prod:eu",
-  };
-  return scopes[seed.id] ?? null;
+  return derivedFor(seed).scope;
 }
 
 function storedDocument(seed: Seed): StoredDocument {

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -212,6 +212,10 @@ const SEED_KEYS = [
 /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
 const SEED_NOTE_KEY = "note";
 
+/** The one nested object array a seed carries. A key added inside an element is dropped from both
+ * sides of the differential just as silently as a top-level one, so it is guarded the same way. */
+const TAG_KEYS = ["id", "name"] as const;
+
 const DERIVED_KEYS = [
   "createdBy",
   "aDouble",
@@ -268,9 +272,11 @@ const derivedFile = parsedDerived;
 // Keep it that way: a parser that rebuilt each row field by field could only ever report the keys
 // this harness already names, and the assertion would pass vacuously.
 seedsFile.seeds.forEach((seed, index) => {
-  assertKeys(`seeds.json seeds[${index}]`, Object.keys(seed), SEED_KEYS, [
-    SEED_NOTE_KEY,
-  ]);
+  const label = `seeds.json seeds[${index}]`;
+  assertKeys(label, Object.keys(seed), SEED_KEYS, [SEED_NOTE_KEY]);
+  seed.tags.forEach((tag, tagIndex) => {
+    assertKeys(`${label}.tags[${tagIndex}]`, Object.keys(tag), TAG_KEYS);
+  });
 });
 
 assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -85,13 +85,107 @@ interface ActionsFile {
   knownDivergences?: KnownDivergence[];
 }
 
+// -- corpus coverage guards ---------------------------------------------------------------------
+//
+// The same parsed seed feeds the stored row AND the check() oracle, so a corpus field this harness
+// does not consume is dropped from both sides at once and the differential agrees for the wrong
+// reason — the projection trap conformance/README.md describes for actions.json, applied to the
+// seeds. Asserting set equality catches both directions: a corpus key nothing here reads, and a key
+// this harness reads that the corpus no longer carries.
+
+const SEED_KEYS = [
+  "id",
+  "aBool",
+  "aString",
+  "aNumber",
+  "aOptionalString",
+  "tags",
+  "subCategoryNames",
+] as const;
+
+/** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
+const SEED_NOTE_KEY = "note";
+
+const DERIVED_KEYS = [
+  "createdBy",
+  "aDouble",
+  "createdAt",
+  "scope",
+  "labels",
+] as const;
+
+/** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
+interface DerivedEntry {
+  createdBy: string;
+  aDouble: number | null;
+  createdAt: string | null;
+  scope: string | null;
+  labels: (string | null)[];
+}
+
+interface DerivedFile {
+  fields: string[];
+  derived: Record<string, DerivedEntry>;
+}
+
+function assertKeys(
+  label: string,
+  got: string[],
+  want: readonly string[],
+  optional: readonly string[] = []
+): void {
+  const allowed = new Set<string>([...want, ...optional]);
+  for (const key of got) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `${label} carries "${key}", which this harness does not consume: an unconsumed corpus field is dropped from the stored row and the check() oracle at once`
+      );
+    }
+  }
+  const present = new Set(got);
+  for (const key of want) {
+    if (!present.has(key)) {
+      throw new Error(
+        `${label} is missing "${key}", which this harness consumes`
+      );
+    }
+  }
+}
+
 const seedsFile: SeedsFile = JSON.parse(
   fs.readFileSync(path.join(CONFORMANCE_DIR, "seeds.json"), "utf8")
 );
 const actionsFile: ActionsFile = JSON.parse(
   fs.readFileSync(path.join(CONFORMANCE_DIR, "actions.json"), "utf8")
 );
+const derivedFile: DerivedFile = JSON.parse(
+  fs.readFileSync(path.join(CONFORMANCE_DIR, "derived-fields.json"), "utf8")
+);
 const SEEDS = seedsFile.seeds;
+
+// SEEDS holds the parsed JSON rows verbatim, so Object.keys reports the corpus key set. Keep it
+// that way: a parser that rebuilt each row field by field could only ever report the keys this
+// harness already names, and the assertion would pass vacuously.
+SEEDS.forEach((seed, index) => {
+  assertKeys(`seeds.json seeds[${index}]`, Object.keys(seed), SEED_KEYS, [
+    SEED_NOTE_KEY,
+  ]);
+});
+
+assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);
+const DERIVED_IDS = Object.keys(derivedFile.derived);
+if (DERIVED_IDS.length !== SEEDS.length) {
+  throw new Error(
+    `derived-fields.json has ${DERIVED_IDS.length} entries for ${SEEDS.length} seeds`
+  );
+}
+for (const seed of SEEDS) {
+  assertKeys(
+    `derived-fields.json derived["${seed.id}"]`,
+    Object.keys(derivedFor(seed)),
+    DERIVED_KEYS
+  );
+}
 
 // Reference actions this adapter cannot express without changing CEL semantics. The shared
 // manifest is the source of truth so the package-local harness and README stay aligned.
@@ -152,99 +246,40 @@ const MANIFEST_ACTIONS = new Set([
   ...(actionsFile.knownDivergences ?? []).map((entry) => entry.action),
 ]);
 
+// -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
+//
+// Read from conformance/derived-fields.json rather than restated here. The same value feeds the
+// stored row and the check() oracle, so a transcription error would be self-consistent and
+// invisible to the differential; one machine-readable definition is what makes that impossible.
+
+function derivedFor(seed: Seed): DerivedEntry {
+  const entry = derivedFile.derived[seed.id];
+  if (entry === undefined) {
+    throw new Error(`derived-fields.json has no entry for seed "${seed.id}"`);
+  }
+  return entry;
+}
+
 /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
 function isoFor(seed: Seed): string {
-  return seed.aNumber >= 2 ? "2024-06-01T00:00:00Z" : "2026-06-01T00:00:00Z";
+  return derivedFor(seed).createdBy;
 }
 
 function doubleFor(seed: Seed): number | null {
-  switch (seed.id) {
-    case "a1":
-      return -0.6;
-    case "a2":
-      return 0.25;
-    case "a3":
-      return null;
-    default:
-      return seed.aNumber + 0.3;
-  }
+  return derivedFor(seed).aDouble;
 }
 
 function scopeFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "dept";
-    case "a2":
-      return "dept.eng";
-    case "a3":
-      return "dept.eng.platform";
-    case "a4":
-      return "dept.eng.platform.obs";
-    case "a5":
-      return "dept.engineering";
-    case "a6":
-      return "dept.sales";
-    case "a8":
-      return "";
-    case "a9":
-      return "50%";
-    case "b1":
-      return "50%:a_b:x";
-    case "b2":
-      return "50x:a_b:y";
-    case "b3":
-      return "50%:aXb:y";
-    case "b4":
-      return "50%:a_b";
-    case "b5":
-      return "dept.eng.platform2";
-    case "b6":
-      return "50%.a_b";
-    case "c1":
-      return "Dept.Eng";
-    case "c2":
-      return "dept.eng.";
-    case "d1":
-      return "[env]:prod:eu";
-    case "d2":
-      return "e:prod:eu";
-    default:
-      return null;
-  }
+  return derivedFor(seed).scope;
 }
 
 function timestampFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "2020-03-15T10:30:00Z";
-    case "a2":
-      return "2037-01-01T00:00:00Z";
-    case "a3":
-      return null;
-    case "a4":
-      return "2024-06-01T00:00:00Z";
-    case "a5":
-      return "2020-03-15T10:30:00.123456Z";
-    default:
-      return seed.aNumber >= 2
-        ? "2036-06-06T06:06:06Z"
-        : "2021-05-05T05:05:05Z";
-  }
+  return derivedFor(seed).createdAt;
 }
 
+/** Third-level label names. A null element is a NULL label name — a missing element attribute. */
 function labelsFor(seed: Seed): (string | null)[] {
-  switch (seed.id) {
-    case "a1":
-      return ["gold", "silver"];
-    case "a6":
-      return [null, "silver"];
-    case "a8":
-      return ["silver"];
-    case "c1":
-      return ["Gold"];
-    default:
-      return [];
-  }
+  return derivedFor(seed).labels;
 }
 
 // -- dedicated SQLite schema (adversarial.db, gitignored) --

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -106,6 +106,10 @@ const SEED_KEYS = [
 /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
 const SEED_NOTE_KEY = "note";
 
+/** The one nested object array a seed carries. A key added inside an element is dropped from both
+ * sides of the differential just as silently as a top-level one, so it is guarded the same way. */
+const TAG_KEYS = ["id", "name"] as const;
+
 const DERIVED_KEYS = [
   "createdBy",
   "aDouble",
@@ -167,9 +171,11 @@ const SEEDS = seedsFile.seeds;
 // that way: a parser that rebuilt each row field by field could only ever report the keys this
 // harness already names, and the assertion would pass vacuously.
 SEEDS.forEach((seed, index) => {
-  assertKeys(`seeds.json seeds[${index}]`, Object.keys(seed), SEED_KEYS, [
-    SEED_NOTE_KEY,
-  ]);
+  const label = `seeds.json seeds[${index}]`;
+  assertKeys(label, Object.keys(seed), SEED_KEYS, [SEED_NOTE_KEY]);
+  seed.tags.forEach((tag, tagIndex) => {
+    assertKeys(`${label}.tags[${tagIndex}]`, Object.keys(tag), TAG_KEYS);
+  });
 });
 
 assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -147,6 +147,13 @@ class ElasticsearchAdversarialConformanceTest {
     /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
     private static final String SEED_NOTE_KEY = "note";
 
+    /**
+     * The one nested object array a seed carries. A key added inside an element is dropped from
+     * both sides of the differential just as silently as a top-level one, so it is guarded the
+     * same way.
+     */
+    private static final List<String> TAG_KEYS = List.of("id", "name");
+
     private static final List<String> DERIVED_KEYS =
             List.of("createdBy", "aDouble", "createdAt", "scope", "labels");
 
@@ -578,8 +585,13 @@ class ElasticsearchAdversarialConformanceTest {
         JsonNode rawSeeds = MAPPER.readTree(conformance.resolve("seeds.json").toFile()).get("seeds");
         assertEquals(seeds.size(), rawSeeds.size(), "seeds.json rows lost in decoding");
         for (int i = 0; i < rawSeeds.size(); i++) {
-            assertKeys("seeds.json seeds[" + i + "]", keysOf(rawSeeds.get(i)),
-                    SEED_KEYS, List.of(SEED_NOTE_KEY));
+            String label = "seeds.json seeds[" + i + "]";
+            assertKeys(label, keysOf(rawSeeds.get(i)), SEED_KEYS, List.of(SEED_NOTE_KEY));
+            JsonNode rawTags = rawSeeds.get(i).get("tags");
+            for (int j = 0; j < rawTags.size(); j++) {
+                assertKeys(label + ".tags[" + j + "]", keysOf(rawTags.get(j)), TAG_KEYS,
+                        List.of());
+            }
         }
 
         assertKeys("derived-fields.json fields", derivedFile.fields(), DERIVED_KEYS, List.of());

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -1,7 +1,9 @@
 package dev.cerbos.queryplan.elasticsearch;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.cerbos.queryplan.elasticsearch.ElasticsearchQueryPlanAdapter.Result;
 import dev.cerbos.sdk.CerbosBlockingClient;
@@ -30,17 +32,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,18 +86,35 @@ class ElasticsearchAdversarialConformanceTest {
         return Path.of(System.getProperty("user.dir"), "..", "conformance").normalize();
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Tag(String id, String name) {}
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
+    /**
+     * One hostile row. {@code note} is corpus documentation this harness never reads; it is named
+     * so that strict decoding accepts it, and it is the one seed key {@link #SEED_KEYS} omits.
+     */
     private record Seed(String id, boolean aBool, String aString, int aNumber,
-                        String aOptionalString, List<Tag> tags, List<String> subCategoryNames) {}
+                        String aOptionalString, List<Tag> tags, List<String> subCategoryNames,
+                        String note) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record PrincipalSpec(String id, List<String> roles, Map<String, List<String>> attr) {}
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private record SeedsFile(PrincipalSpec principal, String resourceKind, List<Seed> seeds) {}
+    /**
+     * conformance/seeds.json. Every key the file carries is named, including the prose ones,
+     * because unknown properties are rejected rather than ignored: a seed field this harness does
+     * not consume would be dropped from the indexed document AND the check() oracle at once, and
+     * the differential would agree for the wrong reason.
+     */
+    private record SeedsFile(@JsonProperty("$schema") String schema, String description,
+                             PrincipalSpec principal, String resourceKind, String principalNote,
+                             List<Seed> seeds) {}
+
+    /** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
+    private record DerivedEntry(String createdBy, Double aDouble, String createdAt, String scope,
+                                List<String> labels) {}
+
+    private record DerivedFile(@JsonProperty("$schema") String schema, String description,
+                               List<String> fields, Map<String, DerivedEntry> derived) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record UnsupportedShape(String action) {}
@@ -112,8 +133,26 @@ class ElasticsearchAdversarialConformanceTest {
                                List<AdapterOutcome> nullRepresentationOmitted,
                                List<KnownDivergence> knownDivergences) {}
 
+    // -- corpus coverage guards -----------------------------------------------------------------
+    //
+    // The same parsed seed feeds the indexed document AND the check() oracle, so a corpus field
+    // this harness does not consume is dropped from both sides at once and the differential agrees
+    // for the wrong reason — the projection trap conformance/README.md describes for actions.json,
+    // applied to the seeds. Asserting set equality catches both directions: a corpus key nothing
+    // here reads, and a key this harness reads that the corpus no longer carries.
+
+    private static final List<String> SEED_KEYS = List.of(
+            "id", "aBool", "aString", "aNumber", "aOptionalString", "tags", "subCategoryNames");
+
+    /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
+    private static final String SEED_NOTE_KEY = "note";
+
+    private static final List<String> DERIVED_KEYS =
+            List.of("createdBy", "aDouble", "createdAt", "scope", "labels");
+
     private static SeedsFile seedsFile;
     private static ActionsFile actionsFile;
+    private static DerivedFile derivedFile;
     private static List<Seed> seeds;
     private static List<String> oracleActions;
     private static List<String> throwingActions;
@@ -142,7 +181,10 @@ class ElasticsearchAdversarialConformanceTest {
         Path conformance = conformanceDir();
         seedsFile = MAPPER.readValue(conformance.resolve("seeds.json").toFile(), SeedsFile.class);
         actionsFile = MAPPER.readValue(conformance.resolve("actions.json").toFile(), ActionsFile.class);
+        derivedFile = MAPPER.readValue(
+                conformance.resolve("derived-fields.json").toFile(), DerivedFile.class);
         seeds = seedsFile.seeds();
+        assertCorpusCoverage(conformance);
         classifyActions();
 
         cerbos = new GenericContainer<>(CerbosTestImage.IMAGE)
@@ -526,63 +568,82 @@ class ElasticsearchAdversarialConformanceTest {
         }
     }
 
+    /**
+     * Proves this harness consumes every seed key and every derived field the corpus defines, and
+     * nothing it does not. Rejecting unknown properties on decode cannot do this alone: it catches
+     * an added key but says nothing about one that disappears, and a disappeared key decodes to its
+     * default on both sides of the differential.
+     */
+    private static void assertCorpusCoverage(Path conformance) throws IOException {
+        JsonNode rawSeeds = MAPPER.readTree(conformance.resolve("seeds.json").toFile()).get("seeds");
+        assertEquals(seeds.size(), rawSeeds.size(), "seeds.json rows lost in decoding");
+        for (int i = 0; i < rawSeeds.size(); i++) {
+            assertKeys("seeds.json seeds[" + i + "]", keysOf(rawSeeds.get(i)),
+                    SEED_KEYS, List.of(SEED_NOTE_KEY));
+        }
+
+        assertKeys("derived-fields.json fields", derivedFile.fields(), DERIVED_KEYS, List.of());
+        assertEquals(seeds.stream().map(Seed::id).collect(Collectors.toCollection(TreeSet::new)),
+                new TreeSet<>(derivedFile.derived().keySet()),
+                "derived-fields.json must carry exactly one entry per seeds.json id");
+        JsonNode rawDerived =
+                MAPPER.readTree(conformance.resolve("derived-fields.json").toFile()).get("derived");
+        for (Map.Entry<String, JsonNode> entry : rawDerived.properties()) {
+            assertKeys("derived-fields.json derived[\"" + entry.getKey() + "\"]",
+                    keysOf(entry.getValue()), DERIVED_KEYS, List.of());
+        }
+    }
+
+    private static void assertKeys(String label, Collection<String> got, Collection<String> want,
+                                   Collection<String> optional) {
+        Set<String> allowed = new LinkedHashSet<>(want);
+        allowed.addAll(optional);
+        for (String key : got) {
+            assertTrue(allowed.contains(key), () -> label + " carries \"" + key
+                    + "\", which this harness does not consume: an unconsumed corpus field is"
+                    + " dropped from the indexed document and the check() oracle at once");
+        }
+        Set<String> missing = new LinkedHashSet<>(want);
+        missing.removeAll(got);
+        assertTrue(missing.isEmpty(),
+                () -> label + " is missing " + missing + ", which this harness consumes");
+    }
+
+    private static List<String> keysOf(JsonNode node) {
+        return node.properties().stream().map(Map.Entry::getKey).toList();
+    }
+
+    // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") -----
+    //
+    // Read from conformance/derived-fields.json rather than restated here. The same value feeds the
+    // indexed document and the check() oracle, so a transcription error would be self-consistent
+    // and invisible to the differential; one machine-readable definition makes that impossible.
+
+    private static DerivedEntry derivedFor(Seed seed) {
+        DerivedEntry entry = derivedFile.derived().get(seed.id());
+        assertNotNull(entry,
+                () -> "derived-fields.json has no entry for seed \"" + seed.id() + "\"");
+        return entry;
+    }
+
     private static String isoFor(Seed seed) {
-        return seed.aNumber() >= 2 ? "2024-06-01T00:00:00Z" : "2026-06-01T00:00:00Z";
+        return derivedFor(seed).createdBy();
     }
 
     private static Double doubleFor(Seed seed) {
-        return switch (seed.id()) {
-            case "a1" -> -0.6;
-            case "a2" -> 0.25;
-            case "a3" -> null;
-            default -> seed.aNumber() + 0.3;
-        };
+        return derivedFor(seed).aDouble();
     }
 
     private static Instant timestampFor(Seed seed) {
-        return switch (seed.id()) {
-            case "a1" -> Instant.parse("2020-03-15T10:30:00Z");
-            case "a2" -> Instant.parse("2037-01-01T00:00:00Z");
-            case "a3" -> null;
-            case "a4" -> Instant.parse("2024-06-01T00:00:00Z");
-            case "a5" -> Instant.parse("2020-03-15T10:30:00.123456Z");
-            default -> seed.aNumber() >= 2
-                    ? Instant.parse("2036-06-06T06:06:06Z")
-                    : Instant.parse("2021-05-05T05:05:05Z");
-        };
+        String value = derivedFor(seed).createdAt();
+        return value == null ? null : Instant.parse(value);
     }
 
     private static List<String> labelsFor(Seed seed) {
-        return switch (seed.id()) {
-            case "a1" -> List.of("gold", "silver");
-            case "a6" -> Arrays.asList(null, "silver");
-            case "a8" -> List.of("silver");
-            case "c1" -> List.of("Gold");
-            default -> List.of();
-        };
+        return derivedFor(seed).labels();
     }
 
     private static String scopeFor(Seed seed) {
-        return switch (seed.id()) {
-            case "a1" -> "dept";
-            case "a2" -> "dept.eng";
-            case "a3" -> "dept.eng.platform";
-            case "a4" -> "dept.eng.platform.obs";
-            case "a5" -> "dept.engineering";
-            case "a6" -> "dept.sales";
-            case "a8" -> "";
-            case "a9" -> "50%";
-            case "b1" -> "50%:a_b:x";
-            case "b2" -> "50x:a_b:y";
-            case "b3" -> "50%:aXb:y";
-            case "b4" -> "50%:a_b";
-            case "b5" -> "dept.eng.platform2";
-            case "b6" -> "50%.a_b";
-            case "c1" -> "Dept.Eng";
-            case "c2" -> "dept.eng.";
-            case "d1" -> "[env]:prod:eu";
-            case "d2" -> "e:prod:eu";
-            default -> null;
-        };
+        return derivedFor(seed).scope();
     }
 }

--- a/ent/adversarial_test.go
+++ b/ent/adversarial_test.go
@@ -433,9 +433,9 @@ func (h *harness) seed(t *testing.T) {
 				"id", "a_bool", "a_string", "a_number", "a_double",
 				"a_optional_string", "created_by", "scope", "created_at",
 			},
-			seed.ID, seed.ABool, seed.AString, seed.ANumber, nullableFloat(aDouble(seed)),
-			nullableString(seed.AOptionalString), createdBy(seed),
-			nullableString(scopeOf(seed)), h.storedTimestamp(t, seed))
+			seed.ID, seed.ABool, seed.AString, seed.ANumber, nullableFloat(h.corpus.aDouble(seed)),
+			nullableString(seed.AOptionalString), h.corpus.createdBy(seed),
+			nullableString(h.corpus.scopeOf(seed)), h.storedTimestamp(t, seed))
 
 		for _, tag := range seed.Tags {
 			h.exec(t, tagTable, []string{"tag_id", "name", "resource_id"},
@@ -447,7 +447,7 @@ func (h *harness) seed(t *testing.T) {
 			h.exec(t, categoryTable, []string{"id", "name", "resource_id"}, catID, "business", seed.ID)
 			h.exec(t, subCategoryTable, []string{"id", "name", "category_id"}, subID, subName, catID)
 
-			for j, label := range labelsOf(seed) {
+			for j, label := range h.corpus.labelsOf(seed) {
 				h.exec(t, labelTable, []string{"id", "name", "sub_category_id"},
 					fmt.Sprintf("%s-label%d", subID, j), nullableString(label), subID)
 			}
@@ -463,7 +463,7 @@ func (h *harness) seed(t *testing.T) {
 func (h *harness) storedTimestamp(t *testing.T, seed Seed) any {
 	t.Helper()
 
-	raw := createdAt(seed)
+	raw := h.corpus.createdAt(seed)
 	if raw == nil {
 		return nil
 	}
@@ -521,7 +521,7 @@ func (h *harness) checkResource(seed Seed) *cerbos.Resource {
 	}
 
 	labels := make([]any, 0)
-	for _, label := range labelsOf(seed) {
+	for _, label := range h.corpus.labelsOf(seed) {
 		if label == nil {
 			labels = append(labels, map[string]any{})
 		} else {
@@ -541,7 +541,7 @@ func (h *harness) checkResource(seed Seed) *cerbos.Resource {
 		"aBool":      seed.ABool,
 		"aString":    seed.AString,
 		"aNumber":    seed.ANumber,
-		"createdBy":  createdBy(seed),
+		"createdBy":  h.corpus.createdBy(seed),
 		"obj":        map[string]any{"inner": seed.AString},
 		"tags":       tags,
 		"tagNames":   tagNames,
@@ -556,13 +556,13 @@ func (h *harness) checkResource(seed Seed) *cerbos.Resource {
 		attr["owner"] = nil
 	}
 
-	if d := aDouble(seed); d != nil {
+	if d := h.corpus.aDouble(seed); d != nil {
 		attr["aDouble"] = *d
 	}
-	if s := scopeOf(seed); s != nil {
+	if s := h.corpus.scopeOf(seed); s != nil {
 		attr["scope"] = *s
 	}
-	if ts := createdAt(seed); ts != nil {
+	if ts := h.corpus.createdAt(seed); ts != nil {
 		attr["createdAt"] = *ts
 	}
 

--- a/ent/corpus_test.go
+++ b/ent/corpus_test.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // The shared adversarial corpus. Everything about what is tested — the hostile rows, the action
@@ -144,6 +142,11 @@ var seedKeys = []string{
 
 // seedNoteKey is documentation, never read by any harness.
 const seedNoteKey = "note"
+
+// tagKeys guards the one nested object array a seed carries. The top-level guard says nothing
+// about a key added inside an element, and an element key is dropped from both sides just as
+// silently.
+var tagKeys = []string{"id", "name"}
 
 // derivedKeys is the exact set of per-seed derived fields this harness consumes, guarded the same
 // way and for the same reason as seedKeys.
@@ -301,7 +304,16 @@ func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 		tb.Fatalf("seeds.json decoded %d rows but carries %d", len(c.Seeds.Seeds), len(raw.Seeds))
 	}
 	for i, seed := range raw.Seeds {
-		assertKeys(tb, fmt.Sprintf("seeds.json seeds[%d]", i), keysOf(seed), seedKeys, seedNoteKey)
+		label := fmt.Sprintf("seeds.json seeds[%d]", i)
+		assertKeys(tb, label, keysOf(seed), seedKeys, seedNoteKey)
+
+		var tags []map[string]json.RawMessage
+		if err := json.Unmarshal(seed["tags"], &tags); err != nil {
+			tb.Fatalf("parsing %s.tags: %v", label, err)
+		}
+		for j, tag := range tags {
+			assertKeys(tb, fmt.Sprintf("%s.tags[%d]", label, j), keysOf(tag), tagKeys)
+		}
 	}
 
 	assertKeys(tb, "derived-fields.json fields", c.Derived.Fields, derivedKeys)
@@ -358,16 +370,18 @@ func keysOf(m map[string]json.RawMessage) []string {
 // TestCorpusCoverage runs the corpus consistency guards on their own, without the containers the
 // differential suite needs. A corpus field this harness stopped consuming — on either side of the
 // differential at once — fails here in milliseconds rather than after a PDP and a database have
-// started.
+// started. loadCorpus does the asserting; the only thing left to check is that it had anything to
+// assert against.
+//
+// Run it with -count=1 after editing the corpus: ../conformance is outside this module, so Go's
+// test cache does not track it and will otherwise serve the previous result. CI checks out fresh,
+// so this only bites local runs.
 func TestCorpusCoverage(t *testing.T) {
 	t.Parallel()
 
-	corpus := loadCorpus(t, adapterName)
-	require.NotEmpty(t, corpus.Seeds.Seeds, "corpus has no seeds")
-	require.Len(t, corpus.Derived.Entries, len(corpus.Seeds.Seeds),
-		"every seed needs exactly one derived-fields.json entry")
-	require.ElementsMatch(t, derivedKeys, corpus.Derived.Fields,
-		"derived-fields.json declares fields this harness does not consume")
+	if corpus := loadCorpus(t, adapterName); len(corpus.Seeds.Seeds) == 0 {
+		t.Fatal("corpus has no seeds")
+	}
 }
 
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") -------

--- a/ent/corpus_test.go
+++ b/ent/corpus_test.go
@@ -4,12 +4,15 @@
 package cerbosent_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // The shared adversarial corpus. Everything about what is tested — the hostile rows, the action
@@ -28,11 +31,13 @@ type Tag struct {
 	ID   string  `json:"id"`
 }
 
-// Seed is one hostile row.
+// Seed is one hostile row. Note is corpus documentation this harness never reads; it is named so
+// strict decoding accepts it, and it is the one seed key seedKeys deliberately omits.
 type Seed struct {
 	AOptionalString  *string  `json:"aOptionalString"`
 	ID               string   `json:"id"`
 	AString          string   `json:"aString"`
+	Note             string   `json:"note"`
 	Tags             []Tag    `json:"tags"`
 	SubCategoryNames []string `json:"subCategoryNames"`
 	ANumber          int      `json:"aNumber"`
@@ -46,11 +51,34 @@ type Principal struct {
 	Roles []string       `json:"roles"`
 }
 
-// SeedsFile is conformance/seeds.json.
+// SeedsFile is conformance/seeds.json. Every key the file carries is named, including the prose
+// ones, because it is decoded with unknown fields rejected.
 type SeedsFile struct {
-	ResourceKind string    `json:"resourceKind"`
-	Seeds        []Seed    `json:"seeds"`
-	Principal    Principal `json:"principal"`
+	Schema        string    `json:"$schema"` //nolint:tagliatelle // JSON Schema's reserved key.
+	Description   string    `json:"description"`
+	ResourceKind  string    `json:"resourceKind"`
+	PrincipalNote string    `json:"principalNote"`
+	Seeds         []Seed    `json:"seeds"`
+	Principal     Principal `json:"principal"`
+}
+
+// DerivedEntry is one seed's deterministic derived fields, read from
+// conformance/derived-fields.json rather than recomputed here. A nil value is a NULL column and a
+// missing check() attribute; a nil element of Labels is a NULL label name.
+type DerivedEntry struct {
+	CreatedAt *string   `json:"createdAt"`
+	Scope     *string   `json:"scope"`
+	ADouble   *float64  `json:"aDouble"`
+	CreatedBy string    `json:"createdBy"`
+	Labels    []*string `json:"labels"`
+}
+
+// DerivedFile is conformance/derived-fields.json.
+type DerivedFile struct {
+	Schema      string                  `json:"$schema"` //nolint:tagliatelle // JSON Schema's reserved key.
+	Description string                  `json:"description"`
+	Entries     map[string]DerivedEntry `json:"derived"`
+	Fields      []string                `json:"fields"`
 }
 
 // UnsupportedShape is an entry in expectedUnsupported.
@@ -95,10 +123,31 @@ type Corpus struct {
 	CerbosVersion      string
 	Actions            ActionsFile
 	Seeds              SeedsFile
+	Derived            DerivedFile
 	OracleActions      []string
 	ThrowingActions    []AdapterEntry
 	NullOmittedActions []AdapterEntry
 }
+
+// seedKeys is the exact set of seeds.json row keys this harness consumes. `note` is corpus prose
+// and is the one documented exclusion.
+//
+// The same parsed seed feeds the stored row AND the check() oracle, so a key this harness does not
+// know about would vanish from both sides at once and the differential would agree for the wrong
+// reason — the projection trap conformance/README.md describes for actions.json, applied to the
+// seeds. Asserting set equality rather than only rejecting unknown fields catches both directions:
+// a corpus key nothing here consumes, and a consumed key the corpus no longer carries (which would
+// otherwise decode to its zero value on both sides).
+var seedKeys = []string{
+	"aBool", "aNumber", "aOptionalString", "aString", "id", "subCategoryNames", "tags",
+}
+
+// seedNoteKey is documentation, never read by any harness.
+const seedNoteKey = "note"
+
+// derivedKeys is the exact set of per-seed derived fields this harness consumes, guarded the same
+// way and for the same reason as seedKeys.
+var derivedKeys = []string{"aDouble", "createdAt", "createdBy", "labels", "scope"}
 
 // loadCorpus reads the corpus and derives the classification for adapterName exactly as
 // conformance/README.md prescribes:
@@ -113,8 +162,10 @@ func loadCorpus(tb testing.TB, adapterName string) *Corpus {
 	dir := findConformanceDir(tb)
 	c := &Corpus{Dir: dir}
 
-	readJSON(tb, filepath.Join(dir, "seeds.json"), &c.Seeds)
+	readJSONStrict(tb, filepath.Join(dir, "seeds.json"), &c.Seeds)
+	readJSONStrict(tb, filepath.Join(dir, "derived-fields.json"), &c.Derived)
 	readJSON(tb, filepath.Join(dir, "actions.json"), &c.Actions)
+	assertCorpusCoverage(tb, dir, c)
 
 	version, err := os.ReadFile(filepath.Join(dir, "CERBOS_VERSION"))
 	if err != nil {
@@ -219,81 +270,134 @@ func readJSON(tb testing.TB, path string, out any) {
 	}
 }
 
+// readJSONStrict decodes a corpus file with unknown fields rejected, so a key the target struct
+// does not name is a build-the-wrong-thing error rather than a silent drop.
+func readJSONStrict(tb testing.TB, path string, out any) {
+	tb.Helper()
+
+	data, err := os.ReadFile(path) //nolint:gosec // corpus paths are derived from the repo layout
+	if err != nil {
+		tb.Fatalf("reading %s: %v", path, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(out); err != nil {
+		tb.Fatalf("parsing %s: %v", path, err)
+	}
+}
+
+// assertCorpusCoverage proves the harness consumes every seed key and every derived field the
+// corpus defines, and nothing it does not. Strict decoding alone cannot do this: it rejects an
+// added key but says nothing about one that disappears, and a disappeared key decodes to its zero
+// value on both sides of the differential.
+func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
+	tb.Helper()
+
+	var raw struct {
+		Seeds []map[string]json.RawMessage `json:"seeds"`
+	}
+	readJSON(tb, filepath.Join(dir, "seeds.json"), &raw)
+	if len(raw.Seeds) != len(c.Seeds.Seeds) {
+		tb.Fatalf("seeds.json decoded %d rows but carries %d", len(c.Seeds.Seeds), len(raw.Seeds))
+	}
+	for i, seed := range raw.Seeds {
+		assertKeys(tb, fmt.Sprintf("seeds.json seeds[%d]", i), keysOf(seed), seedKeys, seedNoteKey)
+	}
+
+	assertKeys(tb, "derived-fields.json fields", c.Derived.Fields, derivedKeys)
+
+	var rawDerived struct {
+		Derived map[string]map[string]json.RawMessage `json:"derived"`
+	}
+	readJSON(tb, filepath.Join(dir, "derived-fields.json"), &rawDerived)
+	for _, seed := range c.Seeds.Seeds {
+		entry, ok := rawDerived.Derived[seed.ID]
+		if !ok {
+			tb.Fatalf("derived-fields.json has no entry for seed %q", seed.ID)
+		}
+		assertKeys(tb, fmt.Sprintf("derived-fields.json derived[%q]", seed.ID), keysOf(entry), derivedKeys)
+	}
+	if len(rawDerived.Derived) != len(c.Seeds.Seeds) {
+		tb.Fatalf("derived-fields.json has %d entries for %d seeds", len(rawDerived.Derived), len(c.Seeds.Seeds))
+	}
+}
+
+// assertKeys fails unless got is exactly want, ignoring order, plus any of the optional keys.
+func assertKeys(tb testing.TB, label string, got, want []string, optional ...string) {
+	tb.Helper()
+
+	allowed := make(map[string]bool, len(want)+len(optional))
+	required := make(map[string]bool, len(want))
+	for _, key := range want {
+		allowed[key] = true
+		required[key] = true
+	}
+	for _, key := range optional {
+		allowed[key] = true
+	}
+
+	for _, key := range got {
+		if !allowed[key] {
+			tb.Fatalf("%s carries %q, which this harness does not consume: an unconsumed corpus field is dropped from the stored row and the check() oracle at once", label, key)
+		}
+		delete(required, key)
+	}
+	for key := range required {
+		tb.Fatalf("%s is missing %q, which this harness consumes", label, key)
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// TestCorpusCoverage runs the corpus consistency guards on their own, without the containers the
+// differential suite needs. A corpus field this harness stopped consuming — on either side of the
+// differential at once — fails here in milliseconds rather than after a PDP and a database have
+// started.
+func TestCorpusCoverage(t *testing.T) {
+	t.Parallel()
+
+	corpus := loadCorpus(t, adapterName)
+	require.NotEmpty(t, corpus.Seeds.Seeds, "corpus has no seeds")
+	require.Len(t, corpus.Derived.Entries, len(corpus.Seeds.Seeds),
+		"every seed needs exactly one derived-fields.json entry")
+	require.ElementsMatch(t, derivedKeys, corpus.Derived.Fields,
+		"derived-fields.json declares fields this harness does not consume")
+}
+
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") -------
 //
 // These are part of the shared contract, not adapter-specific fixtures: the same values feed both
 // the seeded rows and the check() oracle, so an error here would make both sides agree for the
-// wrong reason.
+// wrong reason and nothing downstream could catch it. They are therefore read from
+// conformance/derived-fields.json rather than restated here — restating them is how a
+// transcription error becomes self-consistent and invisible.
 
-func createdBy(s Seed) string {
-	if s.ANumber >= 2 {
-		return "2024-06-01T00:00:00Z"
+func (c *Corpus) derived(s Seed) DerivedEntry {
+	entry, ok := c.Derived.Entries[s.ID]
+	if !ok {
+		// Unreachable: assertCorpusCoverage proves every seed has an entry.
+		panic("no derived-fields.json entry for seed " + s.ID)
 	}
-	return "2026-06-01T00:00:00Z"
+	return entry
 }
 
-func aDouble(s Seed) *float64 {
-	switch s.ID {
-	case "a1":
-		return ptr(-0.6)
-	case "a2":
-		return ptr(0.25)
-	case "a3":
-		return nil
-	default:
-		return ptr(float64(s.ANumber) + 0.3)
-	}
-}
+func (c *Corpus) createdBy(s Seed) string { return c.derived(s).CreatedBy }
 
-func createdAt(s Seed) *string {
-	fixed := map[string]*string{
-		"a1": ptr("2020-03-15T10:30:00Z"),
-		"a2": ptr("2037-01-01T00:00:00Z"),
-		"a3": nil,
-		"a4": ptr("2024-06-01T00:00:00Z"),
-		"a5": ptr("2020-03-15T10:30:00.123456Z"),
-	}
-	if v, ok := fixed[s.ID]; ok {
-		return v
-	}
-	if s.ANumber >= 2 {
-		return ptr("2036-06-06T06:06:06Z")
-	}
-	return ptr("2021-05-05T05:05:05Z")
-}
+func (c *Corpus) aDouble(s Seed) *float64 { return c.derived(s).ADouble }
 
-func scopeOf(s Seed) *string {
-	scopes := map[string]string{
-		"a1": "dept", "a2": "dept.eng", "a3": "dept.eng.platform",
-		"a4": "dept.eng.platform.obs", "a5": "dept.engineering", "a6": "dept.sales",
-		"a8": "", "a9": "50%", "b1": "50%:a_b:x", "b2": "50x:a_b:y", "b3": "50%:aXb:y",
-		"b4": "50%:a_b", "b5": "dept.eng.platform2", "b6": "50%.a_b", "c1": "Dept.Eng",
-		"c2": "dept.eng.", "d1": "[env]:prod:eu", "d2": "e:prod:eu",
-	}
-	if v, ok := scopes[s.ID]; ok {
-		return &v
-	}
-	return nil
-}
+func (c *Corpus) createdAt(s Seed) *string { return c.derived(s).CreatedAt }
+
+func (c *Corpus) scopeOf(s Seed) *string { return c.derived(s).Scope }
 
 // labelsOf returns the third-level label names. A nil element is a NULL label name, which must be
 // a missing element attribute on the check side.
-func labelsOf(s Seed) []*string {
-	switch s.ID {
-	case "a1":
-		return []*string{ptr("gold"), ptr("silver")}
-	case "a6":
-		return []*string{nil, ptr("silver")}
-	case "a8":
-		return []*string{ptr("silver")}
-	case "c1":
-		return []*string{ptr("Gold")}
-	default:
-		return nil
-	}
-}
-
-func ptr[T any](v T) *T { return &v }
+func (c *Corpus) labelsOf(s Seed) []*string { return c.derived(s).Labels }
 
 // categoryID and subCategoryID name the per-seed category graph. Each seed gets its own
 // categories so no two rows share a relation — a shared graph would let a filter match through

--- a/langchain-chromadb/src/adversarial.test.ts
+++ b/langchain-chromadb/src/adversarial.test.ts
@@ -179,6 +179,10 @@ const SEED_KEYS = [
 /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
 const SEED_NOTE_KEY = "note";
 
+/** The one nested object array a seed carries. A key added inside an element is dropped from both
+ * sides of the differential just as silently as a top-level one, so it is guarded the same way. */
+const TAG_KEYS = ["id", "name"] as const;
+
 const DERIVED_KEYS = [
   "createdBy",
   "aDouble",
@@ -221,9 +225,12 @@ function assertSeedKeyCoverage(value: unknown): void {
   );
   seeds.forEach((seed, index) => {
     const label = `seeds.json seeds[${index}]`;
-    assertKeys(label, Object.keys(requireRecord(seed, label)), SEED_KEYS, [
-      SEED_NOTE_KEY,
-    ]);
+    const record = requireRecord(seed, label);
+    assertKeys(label, Object.keys(record), SEED_KEYS, [SEED_NOTE_KEY]);
+    requireArray(record["tags"], `${label}.tags`).forEach((tag, tagIndex) => {
+      const tagLabel = `${label}.tags[${tagIndex}]`;
+      assertKeys(tagLabel, Object.keys(requireRecord(tag, tagLabel)), TAG_KEYS);
+    });
   });
 }
 

--- a/langchain-chromadb/src/adversarial.test.ts
+++ b/langchain-chromadb/src/adversarial.test.ts
@@ -63,6 +63,20 @@ interface SeedsFile {
   seeds: Seed[];
 }
 
+/** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
+interface DerivedEntry {
+  createdBy: string;
+  aDouble: number | null;
+  createdAt: string | null;
+  scope: string | null;
+  labels: (string | null)[];
+}
+
+interface DerivedFile {
+  fields: string[];
+  derived: Record<string, DerivedEntry>;
+}
+
 interface UnsupportedShape {
   action: string;
   shape: string;
@@ -142,6 +156,126 @@ function parseTag(value: unknown, label: string): Tag {
     id: requireString(tag["id"], `${label}.id`),
     name,
   };
+}
+
+// -- corpus coverage guards ---------------------------------------------------------------------
+//
+// The same parsed seed feeds the stored metadata AND the check() oracle, so a corpus field this
+// harness does not consume is dropped from both sides at once and the differential agrees for the
+// wrong reason — the projection trap conformance/README.md describes for actions.json, applied to
+// the seeds. Asserting set equality catches both directions: a corpus key nothing here reads, and a
+// key this harness reads that the corpus no longer carries.
+
+const SEED_KEYS = [
+  "id",
+  "aBool",
+  "aString",
+  "aNumber",
+  "aOptionalString",
+  "tags",
+  "subCategoryNames",
+] as const;
+
+/** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
+const SEED_NOTE_KEY = "note";
+
+const DERIVED_KEYS = [
+  "createdBy",
+  "aDouble",
+  "createdAt",
+  "scope",
+  "labels",
+] as const;
+
+function assertKeys(
+  label: string,
+  got: string[],
+  want: readonly string[],
+  optional: readonly string[] = [],
+): void {
+  const allowed = new Set<string>([...want, ...optional]);
+  for (const key of got) {
+    if (!allowed.has(key)) {
+      throw Error(
+        `${label} carries "${key}", which this harness does not consume: an unconsumed corpus field is dropped from the stored metadata and the check() oracle at once`,
+      );
+    }
+  }
+  const present = new Set(got);
+  for (const key of want) {
+    if (!present.has(key)) {
+      throw Error(`${label} is missing "${key}", which this harness consumes`);
+    }
+  }
+}
+
+/**
+ * Asserted against the RAW json rather than the parsed seeds: parseSeed rebuilds each row field by
+ * field, so a parsed seed can only ever carry the keys this harness already names and the
+ * assertion would pass vacuously.
+ */
+function assertSeedKeyCoverage(value: unknown): void {
+  const seeds = requireArray(
+    requireRecord(value, "seeds.json")["seeds"],
+    "seeds.json seeds",
+  );
+  seeds.forEach((seed, index) => {
+    const label = `seeds.json seeds[${index}]`;
+    assertKeys(label, Object.keys(requireRecord(seed, label)), SEED_KEYS, [
+      SEED_NOTE_KEY,
+    ]);
+  });
+}
+
+function parseDerivedEntry(value: unknown, label: string): DerivedEntry {
+  const entry = requireRecord(value, label);
+  assertKeys(label, Object.keys(entry), DERIVED_KEYS);
+  const aDouble = entry["aDouble"];
+  if (aDouble !== null && typeof aDouble !== "number") {
+    throw Error(`${label}.aDouble must be a number or null`);
+  }
+  const createdAt = entry["createdAt"];
+  if (createdAt !== null && typeof createdAt !== "string") {
+    throw Error(`${label}.createdAt must be a string or null`);
+  }
+  const scope = entry["scope"];
+  if (scope !== null && typeof scope !== "string") {
+    throw Error(`${label}.scope must be a string or null`);
+  }
+  const labels = requireArray(entry["labels"], `${label}.labels`).map(
+    (name, index) => {
+      if (name !== null && typeof name !== "string") {
+        throw Error(`${label}.labels[${index}] must be a string or null`);
+      }
+      return name;
+    },
+  );
+  return {
+    createdBy: requireString(entry["createdBy"], `${label}.createdBy`),
+    aDouble,
+    createdAt,
+    scope,
+    labels,
+  };
+}
+
+function parseDerivedFile(value: unknown): DerivedFile {
+  const file = requireRecord(value, "derived-fields.json");
+  const fields = parseStringArray(
+    file["fields"],
+    "derived-fields.json fields",
+  );
+  assertKeys("derived-fields.json fields", fields, DERIVED_KEYS);
+  const derived: Record<string, DerivedEntry> = {};
+  for (const [id, entry] of Object.entries(
+    requireRecord(file["derived"], "derived-fields.json derived"),
+  )) {
+    derived[id] = parseDerivedEntry(
+      entry,
+      `derived-fields.json derived["${id}"]`,
+    );
+  }
+  return { fields, derived };
 }
 
 function parseSeed(value: unknown, index: number): Seed {
@@ -269,9 +403,22 @@ function readJson(fileName: string): unknown {
   return JSON.parse(fs.readFileSync(path.join(CONFORMANCE_DIR, fileName), "utf8"));
 }
 
-const seedsFile = parseSeedsFile(readJson("seeds.json"));
+const rawSeedsJson = readJson("seeds.json");
+assertSeedKeyCoverage(rawSeedsJson);
+const seedsFile = parseSeedsFile(rawSeedsJson);
 const actionsFile = parseActionsFile(readJson("actions.json"));
+const derivedFile = parseDerivedFile(readJson("derived-fields.json"));
 const SEEDS = seedsFile.seeds;
+
+if (Object.keys(derivedFile.derived).length !== SEEDS.length) {
+  throw Error(
+    `derived-fields.json has ${Object.keys(derivedFile.derived).length} entries for ${SEEDS.length} seeds`,
+  );
+}
+for (const seed of SEEDS) {
+  // Throws when the entry is missing.
+  derivedFor(seed);
+}
 
 const CHROMA_UNSUPPORTED =
   actionsFile.adapterUnsupported["langchain-chromadb"] ?? [];
@@ -333,100 +480,40 @@ const FIELD_NAME_MAPPER: Record<string, string | FieldNameMapperConfig> = {
   "request.resource.attr.obj.inner": { field: "obj.inner", required: true },
 };
 
+// -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
+//
+// Read from conformance/derived-fields.json rather than restated here. The same value feeds the
+// stored row and the check() oracle, so a transcription error would be self-consistent and
+// invisible to the differential; one machine-readable definition is what makes that impossible.
+
+function derivedFor(seed: Seed): DerivedEntry {
+  const entry = derivedFile.derived[seed.id];
+  if (entry === undefined) {
+    throw new Error(`derived-fields.json has no entry for seed "${seed.id}"`);
+  }
+  return entry;
+}
+
 function doubleFor(seed: Seed): number | null {
-  switch (seed.id) {
-    case "a1":
-      return -0.6;
-    case "a2":
-      return 0.25;
-    case "a3":
-      return null;
-    default:
-      return seed.aNumber + 0.3;
-  }
+  return derivedFor(seed).aDouble;
 }
 
+/** Third-level label names. A null element is a NULL label name — a missing element attribute. */
 function labelsFor(seed: Seed): (string | null)[] {
-  switch (seed.id) {
-    case "a1":
-      return ["gold", "silver"];
-    case "a6":
-      return [null, "silver"];
-    case "a8":
-      return ["silver"];
-    case "c1":
-      return ["Gold"];
-    default:
-      return [];
-  }
+  return derivedFor(seed).labels;
 }
 
+/** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
 function isoFor(seed: Seed): string {
-  return seed.aNumber >= 2
-    ? "2024-06-01T00:00:00Z"
-    : "2026-06-01T00:00:00Z";
+  return derivedFor(seed).createdBy;
 }
 
 function timestampFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "2020-03-15T10:30:00Z";
-    case "a2":
-      return "2037-01-01T00:00:00Z";
-    case "a3":
-      return null;
-    case "a4":
-      return "2024-06-01T00:00:00Z";
-    case "a5":
-      return "2020-03-15T10:30:00.123456Z";
-    default:
-      return seed.aNumber >= 2
-        ? "2036-06-06T06:06:06Z"
-        : "2021-05-05T05:05:05Z";
-  }
+  return derivedFor(seed).createdAt;
 }
 
 function scopeFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "dept";
-    case "a2":
-      return "dept.eng";
-    case "a3":
-      return "dept.eng.platform";
-    case "a4":
-      return "dept.eng.platform.obs";
-    case "a5":
-      return "dept.engineering";
-    case "a6":
-      return "dept.sales";
-    case "a8":
-      return "";
-    case "a9":
-      return "50%";
-    case "b1":
-      return "50%:a_b:x";
-    case "b2":
-      return "50x:a_b:y";
-    case "b3":
-      return "50%:aXb:y";
-    case "b4":
-      return "50%:a_b";
-    case "b5":
-      return "dept.eng.platform2";
-    case "b6":
-      return "50%.a_b";
-    case "c1":
-      return "Dept.Eng";
-    case "c2":
-      return "dept.eng.";
-    case "d1":
-      return "[env]:prod:eu";
-    case "d2":
-      return "e:prod:eu";
-    default:
-      return null;
-  }
+  return derivedFor(seed).scope;
 }
 
 function tagAttribute(tag: Tag): Record<string, Value> {

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -188,6 +188,10 @@ const SEED_KEYS = [
 /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
 const SEED_NOTE_KEY = "note";
 
+/** The one nested object array a seed carries. A key added inside an element is dropped from both
+ * sides of the differential just as silently as a top-level one, so it is guarded the same way. */
+const TAG_KEYS = ["id", "name"] as const;
+
 const DERIVED_KEYS = [
   "createdBy",
   "aDouble",
@@ -232,9 +236,16 @@ function assertSeedKeyCoverage(value: unknown): void {
   }
   seeds.forEach((seed, index) => {
     const label = `seeds.json seeds[${index}]`;
-    assertKeys(label, Object.keys(expectRecord(seed, label)), SEED_KEYS, [
-      SEED_NOTE_KEY,
-    ]);
+    const record = expectRecord(seed, label);
+    assertKeys(label, Object.keys(record), SEED_KEYS, [SEED_NOTE_KEY]);
+    const tags = record["tags"];
+    if (!Array.isArray(tags)) {
+      throw new Error(`${label}.tags must be an array`);
+    }
+    tags.forEach((tag, tagIndex) => {
+      const tagLabel = `${label}.tags[${tagIndex}]`;
+      assertKeys(tagLabel, Object.keys(expectRecord(tag, tagLabel)), TAG_KEYS);
+    });
   });
 }
 

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -43,6 +43,20 @@ interface SeedsFile {
   seeds: Seed[];
 }
 
+/** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
+interface DerivedEntry {
+  createdBy: string;
+  aDouble: number | null;
+  createdAt: string | null;
+  scope: string | null;
+  labels: (string | null)[];
+}
+
+interface DerivedFile {
+  fields: string[];
+  derived: Record<string, DerivedEntry>;
+}
+
 interface AdapterEntry {
   action: string;
   reason: string;
@@ -151,6 +165,127 @@ function parseTag(value: unknown, label: string): Tag {
     id: expectString(record["id"], `${label}.id`),
     name,
   };
+}
+
+// -- corpus coverage guards ---------------------------------------------------------------------
+//
+// The same parsed seed feeds the stored document AND the check() oracle, so a corpus field this
+// harness does not consume is dropped from both sides at once and the differential agrees for the
+// wrong reason — the projection trap conformance/README.md describes for actions.json, applied to
+// the seeds. Asserting set equality catches both directions: a corpus key nothing here reads, and a
+// key this harness reads that the corpus no longer carries.
+
+const SEED_KEYS = [
+  "id",
+  "aBool",
+  "aString",
+  "aNumber",
+  "aOptionalString",
+  "tags",
+  "subCategoryNames",
+] as const;
+
+/** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
+const SEED_NOTE_KEY = "note";
+
+const DERIVED_KEYS = [
+  "createdBy",
+  "aDouble",
+  "createdAt",
+  "scope",
+  "labels",
+] as const;
+
+function assertKeys(
+  label: string,
+  got: string[],
+  want: readonly string[],
+  optional: readonly string[] = []
+): void {
+  const allowed = new Set<string>([...want, ...optional]);
+  for (const key of got) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `${label} carries "${key}", which this harness does not consume: an unconsumed corpus field is dropped from the stored document and the check() oracle at once`
+      );
+    }
+  }
+  const present = new Set(got);
+  for (const key of want) {
+    if (!present.has(key)) {
+      throw new Error(
+        `${label} is missing "${key}", which this harness consumes`
+      );
+    }
+  }
+}
+
+/**
+ * Asserted against the RAW json rather than the parsed seeds: parseSeed rebuilds each row field by
+ * field, so a parsed seed can only ever carry the keys this harness already names and the
+ * assertion would pass vacuously.
+ */
+function assertSeedKeyCoverage(value: unknown): void {
+  const seeds = expectRecord(value, "seeds.json")["seeds"];
+  if (!Array.isArray(seeds)) {
+    throw new Error("seeds.json.seeds must be an array");
+  }
+  seeds.forEach((seed, index) => {
+    const label = `seeds.json seeds[${index}]`;
+    assertKeys(label, Object.keys(expectRecord(seed, label)), SEED_KEYS, [
+      SEED_NOTE_KEY,
+    ]);
+  });
+}
+
+function parseDerivedEntry(value: unknown, label: string): DerivedEntry {
+  const record = expectRecord(value, label);
+  assertKeys(label, Object.keys(record), DERIVED_KEYS);
+  const aDouble = record["aDouble"];
+  if (aDouble !== null && typeof aDouble !== "number") {
+    throw new Error(`${label}.aDouble must be a number or null`);
+  }
+  const createdAt = record["createdAt"];
+  if (createdAt !== null && typeof createdAt !== "string") {
+    throw new Error(`${label}.createdAt must be a string or null`);
+  }
+  const scope = record["scope"];
+  if (scope !== null && typeof scope !== "string") {
+    throw new Error(`${label}.scope must be a string or null`);
+  }
+  const labels = record["labels"];
+  if (
+    !Array.isArray(labels) ||
+    !labels.every((entry) => entry === null || typeof entry === "string")
+  ) {
+    throw new Error(`${label}.labels must be an array of strings or nulls`);
+  }
+  return {
+    createdBy: expectString(record["createdBy"], `${label}.createdBy`),
+    aDouble,
+    createdAt,
+    scope,
+    labels,
+  };
+}
+
+function parseDerivedFile(value: unknown): DerivedFile {
+  const record = expectRecord(value, "derived-fields.json");
+  const fields = expectStringArray(
+    record["fields"],
+    "derived-fields.json fields"
+  );
+  assertKeys("derived-fields.json fields", fields, DERIVED_KEYS);
+  const derived: Record<string, DerivedEntry> = {};
+  for (const [id, entry] of Object.entries(
+    expectRecord(record["derived"], "derived-fields.json derived")
+  )) {
+    derived[id] = parseDerivedEntry(
+      entry,
+      `derived-fields.json derived["${id}"]`
+    );
+  }
+  return { fields, derived };
 }
 
 function parseSeed(value: unknown, index: number): Seed {
@@ -292,9 +427,24 @@ function parseActionsFile(value: unknown): ActionsFile {
   };
 }
 
-const seedsFile = parseSeedsFile(readJson("seeds.json"));
+const rawSeedsJson = readJson("seeds.json");
+assertSeedKeyCoverage(rawSeedsJson);
+const seedsFile = parseSeedsFile(rawSeedsJson);
 const actionsFile = parseActionsFile(readJson("actions.json"));
+const derivedFile = parseDerivedFile(readJson("derived-fields.json"));
 const SEEDS = seedsFile.seeds;
+
+if (Object.keys(derivedFile.derived).length !== SEEDS.length) {
+  throw new Error(
+    `derived-fields.json has ${
+      Object.keys(derivedFile.derived).length
+    } entries for ${SEEDS.length} seeds`
+  );
+}
+for (const seed of SEEDS) {
+  // Throws when the entry is missing.
+  derivedFor(seed);
+}
 
 const unsupportedEntries = actionsFile.adapterUnsupported["mongoose"] ?? [];
 const unsupportedActions = new Set(
@@ -512,100 +662,39 @@ const MAPPER: Mapper = {
   },
 };
 
-function doubleFor(seed: Seed): number | null {
-  switch (seed.id) {
-    case "a1":
-      return -0.6;
-    case "a2":
-      return 0.25;
-    case "a3":
-      return null;
-    default:
-      return seed.aNumber + 0.3;
+// -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
+//
+// Read from conformance/derived-fields.json rather than restated here. The same value feeds the
+// stored row and the check() oracle, so a transcription error would be self-consistent and
+// invisible to the differential; one machine-readable definition is what makes that impossible.
+
+function derivedFor(seed: Seed): DerivedEntry {
+  const entry = derivedFile.derived[seed.id];
+  if (entry === undefined) {
+    throw new Error(`derived-fields.json has no entry for seed "${seed.id}"`);
   }
+  return entry;
 }
 
+function doubleFor(seed: Seed): number | null {
+  return derivedFor(seed).aDouble;
+}
+
+/** Third-level label names. A null element is a NULL label name — a missing element attribute. */
 function labelsFor(seed: Seed): (string | null)[] {
-  switch (seed.id) {
-    case "a1":
-      return ["gold", "silver"];
-    case "a6":
-      return [null, "silver"];
-    case "a8":
-      return ["silver"];
-    case "c1":
-      return ["Gold"];
-    default:
-      return [];
-  }
+  return derivedFor(seed).labels;
 }
 
 function createdByFor(seed: Seed): string {
-  return seed.aNumber >= 2
-    ? "2024-06-01T00:00:00Z"
-    : "2026-06-01T00:00:00Z";
+  return derivedFor(seed).createdBy;
 }
 
 function timestampFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "2020-03-15T10:30:00Z";
-    case "a2":
-      return "2037-01-01T00:00:00Z";
-    case "a3":
-      return null;
-    case "a4":
-      return "2024-06-01T00:00:00Z";
-    case "a5":
-      return "2020-03-15T10:30:00.123456Z";
-    default:
-      return seed.aNumber >= 2
-        ? "2036-06-06T06:06:06Z"
-        : "2021-05-05T05:05:05Z";
-  }
+  return derivedFor(seed).createdAt;
 }
 
 function scopeFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "dept";
-    case "a2":
-      return "dept.eng";
-    case "a3":
-      return "dept.eng.platform";
-    case "a4":
-      return "dept.eng.platform.obs";
-    case "a5":
-      return "dept.engineering";
-    case "a6":
-      return "dept.sales";
-    case "a8":
-      return "";
-    case "a9":
-      return "50%";
-    case "b1":
-      return "50%:a_b:x";
-    case "b2":
-      return "50x:a_b:y";
-    case "b3":
-      return "50%:aXb:y";
-    case "b4":
-      return "50%:a_b";
-    case "b5":
-      return "dept.eng.platform2";
-    case "b6":
-      return "50%.a_b";
-    case "c1":
-      return "Dept.Eng";
-    case "c2":
-      return "dept.eng.";
-    case "d1":
-      return "[env]:prod:eu";
-    case "d2":
-      return "e:prod:eu";
-    default:
-      return null;
-  }
+  return derivedFor(seed).scope;
 }
 
 function asTagAttribute(tag: Tag): Record<string, Value> {

--- a/pgx/adversarial_test.go
+++ b/pgx/adversarial_test.go
@@ -235,7 +235,7 @@ func seedDatabase(t *testing.T, ctx context.Context, pool *pgxpool.Pool, corpus 
 
 	for _, seed := range corpus.Seeds.Seeds {
 		var created *time.Time
-		if raw := createdAt(seed); raw != nil {
+		if raw := corpus.createdAt(seed); raw != nil {
 			parsed, err := time.Parse(time.RFC3339Nano, *raw)
 			require.NoError(t, err, "parsing derived createdAt for %s", seed.ID)
 			created = &parsed
@@ -245,8 +245,8 @@ func seedDatabase(t *testing.T, ctx context.Context, pool *pgxpool.Pool, corpus 
 			INSERT INTO adversarial_resource
 				(id, a_bool, a_string, a_number, a_double, a_optional_string, created_by, scope, created_at)
 			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
-			seed.ID, seed.ABool, seed.AString, seed.ANumber, aDouble(seed),
-			seed.AOptionalString, createdBy(seed), scopeOf(seed), created)
+			seed.ID, seed.ABool, seed.AString, seed.ANumber, corpus.aDouble(seed),
+			seed.AOptionalString, corpus.createdBy(seed), corpus.scopeOf(seed), created)
 		require.NoError(t, err, "seeding resource %s", seed.ID)
 
 		for _, tag := range seed.Tags {
@@ -269,7 +269,7 @@ func seedDatabase(t *testing.T, ctx context.Context, pool *pgxpool.Pool, corpus 
 				subID, subName, catID)
 			require.NoError(t, err, "seeding sub-category %s", subID)
 
-			for j, label := range labelsOf(seed) {
+			for j, label := range corpus.labelsOf(seed) {
 				_, err := pool.Exec(ctx,
 					`INSERT INTO adversarial_label (id, name, sub_category_id) VALUES ($1,$2,$3)`,
 					fmt.Sprintf("%s-label%d", subID, j), label, subID)
@@ -309,7 +309,7 @@ func (h *harness) checkResource(seed Seed) *cerbos.Resource {
 	}
 
 	labels := make([]any, 0)
-	for _, label := range labelsOf(seed) {
+	for _, label := range h.corpus.labelsOf(seed) {
 		if label == nil {
 			labels = append(labels, map[string]any{})
 		} else {
@@ -331,7 +331,7 @@ func (h *harness) checkResource(seed Seed) *cerbos.Resource {
 		"aBool":      seed.ABool,
 		"aString":    seed.AString,
 		"aNumber":    seed.ANumber,
-		"createdBy":  createdBy(seed),
+		"createdBy":  h.corpus.createdBy(seed),
 		"obj":        map[string]any{"inner": seed.AString},
 		"tags":       tags,
 		"tagNames":   tagNames,
@@ -346,13 +346,13 @@ func (h *harness) checkResource(seed Seed) *cerbos.Resource {
 		attr["owner"] = nil
 	}
 
-	if d := aDouble(seed); d != nil {
+	if d := h.corpus.aDouble(seed); d != nil {
 		attr["aDouble"] = *d
 	}
-	if s := scopeOf(seed); s != nil {
+	if s := h.corpus.scopeOf(seed); s != nil {
 		attr["scope"] = *s
 	}
-	if ts := createdAt(seed); ts != nil {
+	if ts := h.corpus.createdAt(seed); ts != nil {
 		attr["createdAt"] = *ts
 	}
 

--- a/pgx/corpus_test.go
+++ b/pgx/corpus_test.go
@@ -4,12 +4,15 @@
 package cerbospgx_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // The shared adversarial corpus. Everything about what is tested — the hostile rows, the action
@@ -28,11 +31,13 @@ type Tag struct {
 	ID   string  `json:"id"`
 }
 
-// Seed is one hostile row.
+// Seed is one hostile row. Note is corpus documentation this harness never reads; it is named so
+// strict decoding accepts it, and it is the one seed key seedKeys deliberately omits.
 type Seed struct {
 	AOptionalString  *string  `json:"aOptionalString"`
 	ID               string   `json:"id"`
 	AString          string   `json:"aString"`
+	Note             string   `json:"note"`
 	Tags             []Tag    `json:"tags"`
 	SubCategoryNames []string `json:"subCategoryNames"`
 	ANumber          int      `json:"aNumber"`
@@ -46,11 +51,34 @@ type Principal struct {
 	Roles []string       `json:"roles"`
 }
 
-// SeedsFile is conformance/seeds.json.
+// SeedsFile is conformance/seeds.json. Every key the file carries is named, including the prose
+// ones, because it is decoded with unknown fields rejected.
 type SeedsFile struct {
-	ResourceKind string    `json:"resourceKind"`
-	Seeds        []Seed    `json:"seeds"`
-	Principal    Principal `json:"principal"`
+	Schema        string    `json:"$schema"` //nolint:tagliatelle // JSON Schema's reserved key.
+	Description   string    `json:"description"`
+	ResourceKind  string    `json:"resourceKind"`
+	PrincipalNote string    `json:"principalNote"`
+	Seeds         []Seed    `json:"seeds"`
+	Principal     Principal `json:"principal"`
+}
+
+// DerivedEntry is one seed's deterministic derived fields, read from
+// conformance/derived-fields.json rather than recomputed here. A nil value is a NULL column and a
+// missing check() attribute; a nil element of Labels is a NULL label name.
+type DerivedEntry struct {
+	CreatedAt *string   `json:"createdAt"`
+	Scope     *string   `json:"scope"`
+	ADouble   *float64  `json:"aDouble"`
+	CreatedBy string    `json:"createdBy"`
+	Labels    []*string `json:"labels"`
+}
+
+// DerivedFile is conformance/derived-fields.json.
+type DerivedFile struct {
+	Schema      string                  `json:"$schema"` //nolint:tagliatelle // JSON Schema's reserved key.
+	Description string                  `json:"description"`
+	Entries     map[string]DerivedEntry `json:"derived"`
+	Fields      []string                `json:"fields"`
 }
 
 // UnsupportedShape is an entry in expectedUnsupported.
@@ -88,11 +116,32 @@ type ActionsFile struct {
 	KnownDivergences          []KnownDivergence         `json:"knownDivergences"`
 }
 
+// seedKeys is the exact set of seeds.json row keys this harness consumes. `note` is corpus prose
+// and is the one documented exclusion.
+//
+// The same parsed seed feeds the stored row AND the check() oracle, so a key this harness does not
+// know about would vanish from both sides at once and the differential would agree for the wrong
+// reason — the projection trap conformance/README.md describes for actions.json, applied to the
+// seeds. Asserting set equality rather than only rejecting unknown fields catches both directions:
+// a corpus key nothing here consumes, and a consumed key the corpus no longer carries (which would
+// otherwise decode to its zero value on both sides).
+var seedKeys = []string{
+	"aBool", "aNumber", "aOptionalString", "aString", "id", "subCategoryNames", "tags",
+}
+
+// seedNoteKey is documentation, never read by any harness.
+const seedNoteKey = "note"
+
+// derivedKeys is the exact set of per-seed derived fields this harness consumes, guarded the same
+// way and for the same reason as seedKeys.
+var derivedKeys = []string{"aDouble", "createdAt", "createdBy", "labels", "scope"}
+
 // Corpus is the parsed corpus plus this adapter's derived classification.
 type Corpus struct {
 	Dir           string
 	CerbosVersion string
 	Seeds         SeedsFile
+	Derived       DerivedFile
 	Actions       ActionsFile
 
 	// OracleActions must match the check() oracle exactly.
@@ -118,8 +167,10 @@ func loadCorpus(tb testing.TB, adapterName string) *Corpus {
 	dir := findConformanceDir(tb)
 	c := &Corpus{Dir: dir}
 
-	readJSON(tb, filepath.Join(dir, "seeds.json"), &c.Seeds)
+	readJSONStrict(tb, filepath.Join(dir, "seeds.json"), &c.Seeds)
+	readJSONStrict(tb, filepath.Join(dir, "derived-fields.json"), &c.Derived)
 	readJSON(tb, filepath.Join(dir, "actions.json"), &c.Actions)
+	assertCorpusCoverage(tb, dir, c)
 
 	version, err := os.ReadFile(filepath.Join(dir, "CERBOS_VERSION"))
 	if err != nil {
@@ -224,81 +275,134 @@ func readJSON(tb testing.TB, path string, out any) {
 	}
 }
 
+// readJSONStrict decodes a corpus file with unknown fields rejected, so a key the target struct
+// does not name is a build-the-wrong-thing error rather than a silent drop.
+func readJSONStrict(tb testing.TB, path string, out any) {
+	tb.Helper()
+
+	data, err := os.ReadFile(path) //nolint:gosec // corpus paths are derived from the repo layout
+	if err != nil {
+		tb.Fatalf("reading %s: %v", path, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(out); err != nil {
+		tb.Fatalf("parsing %s: %v", path, err)
+	}
+}
+
+// assertCorpusCoverage proves the harness consumes every seed key and every derived field the
+// corpus defines, and nothing it does not. Strict decoding alone cannot do this: it rejects an
+// added key but says nothing about one that disappears, and a disappeared key decodes to its zero
+// value on both sides of the differential.
+func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
+	tb.Helper()
+
+	var raw struct {
+		Seeds []map[string]json.RawMessage `json:"seeds"`
+	}
+	readJSON(tb, filepath.Join(dir, "seeds.json"), &raw)
+	if len(raw.Seeds) != len(c.Seeds.Seeds) {
+		tb.Fatalf("seeds.json decoded %d rows but carries %d", len(c.Seeds.Seeds), len(raw.Seeds))
+	}
+	for i, seed := range raw.Seeds {
+		assertKeys(tb, fmt.Sprintf("seeds.json seeds[%d]", i), keysOf(seed), seedKeys, seedNoteKey)
+	}
+
+	assertKeys(tb, "derived-fields.json fields", c.Derived.Fields, derivedKeys)
+
+	var rawDerived struct {
+		Derived map[string]map[string]json.RawMessage `json:"derived"`
+	}
+	readJSON(tb, filepath.Join(dir, "derived-fields.json"), &rawDerived)
+	for _, seed := range c.Seeds.Seeds {
+		entry, ok := rawDerived.Derived[seed.ID]
+		if !ok {
+			tb.Fatalf("derived-fields.json has no entry for seed %q", seed.ID)
+		}
+		assertKeys(tb, fmt.Sprintf("derived-fields.json derived[%q]", seed.ID), keysOf(entry), derivedKeys)
+	}
+	if len(rawDerived.Derived) != len(c.Seeds.Seeds) {
+		tb.Fatalf("derived-fields.json has %d entries for %d seeds", len(rawDerived.Derived), len(c.Seeds.Seeds))
+	}
+}
+
+// assertKeys fails unless got is exactly want, ignoring order, plus any of the optional keys.
+func assertKeys(tb testing.TB, label string, got, want []string, optional ...string) {
+	tb.Helper()
+
+	allowed := make(map[string]bool, len(want)+len(optional))
+	required := make(map[string]bool, len(want))
+	for _, key := range want {
+		allowed[key] = true
+		required[key] = true
+	}
+	for _, key := range optional {
+		allowed[key] = true
+	}
+
+	for _, key := range got {
+		if !allowed[key] {
+			tb.Fatalf("%s carries %q, which this harness does not consume: an unconsumed corpus field is dropped from the stored row and the check() oracle at once", label, key)
+		}
+		delete(required, key)
+	}
+	for key := range required {
+		tb.Fatalf("%s is missing %q, which this harness consumes", label, key)
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// TestCorpusCoverage runs the corpus consistency guards on their own, without the containers the
+// differential suite needs. A corpus field this harness stopped consuming — on either side of the
+// differential at once — fails here in milliseconds rather than after a PDP and a database have
+// started.
+func TestCorpusCoverage(t *testing.T) {
+	t.Parallel()
+
+	corpus := loadCorpus(t, adapterName)
+	require.NotEmpty(t, corpus.Seeds.Seeds, "corpus has no seeds")
+	require.Len(t, corpus.Derived.Entries, len(corpus.Seeds.Seeds),
+		"every seed needs exactly one derived-fields.json entry")
+	require.ElementsMatch(t, derivedKeys, corpus.Derived.Fields,
+		"derived-fields.json declares fields this harness does not consume")
+}
+
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") -------
 //
 // These are part of the shared contract, not adapter-specific fixtures: the same values feed both
 // the seeded rows and the check() oracle, so an error here would make both sides agree for the
-// wrong reason.
+// wrong reason and nothing downstream could catch it. They are therefore read from
+// conformance/derived-fields.json rather than restated here — restating them is how a
+// transcription error becomes self-consistent and invisible.
 
-func createdBy(s Seed) string {
-	if s.ANumber >= 2 {
-		return "2024-06-01T00:00:00Z"
+func (c *Corpus) derived(s Seed) DerivedEntry {
+	entry, ok := c.Derived.Entries[s.ID]
+	if !ok {
+		// Unreachable: assertCorpusCoverage proves every seed has an entry.
+		panic("no derived-fields.json entry for seed " + s.ID)
 	}
-	return "2026-06-01T00:00:00Z"
+	return entry
 }
 
-func aDouble(s Seed) *float64 {
-	switch s.ID {
-	case "a1":
-		return ptr(-0.6)
-	case "a2":
-		return ptr(0.25)
-	case "a3":
-		return nil
-	default:
-		return ptr(float64(s.ANumber) + 0.3)
-	}
-}
+func (c *Corpus) createdBy(s Seed) string { return c.derived(s).CreatedBy }
 
-func createdAt(s Seed) *string {
-	fixed := map[string]*string{
-		"a1": ptr("2020-03-15T10:30:00Z"),
-		"a2": ptr("2037-01-01T00:00:00Z"),
-		"a3": nil,
-		"a4": ptr("2024-06-01T00:00:00Z"),
-		"a5": ptr("2020-03-15T10:30:00.123456Z"),
-	}
-	if v, ok := fixed[s.ID]; ok {
-		return v
-	}
-	if s.ANumber >= 2 {
-		return ptr("2036-06-06T06:06:06Z")
-	}
-	return ptr("2021-05-05T05:05:05Z")
-}
+func (c *Corpus) aDouble(s Seed) *float64 { return c.derived(s).ADouble }
 
-func scopeOf(s Seed) *string {
-	scopes := map[string]string{
-		"a1": "dept", "a2": "dept.eng", "a3": "dept.eng.platform",
-		"a4": "dept.eng.platform.obs", "a5": "dept.engineering", "a6": "dept.sales",
-		"a8": "", "a9": "50%", "b1": "50%:a_b:x", "b2": "50x:a_b:y", "b3": "50%:aXb:y",
-		"b4": "50%:a_b", "b5": "dept.eng.platform2", "b6": "50%.a_b", "c1": "Dept.Eng",
-		"c2": "dept.eng.", "d1": "[env]:prod:eu", "d2": "e:prod:eu",
-	}
-	if v, ok := scopes[s.ID]; ok {
-		return &v
-	}
-	return nil
-}
+func (c *Corpus) createdAt(s Seed) *string { return c.derived(s).CreatedAt }
+
+func (c *Corpus) scopeOf(s Seed) *string { return c.derived(s).Scope }
 
 // labelsOf returns the third-level label names. A nil element is a NULL label name, which must be
 // a missing element attribute on the check side.
-func labelsOf(s Seed) []*string {
-	switch s.ID {
-	case "a1":
-		return []*string{ptr("gold"), ptr("silver")}
-	case "a6":
-		return []*string{nil, ptr("silver")}
-	case "a8":
-		return []*string{ptr("silver")}
-	case "c1":
-		return []*string{ptr("Gold")}
-	default:
-		return nil
-	}
-}
-
-func ptr[T any](v T) *T { return &v }
+func (c *Corpus) labelsOf(s Seed) []*string { return c.derived(s).Labels }
 
 // categoryID and subCategoryID name the per-seed category graph. Each seed gets its own
 // categories so no two rows share a relation — a shared graph would let a filter match through

--- a/pgx/corpus_test.go
+++ b/pgx/corpus_test.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // The shared adversarial corpus. Everything about what is tested — the hostile rows, the action
@@ -131,6 +129,11 @@ var seedKeys = []string{
 
 // seedNoteKey is documentation, never read by any harness.
 const seedNoteKey = "note"
+
+// tagKeys guards the one nested object array a seed carries. The top-level guard says nothing
+// about a key added inside an element, and an element key is dropped from both sides just as
+// silently.
+var tagKeys = []string{"id", "name"}
 
 // derivedKeys is the exact set of per-seed derived fields this harness consumes, guarded the same
 // way and for the same reason as seedKeys.
@@ -306,7 +309,16 @@ func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 		tb.Fatalf("seeds.json decoded %d rows but carries %d", len(c.Seeds.Seeds), len(raw.Seeds))
 	}
 	for i, seed := range raw.Seeds {
-		assertKeys(tb, fmt.Sprintf("seeds.json seeds[%d]", i), keysOf(seed), seedKeys, seedNoteKey)
+		label := fmt.Sprintf("seeds.json seeds[%d]", i)
+		assertKeys(tb, label, keysOf(seed), seedKeys, seedNoteKey)
+
+		var tags []map[string]json.RawMessage
+		if err := json.Unmarshal(seed["tags"], &tags); err != nil {
+			tb.Fatalf("parsing %s.tags: %v", label, err)
+		}
+		for j, tag := range tags {
+			assertKeys(tb, fmt.Sprintf("%s.tags[%d]", label, j), keysOf(tag), tagKeys)
+		}
 	}
 
 	assertKeys(tb, "derived-fields.json fields", c.Derived.Fields, derivedKeys)
@@ -363,16 +375,18 @@ func keysOf(m map[string]json.RawMessage) []string {
 // TestCorpusCoverage runs the corpus consistency guards on their own, without the containers the
 // differential suite needs. A corpus field this harness stopped consuming — on either side of the
 // differential at once — fails here in milliseconds rather than after a PDP and a database have
-// started.
+// started. loadCorpus does the asserting; the only thing left to check is that it had anything to
+// assert against.
+//
+// Run it with -count=1 after editing the corpus: ../conformance is outside this module, so Go's
+// test cache does not track it and will otherwise serve the previous result. CI checks out fresh,
+// so this only bites local runs.
 func TestCorpusCoverage(t *testing.T) {
 	t.Parallel()
 
-	corpus := loadCorpus(t, adapterName)
-	require.NotEmpty(t, corpus.Seeds.Seeds, "corpus has no seeds")
-	require.Len(t, corpus.Derived.Entries, len(corpus.Seeds.Seeds),
-		"every seed needs exactly one derived-fields.json entry")
-	require.ElementsMatch(t, derivedKeys, corpus.Derived.Fields,
-		"derived-fields.json declares fields this harness does not consume")
+	if corpus := loadCorpus(t, adapterName); len(corpus.Seeds.Seeds) == 0 {
+		t.Fatal("corpus has no seeds")
+	}
 }
 
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") -------

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -123,13 +123,107 @@ function classifyActionsForAdapter(
   };
 }
 
+// -- corpus coverage guards ---------------------------------------------------------------------
+//
+// The same parsed seed feeds the stored row AND the check() oracle, so a corpus field this harness
+// does not consume is dropped from both sides at once and the differential agrees for the wrong
+// reason — the projection trap conformance/README.md describes for actions.json, applied to the
+// seeds. Asserting set equality catches both directions: a corpus key nothing here reads, and a key
+// this harness reads that the corpus no longer carries.
+
+const SEED_KEYS = [
+  "id",
+  "aBool",
+  "aString",
+  "aNumber",
+  "aOptionalString",
+  "tags",
+  "subCategoryNames",
+] as const;
+
+/** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
+const SEED_NOTE_KEY = "note";
+
+const DERIVED_KEYS = [
+  "createdBy",
+  "aDouble",
+  "createdAt",
+  "scope",
+  "labels",
+] as const;
+
+/** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
+interface DerivedEntry {
+  createdBy: string;
+  aDouble: number | null;
+  createdAt: string | null;
+  scope: string | null;
+  labels: (string | null)[];
+}
+
+interface DerivedFile {
+  fields: string[];
+  derived: Record<string, DerivedEntry>;
+}
+
+function assertKeys(
+  label: string,
+  got: string[],
+  want: readonly string[],
+  optional: readonly string[] = []
+): void {
+  const allowed = new Set<string>([...want, ...optional]);
+  for (const key of got) {
+    if (!allowed.has(key)) {
+      throw new Error(
+        `${label} carries "${key}", which this harness does not consume: an unconsumed corpus field is dropped from the stored row and the check() oracle at once`
+      );
+    }
+  }
+  const present = new Set(got);
+  for (const key of want) {
+    if (!present.has(key)) {
+      throw new Error(
+        `${label} is missing "${key}", which this harness consumes`
+      );
+    }
+  }
+}
+
 const seedsFile: SeedsFile = JSON.parse(
   fs.readFileSync(path.join(CONFORMANCE_DIR, "seeds.json"), "utf8")
 );
 const actionsFile: ActionsFile = JSON.parse(
   fs.readFileSync(path.join(CONFORMANCE_DIR, "actions.json"), "utf8")
 );
+const derivedFile: DerivedFile = JSON.parse(
+  fs.readFileSync(path.join(CONFORMANCE_DIR, "derived-fields.json"), "utf8")
+);
 const SEEDS = seedsFile.seeds;
+
+// SEEDS holds the parsed JSON rows verbatim, so Object.keys reports the corpus key set. Keep it
+// that way: a parser that rebuilt each row field by field could only ever report the keys this
+// harness already names, and the assertion would pass vacuously.
+SEEDS.forEach((seed, index) => {
+  assertKeys(`seeds.json seeds[${index}]`, Object.keys(seed), SEED_KEYS, [
+    SEED_NOTE_KEY,
+  ]);
+});
+
+assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);
+const DERIVED_IDS = Object.keys(derivedFile.derived);
+if (DERIVED_IDS.length !== SEEDS.length) {
+  throw new Error(
+    `derived-fields.json has ${DERIVED_IDS.length} entries for ${SEEDS.length} seeds`
+  );
+}
+for (const seed of SEEDS) {
+  assertKeys(
+    `derived-fields.json derived["${seed.id}"]`,
+    Object.keys(derivedFor(seed)),
+    DERIVED_KEYS
+  );
+}
 
 const {
   oracleActions: ORACLE_ACTIONS,
@@ -161,99 +255,40 @@ const MANIFEST_ACTIONS = new Set([
   ...(actionsFile.knownDivergences ?? []).map((entry) => entry.action),
 ]);
 
-function doubleFor(seed: Seed): number | null {
-  switch (seed.id) {
-    case "a1":
-      return -0.6;
-    case "a2":
-      return 0.25;
-    case "a3":
-      return null;
-    default:
-      return seed.aNumber + 0.3;
+// -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
+//
+// Read from conformance/derived-fields.json rather than restated here. The same value feeds the
+// stored row and the check() oracle, so a transcription error would be self-consistent and
+// invisible to the differential; one machine-readable definition is what makes that impossible.
+
+function derivedFor(seed: Seed): DerivedEntry {
+  const entry = derivedFile.derived[seed.id];
+  if (entry === undefined) {
+    throw new Error(`derived-fields.json has no entry for seed "${seed.id}"`);
   }
+  return entry;
 }
 
+function doubleFor(seed: Seed): number | null {
+  return derivedFor(seed).aDouble;
+}
+
+/** Third-level label names. A null element is a NULL label name — a missing element attribute. */
 function labelsFor(seed: Seed): (string | null)[] {
-  switch (seed.id) {
-    case "a1":
-      return ["gold", "silver"];
-    case "a6":
-      return [null, "silver"];
-    case "a8":
-      return ["silver"];
-    case "c1":
-      return ["Gold"];
-    default:
-      return [];
-  }
+  return derivedFor(seed).labels;
 }
 
 /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
 function isoFor(seed: Seed): string {
-  return seed.aNumber >= 2 ? "2024-06-01T00:00:00Z" : "2026-06-01T00:00:00Z";
+  return derivedFor(seed).createdBy;
 }
 
 function timestampFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "2020-03-15T10:30:00Z";
-    case "a2":
-      return "2037-01-01T00:00:00Z";
-    case "a3":
-      return null;
-    case "a4":
-      return "2024-06-01T00:00:00Z";
-    case "a5":
-      return "2020-03-15T10:30:00.123456Z";
-    default:
-      return seed.aNumber >= 2
-        ? "2036-06-06T06:06:06Z"
-        : "2021-05-05T05:05:05Z";
-  }
+  return derivedFor(seed).createdAt;
 }
 
 function scopeFor(seed: Seed): string | null {
-  switch (seed.id) {
-    case "a1":
-      return "dept";
-    case "a2":
-      return "dept.eng";
-    case "a3":
-      return "dept.eng.platform";
-    case "a4":
-      return "dept.eng.platform.obs";
-    case "a5":
-      return "dept.engineering";
-    case "a6":
-      return "dept.sales";
-    case "a8":
-      return "";
-    case "a9":
-      return "50%";
-    case "b1":
-      return "50%:a_b:x";
-    case "b2":
-      return "50x:a_b:y";
-    case "b3":
-      return "50%:aXb:y";
-    case "b4":
-      return "50%:a_b";
-    case "b5":
-      return "dept.eng.platform2";
-    case "b6":
-      return "50%.a_b";
-    case "c1":
-      return "Dept.Eng";
-    case "c2":
-      return "dept.eng.";
-    case "d1":
-      return "[env]:prod:eu";
-    case "d2":
-      return "e:prod:eu";
-    default:
-      return null;
-  }
+  return derivedFor(seed).scope;
 }
 
 const MAPPER: Record<string, MapperConfig> = {

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -144,6 +144,10 @@ const SEED_KEYS = [
 /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
 const SEED_NOTE_KEY = "note";
 
+/** The one nested object array a seed carries. A key added inside an element is dropped from both
+ * sides of the differential just as silently as a top-level one, so it is guarded the same way. */
+const TAG_KEYS = ["id", "name"] as const;
+
 const DERIVED_KEYS = [
   "createdBy",
   "aDouble",
@@ -205,9 +209,11 @@ const SEEDS = seedsFile.seeds;
 // that way: a parser that rebuilt each row field by field could only ever report the keys this
 // harness already names, and the assertion would pass vacuously.
 SEEDS.forEach((seed, index) => {
-  assertKeys(`seeds.json seeds[${index}]`, Object.keys(seed), SEED_KEYS, [
-    SEED_NOTE_KEY,
-  ]);
+  const label = `seeds.json seeds[${index}]`;
+  assertKeys(label, Object.keys(seed), SEED_KEYS, [SEED_NOTE_KEY]);
+  seed.tags.forEach((tag, tagIndex) => {
+    assertKeys(`${label}.tags[${tagIndex}]`, Object.keys(tag), TAG_KEYS);
+  });
 });
 
 assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -220,6 +220,13 @@ class AdversarialConformanceTest {
     /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
     private static final String SEED_NOTE_KEY = "note";
 
+    /**
+     * The one nested object array a seed carries. A key added inside an element is dropped from
+     * both sides of the differential just as silently as a top-level one, so it is guarded the
+     * same way.
+     */
+    private static final List<String> TAG_KEYS = List.of("id", "name");
+
     private static final List<String> DERIVED_KEYS =
             List.of("createdBy", "aDouble", "createdAt", "scope", "labels");
 
@@ -377,8 +384,13 @@ class AdversarialConformanceTest {
         JsonNode rawSeeds = mapper.readTree(conformance.resolve("seeds.json").toFile()).get("seeds");
         assertEquals(SEEDS.size(), rawSeeds.size(), "seeds.json rows lost in decoding");
         for (int i = 0; i < rawSeeds.size(); i++) {
-            assertKeys("seeds.json seeds[" + i + "]", keysOf(rawSeeds.get(i)),
-                    SEED_KEYS, List.of(SEED_NOTE_KEY));
+            String label = "seeds.json seeds[" + i + "]";
+            assertKeys(label, keysOf(rawSeeds.get(i)), SEED_KEYS, List.of(SEED_NOTE_KEY));
+            JsonNode rawTags = rawSeeds.get(i).get("tags");
+            for (int j = 0; j < rawTags.size(); j++) {
+                assertKeys(label + ".tags[" + j + "]", keysOf(rawTags.get(j)), TAG_KEYS,
+                        List.of());
+            }
         }
 
         assertKeys("derived-fields.json fields", derivedFile.fields(), DERIVED_KEYS, List.of());

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -1,6 +1,8 @@
 package dev.cerbos.queryplan.springdata;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dev.cerbos.api.v1.engine.Engine.PlanResourcesFilter;
@@ -50,15 +52,19 @@ import java.nio.file.Path;
 import com.google.protobuf.Value;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -139,19 +145,36 @@ class AdversarialConformanceTest {
         return Path.of(System.getProperty("user.dir"), "..", "conformance").normalize();
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
     private record Tag(String id, String name) {}
 
-    /** One seeded row; the single source of truth for BOTH the DB entity and the oracle attributes. */
-    @JsonIgnoreProperties(ignoreUnknown = true)
+    /**
+     * One seeded row; the single source of truth for BOTH the DB entity and the oracle attributes.
+     * {@code note} is corpus documentation this harness never reads; it is named so that strict
+     * decoding accepts it, and it is the one seed key {@link #SEED_KEYS} omits.
+     */
     private record Seed(String id, boolean aBool, String aString, int aNumber,
-                        String aOptionalString, List<Tag> tags, List<String> subCategoryNames) {}
+                        String aOptionalString, List<Tag> tags, List<String> subCategoryNames,
+                        String note) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record PrincipalSpec(String id, List<String> roles, Map<String, List<String>> attr) {}
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private record SeedsFile(PrincipalSpec principal, String resourceKind, List<Seed> seeds) {}
+    /**
+     * conformance/seeds.json. Every key the file carries is named, including the prose ones,
+     * because unknown properties are rejected rather than ignored: a seed field this harness does
+     * not consume would be dropped from the entity AND the check() oracle at once, and the
+     * differential would agree for the wrong reason.
+     */
+    private record SeedsFile(@JsonProperty("$schema") String schema, String description,
+                             PrincipalSpec principal, String resourceKind, String principalNote,
+                             List<Seed> seeds) {}
+
+    /** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
+    private record DerivedEntry(String createdBy, Double aDouble, String createdAt, String scope,
+                                List<String> labels) {}
+
+    private record DerivedFile(@JsonProperty("$schema") String schema, String description,
+                               List<String> fields, Map<String, DerivedEntry> derived) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     private record UnsupportedShape(String action, String shape, String springDataMessage) {}
@@ -183,8 +206,26 @@ class AdversarialConformanceTest {
     /** The corpus key for this adapter — its directory name, as every other harness uses. */
     private static final String ADAPTER = "spring-data";
 
+    // -- corpus coverage guards -----------------------------------------------------------------
+    //
+    // The same parsed seed feeds the persisted entity AND the check() oracle, so a corpus field
+    // this harness does not consume is dropped from both sides at once and the differential agrees
+    // for the wrong reason — the projection trap conformance/README.md describes for actions.json,
+    // applied to the seeds. Asserting set equality catches both directions: a corpus key nothing
+    // here reads, and a key this harness reads that the corpus no longer carries.
+
+    private static final List<String> SEED_KEYS = List.of(
+            "id", "aBool", "aString", "aNumber", "aOptionalString", "tags", "subCategoryNames");
+
+    /** Corpus prose, never read by a harness: the one documented exclusion from SEED_KEYS. */
+    private static final String SEED_NOTE_KEY = "note";
+
+    private static final List<String> DERIVED_KEYS =
+            List.of("createdBy", "aDouble", "createdAt", "scope", "labels");
+
     private static SeedsFile seedsFile;
     private static ActionsFile actionsFile;
+    private static DerivedFile derivedFile;
     private static List<Seed> SEEDS;
 
     /**
@@ -255,18 +296,26 @@ class AdversarialConformanceTest {
      * category/subCategory chain.
      */
     private static List<String> labelsFor(Seed s) {
-        return switch (s.id()) {
-            case "a1" -> java.util.Arrays.asList("gold", "silver");
-            case "a6" -> java.util.Arrays.asList(null, "silver");
-            case "a8" -> List.of("silver");
-            case "c1" -> List.of("Gold");
-            default -> List.of();
-        };
+        return derivedFor(s).labels();
     }
 
     /** Deterministic ISO instant per seed for the timestamp probe: split around 2025-01-01. */
     private static String isoFor(Seed s) {
-        return s.aNumber() >= 2 ? "2024-06-01T00:00:00Z" : "2026-06-01T00:00:00Z";
+        return derivedFor(s).createdBy();
+    }
+
+    /**
+     * The deterministic derived fields for one seed, read from conformance/derived-fields.json
+     * rather than restated here. The same value feeds the persisted entity and the check() oracle,
+     * so a transcription error would be self-consistent and invisible to the differential; one
+     * machine-readable definition is what makes that impossible. The JavaDoc on the accessors below
+     * explains what each value witnesses; conformance/README.md states the rules the file
+     * materialises, and validate-corpus.sh re-derives them.
+     */
+    private static DerivedEntry derivedFor(Seed s) {
+        DerivedEntry entry = derivedFile.derived().get(s.id());
+        assertNotNull(entry, () -> "derived-fields.json has no entry for seed \"" + s.id() + "\"");
+        return entry;
     }
 
     /**
@@ -282,16 +331,8 @@ class AdversarialConformanceTest {
      * and MySQL {@code timestamp(6)} columns.
      */
     private static java.time.Instant tsFor(Seed s) {
-        return switch (s.id()) {
-            case "a1" -> java.time.Instant.parse("2020-03-15T10:30:00Z");
-            case "a2" -> java.time.Instant.parse("2037-01-01T00:00:00Z");
-            case "a3" -> null;
-            case "a4" -> java.time.Instant.parse("2024-06-01T00:00:00Z");
-            case "a5" -> java.time.Instant.parse("2020-03-15T10:30:00.123456Z");
-            default -> s.aNumber() >= 2
-                    ? java.time.Instant.parse("2036-06-06T06:06:06Z")
-                    : java.time.Instant.parse("2021-05-05T05:05:05Z");
-        };
+        String value = derivedFor(s).createdAt();
+        return value == null ? null : java.time.Instant.parse(value);
     }
 
     /**
@@ -306,12 +347,7 @@ class AdversarialConformanceTest {
      * sides agree to exclude.
      */
     private static Double doubleFor(Seed s) {
-        return switch (s.id()) {
-            case "a1" -> -0.6;
-            case "a2" -> 0.25;
-            case "a3" -> null;
-            default -> s.aNumber() + 0.3;
-        };
+        return derivedFor(s).aDouble();
     }
 
     /**
@@ -327,27 +363,53 @@ class AdversarialConformanceTest {
      * attribute → CEL error → deny on the check side vs SQL NULL → excluded on the SQL side).
      */
     private static String scopeFor(Seed s) {
-        return switch (s.id()) {
-            case "a1" -> "dept";
-            case "a2" -> "dept.eng";
-            case "a3" -> "dept.eng.platform";
-            case "a4" -> "dept.eng.platform.obs";
-            case "a5" -> "dept.engineering";
-            case "a6" -> "dept.sales";
-            case "a8" -> "";
-            case "a9" -> "50%";
-            case "b1" -> "50%:a_b:x";
-            case "b2" -> "50x:a_b:y";
-            case "b3" -> "50%:aXb:y";
-            case "b4" -> "50%:a_b";
-            case "b5" -> "dept.eng.platform2";
-            case "b6" -> "50%.a_b";
-            case "c1" -> "Dept.Eng";
-            case "c2" -> "dept.eng.";
-            case "d1" -> "[env]:prod:eu"; // literal-bracket descendant for hier-bracket
-            case "d2" -> "e:prod:eu"; // SQL Server char-class trap sibling for hier-bracket
-            default -> null; // a7: NULL scope — a missing attribute on the check side
-        };
+        return derivedFor(s).scope();
+    }
+
+    /**
+     * Proves this harness consumes every seed key and every derived field the corpus defines, and
+     * nothing it does not. Rejecting unknown properties on decode cannot do this alone: it catches
+     * an added key but says nothing about one that disappears, and a disappeared key decodes to its
+     * default on both sides of the differential.
+     */
+    private static void assertCorpusCoverage(ObjectMapper mapper, Path conformance)
+            throws IOException {
+        JsonNode rawSeeds = mapper.readTree(conformance.resolve("seeds.json").toFile()).get("seeds");
+        assertEquals(SEEDS.size(), rawSeeds.size(), "seeds.json rows lost in decoding");
+        for (int i = 0; i < rawSeeds.size(); i++) {
+            assertKeys("seeds.json seeds[" + i + "]", keysOf(rawSeeds.get(i)),
+                    SEED_KEYS, List.of(SEED_NOTE_KEY));
+        }
+
+        assertKeys("derived-fields.json fields", derivedFile.fields(), DERIVED_KEYS, List.of());
+        assertEquals(SEEDS.stream().map(Seed::id).collect(Collectors.toCollection(TreeSet::new)),
+                new TreeSet<>(derivedFile.derived().keySet()),
+                "derived-fields.json must carry exactly one entry per seeds.json id");
+        JsonNode rawDerived =
+                mapper.readTree(conformance.resolve("derived-fields.json").toFile()).get("derived");
+        for (Map.Entry<String, JsonNode> entry : rawDerived.properties()) {
+            assertKeys("derived-fields.json derived[\"" + entry.getKey() + "\"]",
+                    keysOf(entry.getValue()), DERIVED_KEYS, List.of());
+        }
+    }
+
+    private static void assertKeys(String label, Collection<String> got, Collection<String> want,
+                                   Collection<String> optional) {
+        Set<String> allowed = new LinkedHashSet<>(want);
+        allowed.addAll(optional);
+        for (String key : got) {
+            assertTrue(allowed.contains(key), () -> label + " carries \"" + key
+                    + "\", which this harness does not consume: an unconsumed corpus field is"
+                    + " dropped from the persisted entity and the check() oracle at once");
+        }
+        Set<String> missing = new LinkedHashSet<>(want);
+        missing.removeAll(got);
+        assertTrue(missing.isEmpty(),
+                () -> label + " is missing " + missing + ", which this harness consumes");
+    }
+
+    private static List<String> keysOf(JsonNode node) {
+        return node.properties().stream().map(Map.Entry::getKey).toList();
     }
 
     private static GenericContainer<?> cerbos;
@@ -362,7 +424,10 @@ class AdversarialConformanceTest {
         Path conformance = conformanceDir();
         seedsFile = mapper.readValue(conformance.resolve("seeds.json").toFile(), SeedsFile.class);
         actionsFile = mapper.readValue(conformance.resolve("actions.json").toFile(), ActionsFile.class);
+        derivedFile = mapper.readValue(
+                conformance.resolve("derived-fields.json").toFile(), DerivedFile.class);
         SEEDS = seedsFile.seeds();
+        assertCorpusCoverage(mapper, conformance);
 
         // Pinned PDP image — see CerbosTestImage for the pin rationale and bump policy.
         cerbos = new GenericContainer<>(CerbosTestImage.IMAGE)

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -63,11 +63,67 @@ with open(os.path.join(CONFORMANCE_DIR, "seeds.json"), encoding="utf-8") as f:
     SEEDS_FILE = json.load(f)
 with open(os.path.join(CONFORMANCE_DIR, "actions.json"), encoding="utf-8") as f:
     ACTIONS_FILE = json.load(f)
+with open(os.path.join(CONFORMANCE_DIR, "derived-fields.json"), encoding="utf-8") as f:
+    DERIVED_FILE = json.load(f)
 with open(os.path.join(CONFORMANCE_DIR, "CERBOS_VERSION"), encoding="utf-8") as f:
     CERBOS_VERSION = f.read().strip()
 
 SEEDS: List[Dict[str, Any]] = SEEDS_FILE["seeds"]
 RESOURCE_KIND: str = SEEDS_FILE["resourceKind"]
+
+# -- corpus coverage guards -------------------------------------------------
+#
+# The same parsed seed feeds the stored row AND the check() oracle, so a corpus
+# field this harness does not consume is dropped from both sides at once and the
+# differential agrees for the wrong reason — the projection trap
+# conformance/README.md describes for actions.json, applied to the seeds.
+# Asserting set equality catches both directions: a corpus key nothing here
+# reads, and a key this harness reads that the corpus no longer carries.
+SEED_KEYS = {
+    "id",
+    "aBool",
+    "aString",
+    "aNumber",
+    "aOptionalString",
+    "tags",
+    "subCategoryNames",
+}
+# Corpus prose, never read by a harness: the one documented exclusion.
+SEED_NOTE_KEY = "note"
+DERIVED_KEYS = {"createdBy", "aDouble", "createdAt", "scope", "labels"}
+
+
+def _assert_keys(
+    label: str,
+    got: Set[str],
+    want: Set[str],
+    optional: Set[str] = frozenset(),
+) -> None:
+    unconsumed = got - want - optional
+    if unconsumed:
+        raise AssertionError(
+            f"{label} carries {sorted(unconsumed)}, which this harness does not "
+            "consume: an unconsumed corpus field is dropped from the stored row "
+            "and the check() oracle at once"
+        )
+    missing = want - got
+    if missing:
+        raise AssertionError(
+            f"{label} is missing {sorted(missing)}, which this harness consumes"
+        )
+
+
+for _index, _seed in enumerate(SEEDS):
+    _assert_keys(f"seeds.json seeds[{_index}]", set(_seed), SEED_KEYS, {SEED_NOTE_KEY})
+
+DERIVED: Dict[str, Dict[str, Any]] = DERIVED_FILE["derived"]
+_assert_keys("derived-fields.json fields", set(DERIVED_FILE["fields"]), DERIVED_KEYS)
+if set(DERIVED) != {seed["id"] for seed in SEEDS}:
+    raise AssertionError(
+        "derived-fields.json must carry exactly one entry per seeds.json id"
+    )
+for _id, _entry in DERIVED.items():
+    _assert_keys(f'derived-fields.json derived["{_id}"]', set(_entry), DERIVED_KEYS)
 
 # Capability classifications come from the shared manifest. Unsupported
 # conformance actions must throw; globally-unsupported actions promoted for
@@ -124,67 +180,44 @@ SQLALCHEMY_SKIPPED_DIVERGENCES = {
 }
 
 
+# -- deterministic derived fields (conformance/README.md) --------------------
+#
+# Read from conformance/derived-fields.json rather than restated here. The same
+# value feeds the stored row and the check() oracle, so a transcription error
+# would be self-consistent and invisible to the differential; one
+# machine-readable definition is what makes that impossible.
+
+
+def _derived_for(seed: Dict[str, Any]) -> Dict[str, Any]:
+    entry = DERIVED.get(seed["id"])
+    if entry is None:
+        raise AssertionError(
+            f'derived-fields.json has no entry for seed "{seed["id"]}"'
+        )
+    return entry
+
+
 def _iso_for(seed: Dict[str, Any]) -> str:
     """Deterministic ISO instant per seed for the timestamp probe (see
     conformance/README.md): split around the probe's 2025-01-01 threshold."""
-    return "2024-06-01T00:00:00Z" if seed["aNumber"] >= 2 else "2026-06-01T00:00:00Z"
+    return _derived_for(seed)["createdBy"]
 
 
 def _double_for(seed: Dict[str, Any]):
-    if seed["id"] == "a1":
-        return -0.6
-    if seed["id"] == "a2":
-        return 0.25
-    if seed["id"] == "a3":
-        return None
-    return seed["aNumber"] + 0.3
+    return _derived_for(seed)["aDouble"]
 
 
 def _timestamp_for(seed: Dict[str, Any]):
-    timestamps = {
-        "a1": "2020-03-15T10:30:00Z",
-        "a2": "2037-01-01T00:00:00Z",
-        "a3": None,
-        "a4": "2024-06-01T00:00:00Z",
-        "a5": "2020-03-15T10:30:00.123456Z",
-    }
-    value = timestamps.get(
-        seed["id"],
-        "2036-06-06T06:06:06Z" if seed["aNumber"] >= 2 else "2021-05-05T05:05:05Z",
-    )
+    value = _derived_for(seed)["createdAt"]
     return datetime.fromisoformat(value.replace("Z", "+00:00")) if value else None
 
 
 def _scope_for(seed: Dict[str, Any]):
-    return {
-        "a1": "dept",
-        "a2": "dept.eng",
-        "a3": "dept.eng.platform",
-        "a4": "dept.eng.platform.obs",
-        "a5": "dept.engineering",
-        "a6": "dept.sales",
-        "a8": "",
-        "a9": "50%",
-        "b1": "50%:a_b:x",
-        "b2": "50x:a_b:y",
-        "b3": "50%:aXb:y",
-        "b4": "50%:a_b",
-        "b5": "dept.eng.platform2",
-        "b6": "50%.a_b",
-        "c1": "Dept.Eng",
-        "c2": "dept.eng.",
-        "d1": "[env]:prod:eu",
-        "d2": "e:prod:eu",
-    }.get(seed["id"])
+    return _derived_for(seed)["scope"]
 
 
 def _labels_for(seed: Dict[str, Any]):
-    return {
-        "a1": ["gold", "silver"],
-        "a6": [None, "silver"],
-        "a8": ["silver"],
-        "c1": ["Gold"],
-    }.get(seed["id"], [])
+    return _derived_for(seed)["labels"]
 
 
 # ---------------------------------------------------------------------------

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -90,6 +90,10 @@ SEED_KEYS = {
 }
 # Corpus prose, never read by a harness: the one documented exclusion.
 SEED_NOTE_KEY = "note"
+# The one nested object array a seed carries. A key added inside an element is
+# dropped from both sides of the differential just as silently as a top-level
+# one, so it is guarded the same way.
+TAG_KEYS = {"id", "name"}
 DERIVED_KEYS = {"createdBy", "aDouble", "createdAt", "scope", "labels"}
 
 
@@ -114,7 +118,10 @@ def _assert_keys(
 
 
 for _index, _seed in enumerate(SEEDS):
-    _assert_keys(f"seeds.json seeds[{_index}]", set(_seed), SEED_KEYS, {SEED_NOTE_KEY})
+    _label = f"seeds.json seeds[{_index}]"
+    _assert_keys(_label, set(_seed), SEED_KEYS, {SEED_NOTE_KEY})
+    for _tag_index, _tag in enumerate(_seed["tags"]):
+        _assert_keys(f"{_label}.tags[{_tag_index}]", set(_tag), TAG_KEYS)
 
 DERIVED: Dict[str, Dict[str, Any]] = DERIVED_FILE["derived"]
 _assert_keys("derived-fields.json fields", set(DERIVED_FILE["fields"]), DERIVED_KEYS)


### PR DESCRIPTION
Closes #318.

## Why

Every harness deserialized `conformance/seeds.json` into a fixed-field shape with unknown keys ignored, and the **same** parsed value fed both the store seeder and the `check()` oracle. A new seed field was therefore dropped from both sides of the differential at once, so the comparison agreed for the wrong reason — the projection trap `conformance/README.md` documents for `actions.json`, applied to the seeds. Nothing asserted that the parsed key set covered the JSON key set.

Separately, the deterministic derived fields (`createdBy`, `aDouble`, `createdAt`, `scope`, `labels`) were hand-transcribed in all ten harnesses across four toolchains. Each copy fed both the store and the oracle, so a transcription error was self-consistent and invisible.

## What changed

**Seed key coverage.** Every harness declares the exact seed keys it consumes and asserts *set equality* against the corpus — not merely unknown-field rejection, which says nothing about a key the corpus stops carrying (that decodes to a zero value on both sides, the same silent-agreement mode). `note` is the one documented exclusion. The guard also covers `tags[]`, the one nested object array a seed carries. Per language: `DisallowUnknownFields` plus a key-set assertion in Go; records without `@JsonIgnoreProperties(ignoreUnknown = true)` plus a key-set assertion in Java; an explicit `assertKeys` in TypeScript and Python.

The two TypeScript harnesses that rebuild each seed field by field (mongoose, langchain-chromadb) assert against the **raw** JSON — a rebuilt object can only ever report the keys its parser already names, so asserting on it would pass vacuously.

**One derived-field table.** The values now live once, materialised per seed id in the new `conformance/derived-fields.json`, which every harness reads. The same key-set guard covers that file, so a sixth derived field cannot be silently ignored either. `validate-corpus.sh` asserts one entry per seed id and exact per-entry key sets, re-derives `createdBy`/`aDouble`/`createdAt` from `seeds.json` using the documented rules, and diffs `scope`/`labels` — which have no rule to re-derive from — against a restatement of their tables. Restating them inside a checker is not a second source of truth: unlike the ten copies it replaced, it never feeds a stored row or an oracle, so it can only fail loudly.

**Fast failure for the Go harnesses.** ent and pgx gain a container-free `TestCorpusCoverage` so the guard fails in milliseconds instead of after a PDP and a database have started.

## Affected adapters

All ten: prisma, mongoose, drizzle, convex, langchain-chromadb, sqlalchemy, ent, pgx, elasticsearch-java, spring-data.

## No behaviour change

No adapter's translation changes and **no action's oracle moves**. The committed table is bit-identical to what the removed per-harness rules computed — regenerated and diffed for all 20 seed ids × 5 fields. The `aNumber + 0.3` doubles round-trip exactly through JSON, so the `arith-add-*-frac*` traps are preserved.

## Verification

All ten adversarial suites pass unchanged:

| Adapter | Tests | Adapter | Tests |
|---|---|---|---|
| prisma | 148 | sqlalchemy | 297 (full file) |
| spring-data | 148 | ent | 521 (full module) |
| drizzle / mongoose / convex | 147 each | pgx | 243 (full module) |
| langchain-chromadb | 145 | elasticsearch-java | 144 |

`conformance/scripts/validate-corpus.sh` passes (143 actions, 20 seeds). Typecheck, `golangci-lint`, `black` and `isort` are clean.

Acceptance criteria were measured rather than assumed. Each of these fails **every** harness with a message naming the field:

- adding a dummy field to a seed
- removing a field a harness consumes
- adding a key inside `tags[]`
- adding an unconsumed derived field

Perturbing any `scope` or `labels` value fails `validate-corpus.sh`.

## For the reviewer

- Reproducing locally needs Docker (testcontainers for ent/pgx/Java), a MongoDB container for mongoose, a Convex backend for convex, and ChromaDB on port 8234 for langchain-chromadb. The Java harnesses must be run from the repository root so `../conformance/` is mounted.
- Pre-existing, not introduced here: `conformance/` sits outside both Go modules, so `go test` does not track it and can serve a cached pass after a corpus-only edit. CI checks out fresh, so it is a local-dev trap only; `TestCorpusCoverage`'s doc comment now records that a local run after a corpus edit needs `-count=1`.
- Second commit is the fix-up from `/code-review`: the nested `tags[]` guard and the `scope`/`labels` pin.