### PR TITLE
fix(conformance): derive each harness's degeneracy-guard list per adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,11 +151,14 @@ So when you add, fix, or change the handling of any shape:
    to `adapterUnsupported` with a reason naming the real mechanism, and make it throw), or an
    upstream planner bug (`knownDivergences`).
 5. **Bump the per-harness tripwires deliberately** — corpus size, oracle/throwing counts, and the
-   degeneracy-guard action list. Add the new action to that guard so it cannot pass vacuously.
+   degeneracy-guard action lists. Add the new action to each guard so it cannot pass vacuously,
+   choosing the right list per adapter: the *compared* list where that adapter translates the
+   shape, the *liveness-only* list where it throws. Every entry asserts its own side of that split,
+   so a guard list copied from another harness fails instead of quietly guarding nothing.
    The exception is an action whose oracle is empty *by construction* (a `nullRepresentationOmitted`
-   probe): the guard asserts a non-empty, non-total oracle, so such an action must stay out of it
-   and carry a different anti-vacuity assertion — one pinning *why* its rejection is required, not
-   merely that a rejection happens. See `conformance/README.md`.
+   probe): the guard asserts a non-empty, non-total oracle, so such an action must stay out of both
+   lists and carry a different anti-vacuity assertion — one pinning *why* its rejection is required,
+   not merely that a rejection happens. See `conformance/README.md`.
 6. **Update the affected READMEs' `Conformance contract` tables** in the same commit.
 
 A per-adapter unit test is not a substitute for a corpus action. Unit tests pin the filter an

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -181,6 +181,39 @@ for at least a handful of representative actions, that the oracle result is neit
 full seed set (`!ids.isEmpty() && ids.size() < seeds.size()`). This guards the guard: without it, a
 harness whose PDP connection or policy load silently failed would still pass every comparison.
 
+**Derive the list per adapter; never copy another harness's.** The guard protects an oracle
+*comparison*, so an entry naming a shape that adapter never compares — because it sits in that
+adapter's `adapterUnsupported` set, or in the global `expectedUnsupported` — protects nothing. A
+copied list drifts into exactly that as classifications diverge, and the drift is invisible:
+nothing fails, the list simply stops meaning what it says (cerbos/query-plan-adapters#324). Each
+harness therefore keeps two lists and asserts they are complements of its own oracle set:
+
+- **the guard proper** — a representative sample of the actions the adapter *does* oracle-compare,
+  one per hostile group it can express. Each entry is asserted to be in the adapter's oracle set,
+  so moving an action into `adapterUnsupported` fails the guard instead of quietly emptying it.
+- **liveness-only probes** — shapes the adapter refuses to translate, kept because the group has no
+  compared member for that adapter and the non-degenerate oracle still proves the PDP and policy
+  are live. Each entry is asserted *not* to be in the oracle set, so a shape the adapter later
+  gains support for has to be promoted into the guard proper rather than staying a weaker probe.
+
+Both lists still assert the non-empty, non-total oracle. The exclusion for an action whose oracle
+is empty *by construction* is unchanged: it belongs in neither list (see
+`nullRepresentationOmitted` above, and `w1-size-zero-chain`/`w1-not-size-chain`/`in-empty`/the
+string casts).
+
+Adapters differ widely in what they can express — `langchain-chromadb` compares 15 of the 133
+conformance actions where `ent` and `pgx` compare all of them — so the lists are expected to look
+different per harness. That is the point.
+
+### Known divergences still need a tripwire
+
+An action in `knownDivergences` is excluded from the oracle run, which leaves it exercised on
+neither side unless the harness says something about it explicitly. Every harness therefore pins
+the `p-has` planner over-grant directly: the plan folds to `KIND_ALWAYS_ALLOWED`, the check()
+oracle is non-empty and non-total (it denies the seeds whose attribute is missing), and the adapter
+consequently returns every row. When the upstream fold is fixed the assertion fails, which is the
+prompt to move the action back into the oracle run.
+
 ### Deterministic derived fields
 
 The corpus keeps raw relational rows compact; five resource attributes and stored columns are
@@ -257,8 +290,12 @@ guard; run it before trusting it.
    in `prisma/src/adversarial.test.ts`, and the oracle/throwing counts in the convex and
    langchain-chromadb harnesses). Bump them deliberately — that assertion exists so a new action
    cannot slip past an adapter unnoticed.
-7. Add the action to each harness's degeneracy-guard list so it cannot pass vacuously, and check
-   that no harness projects the corpus into a narrower local shape. `langchain-chromadb` used to
+7. Add the action to each harness's degeneracy-guard list so it cannot pass vacuously — to that
+   harness's *compared* list where the adapter translates the shape, and to its liveness-only list
+   where it does not, per "The degeneracy guard" above. Adding it to the compared list of an
+   adapter that throws on it fails immediately, which is the intended feedback rather than an
+   obstacle. Also check that no harness projects the corpus into a narrower local shape.
+   `langchain-chromadb` used to
    rebuild the principal from a hardcoded attribute allowlist; when `pv-exists` added
    `principal.attr.manyTeams`, the projection dropped it, the plan folded to `ALWAYS_DENIED`, and
    the oracle — built from the same projected principal — agreed. The action passed on both sides
@@ -312,7 +349,11 @@ unsupported before you have watched it fail is how a translatable shape gets per
    silently drops the next corpus field from both sides of its own differential.
 
 4. **Assert the degeneracy guard** (see above) and pin the corpus size, so a silently broken PDP
-   connection or a newly added action cannot pass vacuously.
+   connection or a newly added action cannot pass vacuously. Derive the guard's compared list from
+   the adapter's own oracle set and assert per-entry membership — a list lifted from the nearest
+   existing harness will name shapes this adapter does not translate, and those entries guard
+   nothing. Pin every `knownDivergences` action the same way (see above): excluded from the oracle
+   run means exercised nowhere unless the harness says so explicitly.
 
 5. **Run it and let it fail.** Triage every divergence into exactly one of:
    - a translation bug in the adapter — fix it;

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -334,6 +334,52 @@ const MANIFEST_ACTIONS = new Set([
   ...actionsFile.knownDivergences.map((entry) => entry.action),
 ]);
 
+// -- the degeneracy guard (conformance/README.md, "The degeneracy guard") -----------------------
+//
+// A representative sample of the actions this adapter ORACLE-COMPARES, one per hostile group it
+// can express. The two lists are asserted to be complements of `ORACLE_ACTIONS`, so neither can
+// drift into the other unnoticed.
+//
+// w1-size-zero-chain, w1-not-size-chain and the two string-cast actions are deliberately absent
+// from both lists: their oracles are empty by CONSTRUCTION (no seed holds a to-one parent with
+// zero children; every seed's aString raises in int()/double()), so they cannot satisfy a
+// non-empty assertion.
+
+const DEGENERACY_GUARD_ACTIONS = [
+  "vf-le",
+  "like-percent",
+  "all-on-empty",
+  "pv-exists",
+  "pv-all",
+  "null-eq",
+  "null-ne",
+  // The absent to-one parent (#309/#315/#316): the five discriminating chain shapes with a
+  // non-empty oracle.
+  "w1-all-chain",
+  "w1-not-exists-chain",
+  "w1-size-nonneg-chain",
+  "w1-not-in-chain",
+  "w1-not-hasint-chain",
+  // Column arithmetic under a division (#311); the zero-denominator arm is a liveness probe.
+  "cr-div-other-column",
+  "cr-div-then-add",
+  "cr-div-then-add-ne",
+  // Convex is the one adapter that promotes the casts in adapterSupportedExpected, so this is
+  // a real comparison here rather than the liveness probe it is everywhere else.
+  "cast-int-double",
+] as const;
+
+/**
+ * Shapes Convex refuses to translate: they have no oracle comparison to guard, and stay here as
+ * PDP/policy liveness probes for a group Convex's own list cannot cover. See
+ * cerbos/query-plan-adapters#324.
+ */
+const DEGENERACY_LIVENESS_PROBES = [
+  // JSON.stringify(-0) is "0", so the sign of a zero denominator is gone before the adapter
+  // sees it and the shape is refused rather than guessed.
+  "cr-div-neg-zero",
+] as const;
+
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
 //
 // Read from conformance/derived-fields.json rather than restated here. The same value feeds the
@@ -467,6 +513,16 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
     if (result.isAllowed(action)) ids.push(seed.id);
   }
   return ids.sort();
+}
+
+/** The degeneracy guard's per-action assertion, labelled so a failure names the action. */
+async function expectNonDegenerateOracle(action: string): Promise<void> {
+  const ids = await oracleAllowedIds(action);
+  expect({
+    action,
+    nonEmpty: ids.length > 0,
+    nonTotal: ids.length < seedsFile.seeds.length,
+  }).toEqual({ action, nonEmpty: true, nonTotal: true });
 }
 
 async function adapterFilteredIds(
@@ -669,20 +725,22 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    // The #309/#312/#311/#315/#316 additions. w1-size-zero-chain, w1-not-size-chain and the
-    // two string-cast actions are deliberately absent: their oracles are empty by
-    // CONSTRUCTION (no seed holds a to-one parent with zero children; every seed's aString
-    // raises in int()/double()), so they cannot satisfy this guard. cast-int-double is the
-    // cast group's non-degenerate stand-in, and the w1/cr actions below carry it for their
-    // groups.
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
-      "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
-      "w1-not-in-chain", "w1-not-hasint-chain",
-      "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
-      "cast-int-double"]) {
-      const ids = await oracleAllowedIds(action);
-      expect(ids.length).toBeGreaterThan(0);
-      expect(ids.length).toBeLessThan(seedsFile.seeds.length);
+    // Guard the guard: each of these actions must produce a non-empty, non-total oracle set,
+    // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
+    //
+    // Every entry is asserted to be an action Convex actually oracle-compares. A list copied
+    // from another harness drifts into naming shapes this adapter never compares, which guard
+    // nothing (cerbos/query-plan-adapters#324); the membership assertion turns moving an action
+    // into Convex's `adapterUnsupported` set into a failure here rather than a silent no-op.
+    for (const action of DEGENERACY_GUARD_ACTIONS) {
+      expect(ORACLE_ACTIONS).toContain(action);
+      await expectNonDegenerateOracle(action);
+    }
+    // Asserting the complement keeps the split honest — an action Convex gains support for
+    // must move up into the guard proper.
+    for (const action of DEGENERACY_LIVENESS_PROBES) {
+      expect(ORACLE_ACTIONS).not.toContain(action);
+      await expectNonDegenerateOracle(action);
     }
   });
 });

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -252,6 +252,39 @@ const MANIFEST_ACTIONS = new Set([
   ...(actionsFile.knownDivergences ?? []).map((entry) => entry.action),
 ]);
 
+// -- the degeneracy guard (conformance/README.md, "The degeneracy guard") -----------------------
+//
+// A representative sample of the actions this adapter ORACLE-COMPARES, one per hostile group.
+// Drizzle translates every shape in the sample, so it has no liveness-only probes: each entry is
+// asserted to be in `ORACLE_ACTIONS` (cerbos/query-plan-adapters#324), which turns moving one
+// into `adapterUnsupported` into a failure here rather than a silent no-op.
+//
+// w1-size-zero-chain and w1-not-size-chain are deliberately absent: their oracles are empty by
+// CONSTRUCTION (no seed holds a to-one parent with zero children), so they cannot satisfy a
+// non-empty assertion. Their siblings below carry it for that group.
+
+const DEGENERACY_GUARD_ACTIONS = [
+  "vf-le",
+  "like-percent",
+  "all-on-empty",
+  "pv-exists",
+  "pv-all",
+  "null-eq",
+  "null-ne",
+  // The absent to-one parent (#309/#315/#316): the five discriminating chain shapes with a
+  // non-empty oracle.
+  "w1-all-chain",
+  "w1-not-exists-chain",
+  "w1-size-nonneg-chain",
+  "w1-not-in-chain",
+  "w1-not-hasint-chain",
+  // Column arithmetic under a division (#311).
+  "cr-div-neg-zero",
+  "cr-div-other-column",
+  "cr-div-then-add",
+  "cr-div-then-add-ne",
+] as const;
+
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
 //
 // Read from conformance/derived-fields.json rather than restated here. The same value feeds the
@@ -597,6 +630,16 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
   return ids.sort();
 }
 
+/** The degeneracy guard's per-action assertion, labelled so a failure names the action. */
+async function expectNonDegenerateOracle(action: string): Promise<void> {
+  const ids = await oracleAllowedIds(action);
+  expect({
+    action,
+    nonEmpty: ids.length > 0,
+    nonTotal: ids.length < SEEDS.length,
+  }).toEqual({ action, nonEmpty: true, nonTotal: true });
+}
+
 // -- adapter execution through the public queryPlanToDrizzle path --
 
 async function adapterFilteredIds(
@@ -837,19 +880,11 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    // Guard the guard: at least one action must produce a non-empty, non-total oracle set,
+    // Guard the guard: each of these actions must produce a non-empty, non-total oracle set,
     // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
-    // w1-size-zero-chain and w1-not-size-chain are deliberately absent: their oracles are
-    // empty by construction (no seed holds a to-one parent with zero children), so they
-    // cannot satisfy this guard. Their siblings below carry the anti-vacuity assertion for
-    // that group.
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
-      "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
-      "w1-not-in-chain", "w1-not-hasint-chain",
-      "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne"]) {
-      const ids = await oracleAllowedIds(action);
-      expect(ids.length).toBeGreaterThan(0);
-      expect(ids.length).toBeLessThan(SEEDS.length);
+    for (const action of DEGENERACY_GUARD_ACTIONS) {
+      expect(ORACLE_ACTIONS).toContain(action);
+      await expectNonDegenerateOracle(action);
     }
   });
 });

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -562,17 +562,60 @@ class ElasticsearchAdversarialConformanceTest {
                 principal(), Resource.newInstance(seedsFile.resourceKind()), "p-has");
         List<String> oracle = oracleAllowedIds("p-has");
         assertTrue(plan.isAlwaysAllowed(), "p-has should remain the documented planner divergence");
+        // Both halves: an empty oracle is a silently broken PDP or policy load, which the
+        // non-total assertion alone would pass.
+        assertFalse(oracle.isEmpty(), "p-has check() oracle must still allow the seeds holding the attr");
         assertTrue(oracle.size() < seeds.size(), "p-has check() oracle must still deny missing attrs");
+        assertTrue(oracle.contains("a1"), "p-has: a1 holds aOptionalString");
         assertEquals(allIds(), adapterFilteredIds("p-has"));
     }
 
+    /**
+     * A representative sample of the actions this adapter ORACLE-COMPARES, one per hostile group
+     * it can express. Asserted against {@code oracleActions} so moving one into
+     * {@code adapterUnsupported} fails here rather than silently going inert
+     * (cerbos/query-plan-adapters#324).
+     */
+    private static final List<String> DEGENERACY_GUARD_ACTIONS = List.of(
+            "vf-le", "like-percent", "pv-exists", "pv-all", "null-ne",
+            // The chained relation (#309): the shapes Elasticsearch's nested queries express.
+            "w1-exists-chain");
+
+    /**
+     * Shapes this adapter refuses to translate: they have no oracle comparison to guard, and stay
+     * here as PDP/policy liveness probes for a group the list above cannot cover.
+     */
+    private static final List<String> DEGENERACY_LIVENESS_PROBES = List.of(
+            // Elasticsearch does not index an empty nested array, so a positive all() cannot tell
+            // an empty collection (true) from a missing one (CEL error).
+            "all-on-empty",
+            // Nor an explicit null scalar, so positive equality against null cannot tell an
+            // explicit null (allow) from a missing field (deny). The negated forms stay compared.
+            "null-eq");
+
     @Test
     void oracleIsNotDegenerate() {
-        for (String action : List.of("vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne")) {
-            List<String> ids = oracleAllowedIds(action);
-            assertTrue(!ids.isEmpty() && ids.size() < seeds.size(),
-                    "oracle for '" + action + "' is degenerate: " + ids);
+        // Guard the guard: each of these actions must produce a non-empty, non-total oracle set,
+        // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
+        Set<String> compared = Set.copyOf(oracleActions);
+        for (String action : DEGENERACY_GUARD_ACTIONS) {
+            assertTrue(compared.contains(action),
+                    "'" + action + "' guards nothing: this adapter does not oracle-compare it");
+            assertNonDegenerateOracle(action);
         }
+        // Asserting the complement keeps the split honest — an action this adapter gains support
+        // for must move up into the guard proper.
+        for (String action : DEGENERACY_LIVENESS_PROBES) {
+            assertFalse(compared.contains(action),
+                    "'" + action + "' is now oracle-compared: move it into the guard proper");
+            assertNonDegenerateOracle(action);
+        }
+    }
+
+    private static void assertNonDegenerateOracle(String action) {
+        List<String> ids = oracleAllowedIds(action);
+        assertTrue(!ids.isEmpty() && ids.size() < seeds.size(),
+                "oracle for '" + action + "' is degenerate: " + ids);
     }
 
     /**

--- a/ent/adversarial_test.go
+++ b/ent/adversarial_test.go
@@ -13,6 +13,8 @@ import (
 
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+
 	"github.com/cerbos/cerbos-sdk-go/cerbos"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -599,6 +601,16 @@ func (h *harness) oracleAllowedIDs(t *testing.T, action string) []string {
 	return allowed
 }
 
+// allSeedIDs is every seeded id, sorted — what an unfiltered query returns.
+func (h *harness) allSeedIDs() []string {
+	ids := make([]string, 0, len(h.corpus.Seeds.Seeds))
+	for _, seed := range h.corpus.Seeds.Seeds {
+		ids = append(ids, seed.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 // adapterFilteredIDs plans, translates and executes, returning the ids the predicate selects.
 func (h *harness) adapterFilteredIDs(t *testing.T, action string, opts ...cerbosent.Option) ([]string, error) {
 	t.Helper()
@@ -734,29 +746,84 @@ func runConformance(t *testing.T, h *harness) {
 		}
 	})
 
+	// The has() planner fold is a known divergence, so it is excluded from the oracle run above
+	// and nothing else in this suite touches it — the action would be exercised on neither side.
+	// Pin the over-grant itself: the plan folds to ALWAYS_ALLOWED while check() denies the seeds
+	// whose attribute is missing, so this adapter returns every row. When the planner stops
+	// folding, this fails and prompts re-inclusion in the oracle run
+	// (cerbos/query-plan-adapters#324).
+	t.Run("pins the upstream has() planner over-grant", func(t *testing.T) {
+		const action = "p-has"
+		require.True(t, h.corpus.SkippedActions[action],
+			"%s must stay registered as a known divergence for this adapter", action)
+
+		plan, err := h.client.PlanResources(t.Context(), h.principal(),
+			cerbos.NewResource(h.corpus.Seeds.ResourceKind, ""), action)
+		require.NoError(t, err, "planning %s", action)
+		require.Equal(t, enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED,
+			plan.PlanResourcesResponse.GetFilter().GetKind(),
+			"%s must remain the documented planner over-grant", action)
+
+		oracle := h.oracleAllowedIDs(t, action)
+		require.NotEmpty(t, oracle, "%s: check() must still allow the seeds that hold the attribute", action)
+		require.Less(t, len(oracle), len(h.corpus.Seeds.Seeds),
+			"%s: check() must still deny the seeds whose attribute is missing", action)
+		require.Contains(t, oracle, "a1", "%s: a1 holds aOptionalString", action)
+
+		filtered, err := h.adapterFilteredIDs(t, action)
+		require.NoError(t, err, "translating %s", action)
+		require.Equal(t, h.allSeedIDs(), filtered,
+			"%s: the folded plan makes this adapter return every row", action)
+	})
+
 	t.Run("degeneracy guard", func(t *testing.T) {
 		// The comparison above can pass vacuously if the oracle itself is trivial. Assert that a
 		// representative spread of actions has an oracle that is neither empty nor the full seed
 		// set — without this, a silently broken PDP connection would still pass every case.
+		//
+		// Every entry is asserted to be an action this adapter actually oracle-compares: a list
+		// copied between harnesses drifts into naming shapes the adapter never compares, which
+		// guard nothing (cerbos/query-plan-adapters#324). The membership assertion turns moving an
+		// action into adapterUnsupported into a failure here rather than a silent no-op.
+		//
 		// w1-size-zero-chain, w1-not-size-chain, cast-int-string and cast-double-string are
 		// deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
 		// parent with zero children; every seed's aString raises in int()/double()), so they
-		// cannot satisfy this guard. cast-int-double stands in for the cast group.
-		representative := []string{
+		// cannot satisfy this guard.
+		compared := []string{
 			"vf-le", "in-single", "like-percent", "exists-on-empty", "not-exists",
 			"nary-and", "field-to-field", "ternary-cmp", "arith-add", "size-threshold",
 			"hier-ancestor-cf", "pv-exists", "in-null-elem-mixed", "null-eq", "cs-eq",
 			"w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
 			"w1-not-in-chain", "w1-not-hasint-chain",
 			"cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
-			"cast-int-double",
 		}
+		// int() over a numeric column is unsupported for every adapter but convex, so there is no
+		// comparison behind it here: it stays as a PDP/policy liveness probe for the cast group.
+		// Asserting the complement keeps the split honest — a shape this adapter gains support for
+		// must move up into the compared list.
+		livenessOnly := []string{"cast-int-double"}
+
+		oracleCompared := h.corpus.OracleComparedActions()
 		total := len(h.corpus.Seeds.Seeds)
-		for _, action := range representative {
+		assertNonDegenerate := func(t *testing.T, action string) {
+			t.Helper()
+			allowed := h.oracleAllowedIDs(t, action)
+			require.NotEmpty(t, allowed, "%s: oracle allows nothing", action)
+			require.Less(t, len(allowed), total, "%s: oracle allows every seed", action)
+		}
+		for _, action := range compared {
 			t.Run(action, func(t *testing.T) {
-				allowed := h.oracleAllowedIDs(t, action)
-				require.NotEmpty(t, allowed, "%s: oracle allows nothing", action)
-				require.Less(t, len(allowed), total, "%s: oracle allows every seed", action)
+				require.True(t, oracleCompared[action],
+					"%s guards nothing: this adapter does not oracle-compare it", action)
+				assertNonDegenerate(t, action)
+			})
+		}
+		for _, action := range livenessOnly {
+			t.Run(action, func(t *testing.T) {
+				require.False(t, oracleCompared[action],
+					"%s is now oracle-compared: move it into the compared list", action)
+				assertNonDegenerate(t, action)
 			})
 		}
 	})

--- a/ent/corpus_test.go
+++ b/ent/corpus_test.go
@@ -238,6 +238,22 @@ func (c *Corpus) AllClassifiedActions() []string {
 	return seen
 }
 
+// OracleComparedActions is the set of actions this adapter actually compares against the check()
+// oracle. It applies the same skip the oracle run applies, so the two cannot drift: today no
+// knownDivergences action is also a conformance action, and the subtraction is a no-op — but a
+// divergence registered on one later must drop out of both at once, not just the run. The
+// degeneracy guard asserts membership against this, so a guard entry that guards nothing fails
+// loudly instead of going inert (cerbos/query-plan-adapters#324).
+func (c *Corpus) OracleComparedActions() map[string]bool {
+	compared := make(map[string]bool, len(c.OracleActions))
+	for _, action := range c.OracleActions {
+		if !c.SkippedActions[action] {
+			compared[action] = true
+		}
+	}
+	return compared
+}
+
 // findConformanceDir walks up from the working directory so the harness works whether it is run
 // from the module root or from a nested package.
 func findConformanceDir(tb testing.TB) string {

--- a/langchain-chromadb/src/adversarial.test.ts
+++ b/langchain-chromadb/src/adversarial.test.ts
@@ -468,6 +468,45 @@ const MANIFEST_ACTIONS = new Set([
   ...CHROMA_DIVERGENCES,
 ]);
 
+// -- the degeneracy guard (conformance/README.md, "The degeneracy guard") -----------------------
+//
+// Chroma's flat scalar metadata leaves it the narrowest oracle set of any adapter, so the guard
+// is derived from that set rather than shared with the relational harnesses: every entry below is
+// asserted to be in `CHROMA_SUPPORTED_ACTIONS` (cerbos/query-plan-adapters#324). This is every
+// action Chroma oracle-compares except `in-empty`, whose oracle is empty by CONSTRUCTION
+// (`x in []` is false for every seed) and so cannot satisfy a non-empty assertion.
+
+const DEGENERACY_GUARD_ACTIONS = [
+  "vf-le",
+  "vf-ge",
+  "vf-ne",
+  "nary-and",
+  "double-negation",
+  "triple-negation",
+  "cs-eq",
+  "empty-string-eq",
+  "unicode-eq",
+  "in-single",
+  "neg-number",
+  "p-struct",
+  "p-in-null-single",
+  "p-in-null-multi",
+] as const;
+
+/**
+ * Shapes Chroma refuses to translate: they have no oracle comparison to guard, and stay here as
+ * PDP/policy liveness probes for the groups Chroma's own list cannot cover — the collection
+ * macros, the null-selecting directions, the chained relation (#309/#315/#316), the column
+ * arithmetic (#311) and the numeric cast. See cerbos/query-plan-adapters#324.
+ */
+const DEGENERACY_LIVENESS_PROBES = [
+  "pv-exists",
+  "null-eq",
+  "w1-all-chain",
+  "cr-div-neg-zero",
+  "cast-int-double",
+] as const;
+
 // Fields are optional unless declared otherwise, so `$ne`/`$nin` are rejected by default.
 // `required: true` is asserted only for the metadata keys that `metadataFor` writes for every
 // seed in conformance/seeds.json. `aOptionalString` is null for a2/a4/a8/c2/e1, so it stays
@@ -651,6 +690,16 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
   return ids.sort();
 }
 
+/** The degeneracy guard's per-action assertion, labelled so a failure names the action. */
+async function expectNonDegenerateOracle(action: string): Promise<void> {
+  const ids = await oracleAllowedIds(action);
+  expect({
+    action,
+    nonEmpty: ids.length > 0,
+    nonTotal: ids.length < SEEDS.length,
+  }).toEqual({ action, nonEmpty: true, nonTotal: true });
+}
+
 async function adapterFilteredIds(action: string): Promise<string[]> {
   const translated = queryPlanToChromaDB({
     queryPlan: await planFor(action),
@@ -756,17 +805,20 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    // #309/#312/#311/#315/#316. w1-size-zero-chain, w1-not-size-chain and the two string-cast
-    // actions are deliberately absent: their oracles are empty by CONSTRUCTION, so they
-    // cannot satisfy this guard; cast-int-double is the cast group's non-degenerate stand-in.
-    for (const action of ["vf-le", "nary-and", "p-in-null-multi", "pv-exists", "pv-all", "null-eq", "null-ne",
-      "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
-      "w1-not-in-chain", "w1-not-hasint-chain",
-      "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
-      "cast-int-double"]) {
-      const ids = await oracleAllowedIds(action);
-      expect(ids.length).toBeGreaterThan(0);
-      expect(ids.length).toBeLessThan(SEEDS.length);
+    // Guard the guard: each of these actions must produce a non-empty, non-total oracle set,
+    // otherwise the differential comparison could pass vacuously (e.g. PDP denying all). The
+    // membership assertion is what keeps the list honest — Chroma compares 15 of the corpus's
+    // 133 conformance actions, so a guard list shared with a relational harness would name
+    // shapes it never compares (cerbos/query-plan-adapters#324).
+    for (const action of DEGENERACY_GUARD_ACTIONS) {
+      expect(CHROMA_SUPPORTED_ACTIONS).toContain(action);
+      await expectNonDegenerateOracle(action);
+    }
+    // Asserting the complement keeps the split honest — an action Chroma gains support for must
+    // move up into the guard proper.
+    for (const action of DEGENERACY_LIVENESS_PROBES) {
+      expect(CHROMA_SUPPORTED_ACTIONS).not.toContain(action);
+      await expectNonDegenerateOracle(action);
     }
   });
 });

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -497,6 +497,51 @@ const MANIFEST_ACTIONS = new Set([
   ...actionsFile.knownDivergences.map((entry) => entry.action),
 ]);
 
+// -- the degeneracy guard (conformance/README.md, "The degeneracy guard") -----------------------
+//
+// A representative sample of the actions this adapter ORACLE-COMPARES, one per hostile group it
+// can express. The two lists are asserted to be complements of `ORACLE_ACTIONS`, so neither can
+// drift into the other unnoticed.
+//
+// w1-size-zero-chain, w1-not-size-chain and the two string-cast actions are deliberately absent
+// from both lists: their oracles are empty by CONSTRUCTION (no seed holds a to-one parent with
+// zero children; every seed's aString raises in int()/double()), so they cannot satisfy a
+// non-empty assertion.
+
+const DEGENERACY_GUARD_ACTIONS = [
+  "vf-le",
+  "like-percent",
+  "all-on-empty",
+  "pv-exists",
+  "pv-all",
+  "null-eq",
+  "null-ne",
+  // The absent to-one parent (#309/#315/#316): the four discriminating chain shapes Mongoose
+  // translates. Its negated-exists sibling is a liveness probe below.
+  "w1-all-chain",
+  "w1-size-nonneg-chain",
+  "w1-not-in-chain",
+  "w1-not-hasint-chain",
+  // Mongoose throws on the whole cr-div group (#311), so the computed-relation group is guarded
+  // by the fractional-size shape it does translate.
+  "cr-size-frac-ge",
+] as const;
+
+/**
+ * Shapes Mongoose refuses to translate: they have no oracle comparison to guard, and stay here as
+ * PDP/policy liveness probes for a group Mongoose's own list cannot cover. See
+ * cerbos/query-plan-adapters#324.
+ */
+const DEGENERACY_LIVENESS_PROBES = [
+  // A negated macro over a chain has no UNKNOWN to represent in a Mongo filter.
+  "w1-not-exists-chain",
+  // $divide aborts the query on a zero denominator, so the cr-div group throws.
+  "cr-div-neg-zero",
+  // int() over a numeric column: truncation-versus-rounding, unsupported for every adapter but
+  // convex, which promotes it in adapterSupportedExpected.
+  "cast-int-double",
+] as const;
+
 interface AdversarialLabel {
   name: string | null;
 }
@@ -818,6 +863,16 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
     .sort();
 }
 
+/** The degeneracy guard's per-action assertion, labelled so a failure names the action. */
+async function expectNonDegenerateOracle(action: string): Promise<void> {
+  const ids = await oracleAllowedIds(action);
+  expect({
+    action,
+    nonEmpty: ids.length > 0,
+    nonTotal: ids.length < SEEDS.length,
+  }).toEqual({ action, nonEmpty: true, nonTotal: true });
+}
+
 async function adapterFilteredIds(
   action: string,
   nullAttributeRepresentation: "explicit" | "omitted" = "explicit"
@@ -1063,20 +1118,22 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    // The #309/#312/#311/#315/#316 additions. w1-size-zero-chain, w1-not-size-chain and the
-    // two string-cast actions are deliberately absent: their oracles are empty by
-    // CONSTRUCTION (no seed holds a to-one parent with zero children; every seed's aString
-    // raises in int()/double()), so they cannot satisfy this guard. cast-int-double is the
-    // cast group's non-degenerate stand-in, and the w1/cr actions below carry it for their
-    // groups.
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
-      "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
-      "w1-not-in-chain", "w1-not-hasint-chain",
-      "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
-      "cast-int-double"]) {
-      const ids = await oracleAllowedIds(action);
-      expect(ids.length).toBeGreaterThan(0);
-      expect(ids.length).toBeLessThan(SEEDS.length);
+    // Guard the guard: each of these actions must produce a non-empty, non-total oracle set,
+    // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
+    //
+    // Every entry is asserted to be an action Mongoose actually oracle-compares. A list copied
+    // from another harness drifts into naming shapes this adapter never compares, which guard
+    // nothing (cerbos/query-plan-adapters#324); the membership assertion turns moving an action
+    // into Mongoose's `adapterUnsupported` set into a failure here rather than a silent no-op.
+    for (const action of DEGENERACY_GUARD_ACTIONS) {
+      expect(ORACLE_ACTIONS).toContain(action);
+      await expectNonDegenerateOracle(action);
+    }
+    // Asserting the complement keeps the split honest — an action Mongoose gains support for
+    // must move up into the guard proper.
+    for (const action of DEGENERACY_LIVENESS_PROBES) {
+      expect(ORACLE_ACTIONS).not.toContain(action);
+      await expectNonDegenerateOracle(action);
     }
   });
 });

--- a/pgx/adversarial_test.go
+++ b/pgx/adversarial_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+
 	"github.com/cerbos/cerbos-sdk-go/cerbos"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -390,6 +392,16 @@ func (h *harness) oracleAllowedIDs(t *testing.T, action string) []string {
 	return allowed
 }
 
+// allSeedIDs is every seeded id, sorted — what an unfiltered query returns.
+func (h *harness) allSeedIDs() []string {
+	ids := make([]string, 0, len(h.corpus.Seeds.Seeds))
+	for _, seed := range h.corpus.Seeds.Seeds {
+		ids = append(ids, seed.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 // adapterFilteredIDs plans, translates and executes, returning the ids the filter selects.
 func (h *harness) adapterFilteredIDs(t *testing.T, action string, opts ...cerbospgx.Option) ([]string, error) {
 	t.Helper()
@@ -509,29 +521,84 @@ func TestAdversarialConformance(t *testing.T) {
 		}
 	})
 
+	// The has() planner fold is a known divergence, so it is excluded from the oracle run above
+	// and nothing else in this suite touches it — the action would be exercised on neither side.
+	// Pin the over-grant itself: the plan folds to ALWAYS_ALLOWED while check() denies the seeds
+	// whose attribute is missing, so this adapter returns every row. When the planner stops
+	// folding, this fails and prompts re-inclusion in the oracle run
+	// (cerbos/query-plan-adapters#324).
+	t.Run("pins the upstream has() planner over-grant", func(t *testing.T) {
+		const action = "p-has"
+		require.True(t, h.corpus.SkippedActions[action],
+			"%s must stay registered as a known divergence for this adapter", action)
+
+		plan, err := h.client.PlanResources(t.Context(), h.principal(),
+			cerbos.NewResource(h.corpus.Seeds.ResourceKind, ""), action)
+		require.NoError(t, err, "planning %s", action)
+		require.Equal(t, enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED,
+			plan.PlanResourcesResponse.GetFilter().GetKind(),
+			"%s must remain the documented planner over-grant", action)
+
+		oracle := h.oracleAllowedIDs(t, action)
+		require.NotEmpty(t, oracle, "%s: check() must still allow the seeds that hold the attribute", action)
+		require.Less(t, len(oracle), len(h.corpus.Seeds.Seeds),
+			"%s: check() must still deny the seeds whose attribute is missing", action)
+		require.Contains(t, oracle, "a1", "%s: a1 holds aOptionalString", action)
+
+		filtered, err := h.adapterFilteredIDs(t, action)
+		require.NoError(t, err, "translating %s", action)
+		require.Equal(t, h.allSeedIDs(), filtered,
+			"%s: the folded plan makes this adapter return every row", action)
+	})
+
 	t.Run("degeneracy guard", func(t *testing.T) {
 		// The comparison above can pass vacuously if the oracle itself is trivial. Assert that a
 		// representative spread of actions has an oracle that is neither empty nor the full seed
 		// set — without this, a silently broken PDP connection would still pass every case.
+		//
+		// Every entry is asserted to be an action this adapter actually oracle-compares: a list
+		// copied between harnesses drifts into naming shapes the adapter never compares, which
+		// guard nothing (cerbos/query-plan-adapters#324). The membership assertion turns moving an
+		// action into adapterUnsupported into a failure here rather than a silent no-op.
+		//
 		// w1-size-zero-chain, w1-not-size-chain, cast-int-string and cast-double-string are
 		// deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
 		// parent with zero children; every seed's aString raises in int()/double()), so they
-		// cannot satisfy this guard. cast-int-double stands in for the cast group.
-		representative := []string{
+		// cannot satisfy this guard.
+		compared := []string{
 			"vf-le", "in-single", "like-percent", "exists-on-empty", "not-exists",
 			"nary-and", "field-to-field", "ternary-cmp", "arith-add", "size-threshold",
 			"hier-ancestor-cf", "pv-exists", "in-null-elem-mixed", "null-eq", "cs-eq",
 			"w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
 			"w1-not-in-chain", "w1-not-hasint-chain",
 			"cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
-			"cast-int-double",
 		}
+		// int() over a numeric column is unsupported for every adapter but convex, so there is no
+		// comparison behind it here: it stays as a PDP/policy liveness probe for the cast group.
+		// Asserting the complement keeps the split honest — a shape this adapter gains support for
+		// must move up into the compared list.
+		livenessOnly := []string{"cast-int-double"}
+
+		oracleCompared := h.corpus.OracleComparedActions()
 		total := len(h.corpus.Seeds.Seeds)
-		for _, action := range representative {
+		assertNonDegenerate := func(t *testing.T, action string) {
+			t.Helper()
+			allowed := h.oracleAllowedIDs(t, action)
+			require.NotEmpty(t, allowed, "%s: oracle allows nothing", action)
+			require.Less(t, len(allowed), total, "%s: oracle allows every seed", action)
+		}
+		for _, action := range compared {
 			t.Run(action, func(t *testing.T) {
-				allowed := h.oracleAllowedIDs(t, action)
-				require.NotEmpty(t, allowed, "%s: oracle allows nothing", action)
-				require.Less(t, len(allowed), total, "%s: oracle allows every seed", action)
+				require.True(t, oracleCompared[action],
+					"%s guards nothing: this adapter does not oracle-compare it", action)
+				assertNonDegenerate(t, action)
+			})
+		}
+		for _, action := range livenessOnly {
+			t.Run(action, func(t *testing.T) {
+				require.False(t, oracleCompared[action],
+					"%s is now oracle-compared: move it into the compared list", action)
+				assertNonDegenerate(t, action)
 			})
 		}
 	})

--- a/pgx/corpus_test.go
+++ b/pgx/corpus_test.go
@@ -243,6 +243,22 @@ func (c *Corpus) AllClassifiedActions() []string {
 	return seen
 }
 
+// OracleComparedActions is the set of actions this adapter actually compares against the check()
+// oracle. It applies the same skip the oracle run applies, so the two cannot drift: today no
+// knownDivergences action is also a conformance action, and the subtraction is a no-op — but a
+// divergence registered on one later must drop out of both at once, not just the run. The
+// degeneracy guard asserts membership against this, so a guard entry that guards nothing fails
+// loudly instead of going inert (cerbos/query-plan-adapters#324).
+func (c *Corpus) OracleComparedActions() map[string]bool {
+	compared := make(map[string]bool, len(c.OracleActions))
+	for _, action := range c.OracleActions {
+		if !c.SkippedActions[action] {
+			compared[action] = true
+		}
+	}
+	return compared
+}
+
 // findConformanceDir walks up from the working directory so the harness works whether it is run
 // from the module root or from a nested package.
 func findConformanceDir(tb testing.TB) string {

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -261,6 +261,53 @@ const MANIFEST_ACTIONS = new Set([
   ...(actionsFile.knownDivergences ?? []).map((entry) => entry.action),
 ]);
 
+// -- the degeneracy guard (conformance/README.md, "The degeneracy guard") -----------------------
+//
+// A representative sample of the actions this adapter ORACLE-COMPARES, one per hostile group it
+// can express. The two lists are asserted to be complements of `ORACLE_ACTIONS`, so neither can
+// drift into the other unnoticed.
+//
+// w1-size-zero-chain, w1-not-size-chain and the two string-cast actions are deliberately absent
+// from both lists: their oracles are empty by CONSTRUCTION (no seed holds a to-one parent with
+// zero children; every seed's aString raises in int()/double()), so they cannot satisfy a
+// non-empty assertion.
+
+const DEGENERACY_GUARD_ACTIONS = [
+  "vf-le",
+  // Prisma cannot express the % needle (see the liveness probe below), so the LIKE
+  // metacharacter group is guarded by the escape spelling it does translate.
+  "like-backslash",
+  "all-on-empty",
+  "pv-exists",
+  "pv-all",
+  "null-eq",
+  "null-ne",
+  // The absent to-one parent (#309/#315/#316): the three discriminating chain shapes Prisma
+  // translates. Its two unsupported siblings are liveness probes below.
+  "w1-not-exists-chain",
+  "w1-not-in-chain",
+  "w1-not-hasint-chain",
+] as const;
+
+/**
+ * Shapes Prisma refuses to translate: they have no oracle comparison to guard, and stay here as
+ * PDP/policy liveness probes for a group Prisma's own list cannot cover. See
+ * cerbos/query-plan-adapters#324.
+ */
+const DEGENERACY_LIVENESS_PROBES = [
+  // Prisma emits LIKE with no ESCAPE clause, so a % needle throws.
+  "like-percent",
+  // every() cannot require the intermediate hop of a chain, and a >= 0 relation count has no
+  // none/some spelling — the two chain shapes Prisma throws on.
+  "w1-all-chain",
+  "w1-size-nonneg-chain",
+  // Prisma filters have no column arithmetic, so the whole cr-div group (#311) throws.
+  "cr-div-neg-zero",
+  // int() over a numeric column: truncation-versus-rounding, unsupported for every adapter but
+  // convex, which promotes it in adapterSupportedExpected.
+  "cast-int-double",
+] as const;
+
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
 //
 // Read from conformance/derived-fields.json rather than restated here. The same value feeds the
@@ -525,6 +572,16 @@ async function oracleAllowedIds(action: string): Promise<string[]> {
     }
   }
   return ids.sort();
+}
+
+/** The degeneracy guard's per-action assertion, labelled so a failure names the action. */
+async function expectNonDegenerateOracle(action: string): Promise<void> {
+  const ids = await oracleAllowedIds(action);
+  expect({
+    action,
+    nonEmpty: ids.length > 0,
+    nonTotal: ids.length < SEEDS.length,
+  }).toEqual({ action, nonEmpty: true, nonTotal: true });
 }
 
 // -- adapter execution through the public queryPlanToPrisma path --
@@ -796,22 +853,23 @@ describe("adversarial conformance corpus", () => {
   });
 
   test("oracle is not degenerate", async () => {
-    // Guard the guard: at least one action must produce a non-empty, non-total oracle set,
+    // Guard the guard: each of these actions must produce a non-empty, non-total oracle set,
     // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
-    // The #309/#312/#311/#315/#316 additions. w1-size-zero-chain, w1-not-size-chain and the
-    // two string-cast actions are deliberately absent: their oracles are empty by
-    // CONSTRUCTION (no seed holds a to-one parent with zero children; every seed's aString
-    // raises in int()/double()), so they cannot satisfy this guard. cast-int-double is the
-    // cast group's non-degenerate stand-in, and the w1/cr actions below carry it for their
-    // groups.
-    for (const action of ["vf-le", "like-percent", "all-on-empty", "pv-exists", "pv-all", "null-eq", "null-ne",
-      "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
-      "w1-not-in-chain", "w1-not-hasint-chain",
-      "cr-div-neg-zero", "cr-div-other-column", "cr-div-then-add", "cr-div-then-add-ne",
-      "cast-int-double"]) {
-      const ids = await oracleAllowedIds(action);
-      expect(ids.length).toBeGreaterThan(0);
-      expect(ids.length).toBeLessThan(SEEDS.length);
+    //
+    // Every entry is asserted to be an action Prisma actually oracle-compares. A list copied
+    // from another harness drifts into naming shapes this adapter never compares, which guard
+    // nothing (cerbos/query-plan-adapters#324); the membership assertion turns moving an action
+    // into Prisma's `adapterUnsupported` set into a failure here rather than a silent no-op.
+    for (const action of DEGENERACY_GUARD_ACTIONS) {
+      expect(ORACLE_ACTIONS).toContain(action);
+      await expectNonDegenerateOracle(action);
+    }
+    // Shapes Prisma refuses to translate, so there is no comparison behind them: these carry
+    // PDP/policy liveness for their group only. Asserting the complement keeps the split
+    // honest — an action Prisma gains support for must move up into the guard proper.
+    for (const action of DEGENERACY_LIVENESS_PROBES) {
+      expect(ORACLE_ACTIONS).not.toContain(action);
+      await expectNonDegenerateOracle(action);
     }
   });
 });

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -1098,31 +1098,56 @@ class AdversarialConformanceTest {
                 "every promoted action must exist in expectedUnsupported");
     }
 
+    /**
+     * A representative sample of the actions this adapter ORACLE-COMPARES, one per hostile group
+     * it can express. Asserted against {@link #conformanceActions()} so moving one into
+     * {@code adapterUnsupported} fails here rather than silently going inert
+     * (cerbos/query-plan-adapters#324).
+     *
+     * <p>{@code w1-size-zero-chain}, {@code w1-not-size-chain} and the two string-cast actions
+     * are deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a to-one
+     * parent with zero children; every seed's aString raises in {@code int()}/{@code double()}),
+     * so they cannot satisfy this guard.
+     */
+    private static final List<String> DEGENERACY_GUARD_ACTIONS = List.of(
+            "vf-le", "like-percent", "all-on-empty", "null-eq", "null-ne",
+            // The absent to-one parent (#309/#315/#316).
+            "w1-all-chain", "w1-not-exists-chain", "w1-size-nonneg-chain",
+            "w1-not-in-chain", "w1-not-hasint-chain",
+            // Column arithmetic under a division (#311). The two shapes that nest further
+            // arithmetic on top of the division are liveness probes below.
+            "cr-div-neg-zero", "cr-div-other-column");
+
+    /**
+     * Shapes this adapter refuses to translate: they have no oracle comparison to guard, and stay
+     * here as PDP/policy liveness probes for a group the list above cannot cover.
+     */
+    private static final List<String> DEGENERACY_LIVENESS_PROBES = List.of(
+            // A division nested inside further arithmetic fails closed: SQL has no value that
+            // carries CEL's NaN or signed infinity through the sum.
+            "cr-div-then-add", "cr-div-then-add-ne",
+            // int() over a numeric column: truncation-versus-rounding, unsupported for every
+            // adapter but convex, which promotes it in adapterSupportedExpected.
+            "cast-int-double");
+
     @Test
     void oracleIsNotDegenerate() {
-        // Guard the guard: at least one action must produce a non-empty, non-total oracle set,
+        // Guard the guard: each of these actions must produce a non-empty, non-total oracle set,
         // otherwise the differential comparison could pass vacuously (e.g. PDP denying all).
+        Set<String> compared = conformanceActions().collect(Collectors.toSet());
         Map<String, List<String>> samples = new LinkedHashMap<>();
-        samples.put("vf-le", oracleAllowedIds("vf-le"));
-        samples.put("like-percent", oracleAllowedIds("like-percent"));
-        samples.put("all-on-empty", oracleAllowedIds("all-on-empty"));
-        samples.put("null-eq", oracleAllowedIds("null-eq"));
-        samples.put("null-ne", oracleAllowedIds("null-ne"));
-        // #309/#312/#311/#315/#316. w1-size-zero-chain, w1-not-size-chain and the two
-        // string-cast actions are deliberately absent: their oracles are empty by CONSTRUCTION
-        // (no seed holds a to-one parent with zero children; every seed's aString raises in
-        // int()/double()), so they cannot satisfy this guard. cast-int-double is the cast
-        // group's non-degenerate stand-in.
-        samples.put("w1-all-chain", oracleAllowedIds("w1-all-chain"));
-        samples.put("w1-not-exists-chain", oracleAllowedIds("w1-not-exists-chain"));
-        samples.put("w1-size-nonneg-chain", oracleAllowedIds("w1-size-nonneg-chain"));
-        samples.put("w1-not-in-chain", oracleAllowedIds("w1-not-in-chain"));
-        samples.put("w1-not-hasint-chain", oracleAllowedIds("w1-not-hasint-chain"));
-        samples.put("cr-div-neg-zero", oracleAllowedIds("cr-div-neg-zero"));
-        samples.put("cr-div-other-column", oracleAllowedIds("cr-div-other-column"));
-        samples.put("cr-div-then-add", oracleAllowedIds("cr-div-then-add"));
-        samples.put("cr-div-then-add-ne", oracleAllowedIds("cr-div-then-add-ne"));
-        samples.put("cast-int-double", oracleAllowedIds("cast-int-double"));
+        for (String action : DEGENERACY_GUARD_ACTIONS) {
+            assertTrue(compared.contains(action),
+                    "'" + action + "' guards nothing: this adapter does not oracle-compare it");
+            samples.put(action, oracleAllowedIds(action));
+        }
+        // Asserting the complement keeps the split honest — an action this adapter gains support
+        // for must move up into the guard proper.
+        for (String action : DEGENERACY_LIVENESS_PROBES) {
+            assertFalse(compared.contains(action),
+                    "'" + action + "' is now oracle-compared: move it into the guard proper");
+            samples.put(action, oracleAllowedIds(action));
+        }
         samples.forEach((action, ids) -> assertTrue(
                 !ids.isEmpty() && ids.size() < SEEDS.size(),
                 "oracle for '" + action + "' is degenerate: " + ids));

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -186,6 +186,49 @@ SQLALCHEMY_SKIPPED_DIVERGENCES = {
     if "sqlalchemy" in d["adapters"]
 }
 
+# -- the degeneracy guard (conformance/README.md, "The degeneracy guard") ----
+#
+# A representative sample of the actions this adapter ORACLE-COMPARES, one per
+# hostile group it can express. The two lists are asserted to be complements of
+# ORACLE_ACTIONS, so neither can drift into the other unnoticed.
+#
+# w1-size-zero-chain, w1-not-size-chain and the two string-cast actions are
+# deliberately absent: their oracles are empty by CONSTRUCTION (no seed holds a
+# to-one parent with zero children; every seed's aString raises in
+# int()/double()), so they cannot satisfy this guard.
+DEGENERACY_GUARD_ACTIONS = (
+    "vf-le",
+    "like-percent",
+    "all-on-empty",
+    "pv-exists",
+    "pv-all",
+    "null-eq",
+    "null-ne",
+    # The absent to-one parent (#309/#315/#316).
+    "w1-all-chain",
+    "w1-not-exists-chain",
+    "w1-size-nonneg-chain",
+    "w1-not-in-chain",
+    "w1-not-hasint-chain",
+    # Column arithmetic under a division (#311); the zero-denominator arm is a
+    # liveness probe below.
+    "cr-div-other-column",
+    "cr-div-then-add",
+    "cr-div-then-add-ne",
+)
+
+# Shapes this adapter refuses to translate: they have no oracle comparison to
+# guard, and stay here as PDP/policy liveness probes for a group the list above
+# cannot cover. See cerbos/query-plan-adapters#324.
+DEGENERACY_LIVENESS_PROBES = (
+    # json.loads renders the wire's -0 as the integer 0, so the sign of a zero
+    # denominator is gone before the adapter sees it.
+    "cr-div-neg-zero",
+    # int() over a numeric column: truncation-versus-rounding, unsupported for
+    # every adapter but convex, which promotes it in adapterSupportedExpected.
+    "cast-int-double",
+)
+
 
 # -- deterministic derived fields (conformance/README.md) --------------------
 #
@@ -1024,28 +1067,22 @@ class TestAdversarialConformance:
         # Guard the guard: these actions must produce a non-empty, non-total
         # oracle set, otherwise the differential comparison could pass
         # vacuously (e.g. a PDP that denies everything).
-        for action in (
-            "vf-le",
-            "like-percent",
-            "all-on-empty",
-            "pv-exists",
-            "pv-all",
-            "null-eq",
-            "null-ne",
-            # #309/#312/#311/#315/#316. w1-size-zero-chain, w1-not-size-chain and
-            # the two string casts are absent on purpose: their oracles are empty by
-            # CONSTRUCTION, so they cannot satisfy this guard; cast-int-double stands
-            # in for the cast group.
-            "w1-all-chain",
-            "w1-not-exists-chain",
-            "w1-size-nonneg-chain",
-            "w1-not-in-chain",
-            "w1-not-hasint-chain",
-            "cr-div-neg-zero",
-            "cr-div-other-column",
-            "cr-div-then-add",
-            "cr-div-then-add-ne",
-            "cast-int-double",
-        ):
+        #
+        # Every entry is asserted to be an action this adapter actually
+        # oracle-compares. A list copied from another harness drifts into naming
+        # shapes it never compares, which guard nothing
+        # (cerbos/query-plan-adapters#324); the membership assertion turns moving
+        # an action into adapterUnsupported into a failure here rather than a
+        # silent no-op.
+        def assert_non_degenerate(action: str) -> None:
             ids = _oracle_allowed_ids(adv_cerbos_client, action)
-            assert 0 < len(ids) < len(SEEDS)
+            assert 0 < len(ids) < len(SEEDS), f"{action} has a degenerate oracle"
+
+        for action in DEGENERACY_GUARD_ACTIONS:
+            assert action in ORACLE_ACTIONS, f"{action} is not oracle-compared"
+            assert_non_degenerate(action)
+        # Asserting the complement keeps the split honest — an action this
+        # adapter gains support for must move up into the guard proper.
+        for action in DEGENERACY_LIVENESS_PROBES:
+            assert action not in ORACLE_ACTIONS, f"{action} is now oracle-compared"
+            assert_non_degenerate(action)


### PR DESCRIPTION
Closes #324.

## The problem

The degeneracy guard exists so an action's oracle comparison **cannot pass vacuously**. Several harnesses copied a shared candidate list instead of deriving it, so many entries named shapes that adapter never oracle-compares — they sit in its own `adapterUnsupported` set, or in the global `expectedUnsupported`. Those entries guarded nothing.

Counts against the current manifest (the corpus has grown since the audit, so these differ from the issue's numbers):

| adapter | live before |
|---|---|
| prisma | 9 / 17 |
| mongoose | 11 / 17 |
| langchain-chromadb | 3 / 17 |
| elasticsearch-java | 5 / 7 |
| spring-data | 12 / 15 |
| sqlalchemy | 15 / 17 |
| convex | 16 / 17 |
| ent, pgx | 24 / 25 |
| drizzle | 16 / 16 |

Nothing failed. The lists simply stopped meaning what they said.

## The fix

Every harness now keeps two lists, asserted to be complements of its own oracle set:

- **the guard proper** — a representative sample of the actions that adapter *does* compare, one per hostile group it can express. Each entry is asserted to be in the oracle set, so moving an action into `adapterUnsupported` fails the guard instead of quietly emptying it.
- **liveness-only probes** — shapes the adapter refuses to translate, kept where a group has no compared member for it. Each is asserted **not** to be in the oracle set, so a shape it later supports has to be promoted rather than stay a weaker probe.

Where a group lost its only entry, it is guarded by a shape that adapter actually translates: prisma's LIKE group by `like-backslash`, mongoose's computed-relation group by `cr-size-frac-ge`, elasticsearch-java's chained relation by `w1-exists-chain`. `langchain-chromadb`'s compared list is rebuilt from its own 15-action oracle set (`in-empty` excluded — empty oracle by construction).

Guard entries were chosen against real oracle sizes, not guessed: a probe script replayed the shared oracle recipe against a local PDP for all 143 actions first.

## ent / pgx: the `has()` over-grant tripwire

`p-has` sits in `knownDivergences` for both, and their skipped-actions path can never intersect their oracle set, so the action was exercised on **neither** side — an upstream planner fix would have gone unnoticed there. Both now pin the over-grant in the shape the other eight harnesses use: plan kind `ALWAYS_ALLOWED`, a non-empty non-total oracle, and the full-row adapter result.

Review also caught that elasticsearch-java's existing tripwire asserted only the non-total half, so an empty oracle — a silently broken PDP or policy load — would have passed. It now asserts both halves.

## Unchanged

The empty-by-construction exclusion: `nullRepresentationOmitted`, `w1-size-zero-chain`, `w1-not-size-chain`, `in-empty` and the string casts stay out of both lists and keep their own anti-vacuity assertions. No corpus action was added or removed; no adapter's classification changed. `conformance/actions.json` is untouched.

## Verification

The tripwire was verified empirically: temporarily reclassifying `vf-le` as drizzle-unsupported failed the guard with `Expected value: "vf-le"`, then the corpus was restored.

All ten adversarial suites pass:

| adapter | tests |
|---|---|
| prisma | 148 |
| drizzle / mongoose / convex | 147 each |
| langchain-chromadb | 145 |
| sqlalchemy | 297 |
| spring-data | 148 |
| elasticsearch-java | 144 |
| ent | 524 (sqlite + postgres + mysql) |
| pgx | 244 |

`conformance/scripts/validate-corpus.sh` green (143 actions, 20 seeds). Typecheck clean on all five TypeScript adapters; `go vet` and `golangci-lint` clean on ent and pgx; black/isort clean.

## Reproducing locally

The Java suites need the repo root mounted (see CLAUDE.md). Note that prisma's `test:adversarial` force-resets `prisma/dev-adversarial.db`, which recent Prisma CLI versions block under an AI agent without `PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION`.