### PR TITLE
all ten adapters: declare a position on the six mapping hazards

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -361,20 +361,75 @@ violation of exactly that one sentence, and every one of them was a real over-gr
 
 | Hazard | What goes wrong | Where it shows up |
 |---|---|---|
-| A **filtered association** | the application's association applies a predicate the subquery does not, so the subquery matches rows the application never serialised | ActiveRecord `has_many …, -> { where(visible: true) }`; Prisma filtered relations; SQLAlchemy `relationship(primaryjoin=…)`; Hibernate `@Where`/`@Filter` |
+| A **filtered association** | the application's association applies a predicate the subquery does not, so the subquery matches rows the application never serialised | ActiveRecord `has_many …, -> { where(visible: true) }`; SQLAlchemy `relationship(primaryjoin=…)`; Hibernate `@Where`/`@Filter`; a Prisma client extension or middleware injecting `where` |
 | A **default scope on the target model** | the subquery reads the table directly and skips the scope every application read applies | ActiveRecord `default_scope`; Hibernate `@Where` on the entity; a soft-delete filter |
-| **Subtype discrimination** | the association also filters on a type/discriminator column; the bare table holds the other subtypes too | ActiveRecord STI; Mongoose discriminators; JPA `@DiscriminatorValue` |
+| **Subtype discrimination** | the association also filters on a type/discriminator column; the bare table holds the other subtypes too | ActiveRecord STI; JPA `@DiscriminatorValue`; a Mongoose discriminator, though only for the model the caller hands to `find()` |
 | A **to-one relation used as a collection** | nothing makes the database enforce one row, so the application sees one and the subquery examines all of them | ActiveRecord `has_one`; any unindexed FK-back-reference |
 | A **composite association key** | a multi-column key becomes one quoted identifier and the query fails, or worse joins on the wrong column | ActiveRecord 7.1+ composite keys; any two-column FK |
 | An **absent to-one parent** | see the section above — this one *is* expressible, and `w1-all-chain` and friends pin it | every relational adapter |
 
-Two things follow for an adapter author:
+Two things follow for an adapter author.
 
-1. **Decide about each hazard explicitly.** Either the mapping reproduces the store-side filtering
-   exactly, or the adapter rejects the mapping with an error naming the mechanism. A best-effort
-   subquery is the one outcome the invariant forbids.
-2. **Say so in the adapter's README**, next to the `Conformance contract` table. A consumer whose
-   ORM offers filtered associations needs to know before they wire one up, not after.
+**1. Decide about each hazard explicitly.** For a hazard that *can arise* in an adapter, there are
+exactly three sanctioned outcomes:
+
+- **Reproduced** — the mapping carries the store-side predicate, so the subquery reads the rows the
+  application reads. Class 1 adapters (below) take an optional relation predicate for this.
+- **Rejected** — the adapter refuses the mapping with an error naming the real mechanism, or the
+  mapper type makes the hazardous mapping unexpressible in the first place. A composite association
+  key is rejected this way by every adapter whose relation mapping takes a single source column: the
+  caller gets a compile error, not a wrong join.
+- **Declared caller-owned** — the adapter states that holding the invariant is the caller's job, and
+  the README names the ORM feature the caller has to go and check.
+
+A best-effort subquery is the one outcome the invariant forbids.
+
+A fourth answer is available, and it is not one of the three because it is not a decision: **not
+applicable** — the hazard cannot arise, so there is nothing to decide. It is only honest when the
+row can say *structurally* why, and the structural reason is load-bearing enough to be worth a test
+of its own. Class 3 adapters (below) write it for the five subquery hazards because they build no
+subquery, and mongoose's harness asserts exactly that — the day it grows a `$lookup`, five "not
+applicable" rows silently become over-grants. "Not applicable" with no mechanism behind it is a
+best-effort subquery wearing a label, and does not pass review.
+
+**Declared caller-owned is available only where the adapter cannot detect the hazard from the mapper
+it is given.** That restriction is what stops it being a loophole, because "reject" presupposes a
+detection that mostly does not exist: an adapter handed a table and two column references cannot see
+a client extension, a soft-delete convention or a discriminator. Where the adapter *can* see the
+hazard, caller-owned is not available and the position must be reproduced or rejected.
+
+The second guard is a positive obligation: **a caller-owned row must name the exact ORM feature the
+caller must check.** A row that only says "caller-owned" does not pass review, for the same reason
+"cannot express this shape faithfully" is not an acceptable `adapterUnsupported` reason.
+
+**2. Say so in the adapter's README**, next to the `Conformance contract` table, as a table with one
+row per hazard above — six rows, in the same order:
+
+```
+| Hazard | Position | Mechanism to check |
+```
+
+Six rows even when most of them are inapplicable, because a reader diffing the adapter's table
+against this one should find every hazard accounted for rather than having to work out which
+omissions were deliberate. The absent to-one parent's row records that it is *proved by the corpus*
+(`w1-all-chain` and its siblings) rather than merely documented — it is what a closed hazard looks
+like, and it is the row that makes the difference visible.
+
+The three classes the ten adapters fall into determine most of the answers:
+
+| Class | Adapters | What the store applies to the subquery |
+|---|---|---|
+| **1 — bare-table subquery** | drizzle, ent, pgx, prisma | nothing |
+| **2 — ORM-association subquery** | spring-data, sqlalchemy | Hibernate applies `@SQLRestriction`/`@Where` — on the entity and on the joined collection — and the single-table discriminator; SQLAlchemy applies `primaryjoin` and the single-table discriminator *only* when the caller's override goes through a mapped `relationship()` |
+| **3 — no subquery** | mongoose, convex, langchain-chromadb, elasticsearch-java | n/a — relations are paths inside the same document |
+
+Prisma names a relation, so it looks like class 2. It is class 1: Prisma has no `@Where` equivalent,
+so nothing store-side reaches the nested `some`/`every`/`none`.
+
+Class 1 adapters expose an **optional** relation predicate the caller attaches to the mapping;
+declaring nothing emits exactly the filter the adapter emitted before the field existed. Class 2
+adapters deliberately do **not** expose one — a caller who re-declared a filter the ORM already
+applies would have it applied twice, silently removing rows the PDP permits.
 
 The precedent for handling this without a policy action is `nullRepresentationOmitted`: a
 per-adapter contract asserted by each harness rather than a shape in `adversarial.yaml`. If a

--- a/convex/README.md
+++ b/convex/README.md
@@ -118,6 +118,21 @@ The adapter is differentially tested with 20 hostile seed documents against Cerb
 
 This support statement includes value-first comparisons, field-to-field expressions, null and missing-attribute behavior, nested lambdas, collection macros, string and arithmetic expressions, timestamps, hierarchy operations, and chained nested fields. Fields that may be absent must be marked `nullable: true` in the mapper so the adapter evaluates their predicates with CEL-compatible missing-value semantics instead of pushing them to a Convex filter.
 
+## Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the filter select the documents `check()` allows. The other half is the *mapping*: **the documents the filter reads must be the documents the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter **builds no subquery.** Convex has no joins, so the mapper resolves every Cerbos path — including chained ones such as `mainCategory.subCategories` — to a path inside the same document, and the returned `filter`/`postFilter` pair reads exactly the document the application serialised.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | Not applicable — no subquery | — |
+| Default scope on the target model | Not applicable — no second table is read | — |
+| Subtype discrimination | **Caller-owned** | The table you pass to `ctx.db.query()`. The adapter is handed a plan, never a table, so it cannot check that the table you filter is the one the resource attributes were read from. If one Convex table holds several document shapes distinguished by a field, that field is not in the returned filter and you have to add it yourself |
+| To-one relation used as a collection | Not applicable — a document path holds exactly what the application stored | — |
+| Composite association key | Not applicable — no join, so no key to compose | — |
+| Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain` and siblings) | None — the post-filter evaluates a missing path as a CEL error, which denies, so an absent `mainCategory` is excluded under both polarities rather than reading as an empty collection ([#309](https://github.com/cerbos/query-plan-adapters/issues/309)) |
+
 ## Requirements
 
 - Cerbos > v0.16 plus either the `@cerbos/http` or `@cerbos/grpc` client

--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -52,6 +52,46 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 The oracle coverage includes value-first and field-to-field comparisons, escaped string predicates, relation counts and nested collection macros, null/error propagation, arithmetic and ternaries, hierarchy operations, typed timestamps, and multi-hop relations. The fail-closed shapes throw rather than return a broader SQL filter. `matches()` is rejected because SQL regex dialects do not guarantee CEL/RE2 semantics.
 
+## Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the filter select the rows `check()` allows. The other half is the *mapping*: **the rows the subquery reads must be the rows the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter builds a **bare-table subquery.** A relation mapping is a table plus a source and a target column; Drizzle has no association metadata for the adapter to consult, so nothing the application applies to its own reads reaches the generated `EXISTS`. Where the application narrows those reads, declare the same predicate as [`subqueryFilter`](#declaring-the-applications-own-predicate) on the relation and the adapter reproduces it. Declaring nothing emits exactly the SQL this adapter emitted before the field existed — it cannot detect the omission, so silence is not a warning.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | **Caller-owned**, reproducible with `subqueryFilter` | The `where` you pass to Drizzle's relational query builder (`db.query.<table>.findMany({ with: { rel: { where } } })`), and any repository helper that appends one. Drizzle applies those to the query you call them on; the adapter is given `table`, `sourceColumn` and `targetColumn` and reads the table bare |
+| Default scope on the target model | **Caller-owned**, reproducible with `subqueryFilter` | A soft-delete column (`deletedAt IS NULL`), a tenant column, a `published` flag — anything every application read of that table filters on. Drizzle has no `default_scope` construct, so the convention lives in your own query code and only you can see it |
+| Subtype discrimination | **Caller-owned**, reproducible with `subqueryFilter` | A `type`/`kind` discriminator column where one table holds several row kinds. Declare `eq(table.type, "…")` |
+| To-one relation used as a collection | **Caller-owned** | A `type: "one"` relation whose target column has no unique index. `type` is declarative — the adapter emits the same correlated `EXISTS` for either value — so nothing makes the database enforce the single row the application saw. Add the unique constraint, or accept that the subquery examines every matching row |
+| Composite association key | **Rejected by the type system** | `sourceColumn`/`targetColumn` are each a single `AnyColumn`, so a two-column key cannot be expressed. This is a compile error, not a wrong join |
+| Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain` and siblings) | None — every operator reached through a relation chain requires its intermediate hops separately, so a missing parent is UNKNOWN under both polarities ([#309](https://github.com/cerbos/query-plan-adapters/issues/309), [#315](https://github.com/cerbos/query-plan-adapters/issues/315)) |
+
+### Declaring the application's own predicate
+
+```ts
+import { and, eq, isNull } from "drizzle-orm";
+
+const result = queryPlanToDrizzle({
+  queryPlan,
+  mapper: {
+    "request.resource.attr.tags": {
+      relation: {
+        type: "many",
+        table: tags,
+        sourceColumn: resources.id,
+        targetColumn: tags.resourceId,
+        field: tags.name,
+        // Exactly the predicate your own reads of `tags` apply.
+        subqueryFilter: and(isNull(tags.deletedAt), eq(tags.kind, "label")),
+      },
+    },
+  },
+});
+```
+
+`subqueryFilter` is ANDed into the correlated subquery alongside the join, so it narrows the rows the subquery *examines* rather than the rows it returns. That is what makes it right under negation as well: `all()` compiles to a `NOT EXISTS` over a false witness, and restricting the scan turns it into "every visible row satisfies the predicate" instead of "every row in the table does". It applies to every operator reached through the relation — `exists`, `all`, `except`, membership, `hasIntersection`, `size` — and to the hop-existence guard, so an intermediate hop must exist *and* be visible.
+
 ## How it works
 
 Cerbos can respond to a `PlanResources` request with one of three plan kinds. The adapter mirrors that API:
@@ -225,6 +265,8 @@ const result = queryPlanToDrizzle({
 
 With the above mapper, query plan references such as `request.resource.attr.owner.email` and `request.resource.attr.tags.name`
 are translated into `EXISTS` expressions that join the `owners` and `tags` tables respectively.
+
+Those `EXISTS` expressions read the mapped table bare. If your own reads of that table apply a predicate — a soft-delete flag, a tenant column, a subtype discriminator — declare it as `subqueryFilter` on the relation so the subquery sees the same rows the application serialised. See [Mapping hazards](#mapping-hazards).
 
 ### Working with collections
 

--- a/drizzle/src/index.test.ts
+++ b/drizzle/src/index.test.ts
@@ -1679,3 +1679,166 @@ describe("nullAttributeRepresentation", () => {
     );
   });
 });
+
+// The class 1 mapping-hazard contract (README, "Mapping hazards"): the adapter reads the relation
+// table directly, so a soft-delete flag, tenant column or subtype discriminator the application
+// applies to its own reads does NOT reach the generated EXISTS unless the caller declares it.
+// `subqueryFilter` is that declaration (cerbos/query-plan-adapters#323).
+describe("relation subqueryFilter", () => {
+  const hazardResources = sqliteTable("hazard_resources", {
+    id: text("id").primaryKey(),
+  });
+  const hazardTags = sqliteTable("hazard_tags", {
+    id: text("id").primaryKey(),
+    resourceId: text("resource_id").notNull(),
+    name: text("name").notNull(),
+    deleted: integer("deleted", { mode: "boolean" }).notNull(),
+  });
+
+  const relation = (subqueryFilter?: ReturnType<typeof eq>) => ({
+    relation: {
+      type: "many" as const,
+      table: hazardTags,
+      sourceColumn: hazardResources.id,
+      targetColumn: hazardTags.resourceId,
+      field: hazardTags.name,
+      fields: { name: hazardTags.name },
+      ...(subqueryFilter ? { subqueryFilter } : {}),
+    },
+  });
+
+  const mapperFor = (
+    subqueryFilter?: ReturnType<typeof eq>
+  ): Record<string, MapperEntry> => ({
+    "request.resource.attr.tags": relation(subqueryFilter),
+  });
+
+  const VISIBLE_ONLY = eq(hazardTags.deleted, false);
+
+  const existsPlan = buildPlan({
+    operator: "exists",
+    operands: [
+      { name: "request.resource.attr.tags" },
+      {
+        operator: "lambda",
+        operands: [
+          {
+            operator: "eq",
+            operands: [{ name: "t.name" }, { value: "secret" }],
+          },
+          { name: "t" },
+        ],
+      },
+    ],
+  } as PlanExpressionOperand);
+
+  const allPlan = buildPlan({
+    operator: "all",
+    operands: [
+      { name: "request.resource.attr.tags" },
+      {
+        operator: "lambda",
+        operands: [
+          {
+            operator: "eq",
+            operands: [{ name: "t.name" }, { value: "public" }],
+          },
+          { name: "t" },
+        ],
+      },
+    ],
+  } as PlanExpressionOperand);
+
+  const sizePlan = buildPlan({
+    operator: "eq",
+    operands: [
+      {
+        operator: "size",
+        operands: [{ name: "request.resource.attr.tags" }],
+      },
+      { value: 1 },
+    ],
+  } as PlanExpressionOperand);
+
+  const idsFor = (
+    plan: PlanResourcesResponse,
+    subqueryFilter?: ReturnType<typeof eq>
+  ): string[] =>
+    db
+      .select({ id: hazardResources.id })
+      .from(hazardResources)
+      .where(ensureFilter(queryPlanToDrizzle({ queryPlan: plan, mapper: mapperFor(subqueryFilter) })))
+      .all()
+      .map((row) => row.id)
+      .sort();
+
+  beforeAll(() => {
+    sqlite.exec(`
+      CREATE TABLE hazard_resources (id TEXT PRIMARY KEY);
+      CREATE TABLE hazard_tags (
+        id TEXT PRIMARY KEY,
+        resource_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        deleted INTEGER NOT NULL
+      );
+      INSERT INTO hazard_resources (id) VALUES ('r1'), ('r2');
+      -- r1's application view is ['public']; the 'secret' row is soft-deleted, so the
+      -- application never serialised it into the resource attributes.
+      INSERT INTO hazard_tags (id, resource_id, name, deleted) VALUES
+        ('t1', 'r1', 'public', 0),
+        ('t2', 'r1', 'secret', 1),
+        ('t3', 'r2', 'secret', 0);
+    `);
+  });
+
+  test("declared: exists() sees only the rows the application serialised", () => {
+    // Undeclared, r1 matches on a row its own reads hide — the over-grant #314 catalogues.
+    expect(idsFor(existsPlan)).toEqual(["r1", "r2"]);
+    expect(idsFor(existsPlan, VISIBLE_ONLY)).toEqual(["r2"]);
+  });
+
+  test("declared: all() narrows the scan, not the result", () => {
+    // all() compiles to a NOT EXISTS over a false witness, so a declaration applied around the
+    // subquery instead of inside it would leave the hidden 'secret' row denying r1.
+    expect(idsFor(allPlan)).toEqual([]);
+    expect(idsFor(allPlan, VISIBLE_ONLY)).toEqual(["r1"]);
+  });
+
+  test("declared: size() counts only the rows the application serialised", () => {
+    expect(idsFor(sizePlan)).toEqual(["r2"]);
+    expect(idsFor(sizePlan, VISIBLE_ONLY)).toEqual(["r1", "r2"]);
+  });
+
+  test("undeclared: the emitted SQL is byte-identical to before the field existed", () => {
+    // The non-breaking guarantee. Silence must not add a clause, and must not warn.
+    const withoutField = queryPlanToDrizzle({
+      queryPlan: existsPlan,
+      mapper: {
+        "request.resource.attr.tags": {
+          relation: {
+            type: "many",
+            table: hazardTags,
+            sourceColumn: hazardResources.id,
+            targetColumn: hazardTags.resourceId,
+            field: hazardTags.name,
+            fields: { name: hazardTags.name },
+          },
+        },
+      },
+    });
+    const withUndefined = queryPlanToDrizzle({
+      queryPlan: existsPlan,
+      mapper: mapperFor(undefined),
+    });
+
+    const render = (result: QueryPlanToDrizzleResult) =>
+      db
+        .select()
+        .from(hazardResources)
+        .where(ensureFilter(result))
+        .toSQL();
+
+    expect(render(withUndefined)).toEqual(render(withoutField));
+    expect(render(withoutField).sql).not.toContain("deleted");
+  });
+});

--- a/drizzle/src/index.ts
+++ b/drizzle/src/index.ts
@@ -178,6 +178,32 @@ export interface RelationMapping {
   targetColumn: AnyColumn;
   field?: MapperEntry;
   fields?: { [key: string]: MapperEntry };
+  /**
+   * The predicate the application itself applies when it reads this relation — a soft-delete
+   * flag, a tenant column, a subtype discriminator, whatever narrows the rows that became the
+   * resource attributes.
+   *
+   * The adapter reads `table` directly. Drizzle has no association metadata to consult, so
+   * nothing that narrows the application's own read reaches the generated `EXISTS`, and any
+   * such narrowing makes the subquery see rows the application never serialised — a filter that
+   * returns rows the PDP denies. Declaring the predicate here restores the equality; the adapter
+   * cannot detect the omission, which is why the field is optional and silence is not a warning.
+   * See "Mapping hazards" in the README.
+   *
+   * It is ANDed into the correlated subquery over `table`, so it constrains every operator
+   * reached through this relation — `exists`, `all`, membership, counts — under both polarities.
+   *
+   * ```ts
+   * relation: {
+   *   type: "many",
+   *   table: tags,
+   *   sourceColumn: resources.id,
+   *   targetColumn: tags.resourceId,
+   *   subqueryFilter: isNull(tags.deletedAt),
+   * }
+   * ```
+   */
+  subqueryFilter?: SQL;
 }
 
 type ScopedMapperMetadata = {
@@ -491,6 +517,23 @@ const wrapRelationChain = (
     options
   );
 
+/**
+ * The correlation predicate of a subquery over `relation`: the join, narrowed by whatever
+ * store-side predicate the caller declared on the mapping.
+ *
+ * Every subquery the adapter builds over a relation goes through here or through
+ * `wrapWithRelations`, so a declared `subqueryFilter` reaches the EXISTS forms, the COUNT forms
+ * and the hop-existence guard alike. Adding a new subquery shape means routing it through one of
+ * the two, or the declaration silently stops applying to it.
+ */
+const relationCorrelation = (relation: RelationMapping): SQL => {
+  const joinCondition = eq(relation.targetColumn, relation.sourceColumn);
+  if (relation.subqueryFilter === undefined) {
+    return joinCondition;
+  }
+  return and(joinCondition, relation.subqueryFilter) ?? joinCondition;
+};
+
 const wrapWithRelations = (
   relations: RelationMapping[],
   filter: SQL,
@@ -504,8 +547,12 @@ const wrapWithRelations = (
       if (options?.skipRelations?.has(relation)) {
         return currentFilter;
       }
-      const joinCondition = eq(relation.targetColumn, relation.sourceColumn);
-      const condition = and(joinCondition, currentFilter);
+      // The caller-declared store-side predicate goes in alongside the join, not around the
+      // EXISTS, so it narrows the rows the subquery examines rather than the rows it returns.
+      // That is what makes it correct under negation too: `all` compiles to `NOT EXISTS (… AND
+      // NOT P)`, and restricting the scan is what turns that into "every VISIBLE row satisfies
+      // P" instead of "every row in the table does".
+      const condition = and(relationCorrelation(relation), currentFilter);
       const tableName = resolveTableName(relation.table, reference);
       return exists(
         sql`(select 1 from ${sql.identifier(tableName)} where ${condition})`
@@ -980,10 +1027,7 @@ const buildSizeExpression = (
       scope.primaryRelation.table,
       scope.collectionName
     );
-    const joinCondition = eq(
-      scope.primaryRelation.targetColumn,
-      scope.primaryRelation.sourceColumn
-    );
+    const joinCondition = relationCorrelation(scope.primaryRelation);
     const chainWhere = scope.leadingRelations.length
       ? wrapWithRelations(
           scope.leadingRelations,
@@ -1014,7 +1058,7 @@ const buildSizeExpression = (
     const primary = relations[relations.length - 1]!;
     const leading = relations.slice(0, -1);
     const tableName = resolveTableName(primary.table, operand.name);
-    const joinCondition = eq(primary.targetColumn, primary.sourceColumn);
+    const joinCondition = relationCorrelation(primary);
     const chainWhere = leading.length
       ? wrapWithRelations(leading, joinCondition, operand.name, options)
       : joinCondition;
@@ -1980,11 +2024,10 @@ const buildCollectionOperatorFilter = (
       }
     case "exists_one": {
       const tableName = resolveTableName(primaryRelation.table, collectionName);
-      const joinCondition = eq(
-        primaryRelation.targetColumn,
-        primaryRelation.sourceColumn
+      const matchCondition = and(
+        relationCorrelation(primaryRelation),
+        rowCondition
       );
-      const matchCondition = and(joinCondition, rowCondition);
       if (!matchCondition) {
         return FALSE_CONDITION;
       }

--- a/elasticsearch-java/README.md
+++ b/elasticsearch-java/README.md
@@ -387,6 +387,21 @@ predicates that require distinguishing an indexed empty array from a missing fie
 
 Elasticsearch does not index empty arrays. An `exists` or nested query therefore cannot distinguish an attribute explicitly set to `[]` from an attribute omitted entirely. CEL treats the former as an empty collection and the latter as an evaluation error, so polarity matters: positive `exists`, positive non-empty checks, negated `all`, and negated empty checks remain safe; the opposite polarities throw rather than authorizing a document with a missing collection.
 
+### Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the query select the documents `check()` allows. The other half is the *mapping*: **the documents the query reads must be the documents the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter **builds no subquery.** A collection is a `nested` field on the same document (see below), so the `nested` query matches inner objects of the document being scored — it never reaches a second index. The emitted DSL contains no `has_child` and no `has_parent`, and its `terms` queries always carry an inline value list rather than a terms *lookup*.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | Not applicable — no subquery | — |
+| Default scope on the target model | Not applicable — no second index is read | — |
+| Subtype discrimination | **Caller-owned** | The index or alias you send the query to, and any filtered alias on it. The adapter is handed a plan, never an index, so it cannot check that the documents you search are the ones the resource attributes were built from. An alias whose filter differs from the application's own read path, or an index holding several document kinds, needs its discriminator added to your `bool.filter` yourself |
+| To-one relation used as a collection | Not applicable — a `nested` field holds exactly the inner objects the application indexed | — |
+| Composite association key | Not applicable — no join, so no key to compose | — |
+| Absent to-one parent | **Reproduced** for the safe polarities, **rejected** for the rest — `w1-exists-chain`, `w1-size-chain` and `w1-in-chain` are oracle-tested; `w1-all-chain`, `w1-not-exists-chain`, `w1-size-zero-chain`, `w1-size-nonneg-chain`, `w1-not-in-chain`, `w1-not-hasint-chain` and `w1-not-size-chain` are in `adapterUnsupported` and throw | None — it is the empty-array limitation above, not a mapping choice: Elasticsearch cannot tell a document with no parent from a document whose parent has no children, so the polarities that would read that as an allow are refused ([#309](https://github.com/cerbos/query-plan-adapters/issues/309)) |
+
 ### Nested object queries (collection operators)
 
 When your Cerbos policies use collection operators (`exists`, `all`, `except`) or `hasIntersection` with `map` on arrays of nested objects, pass a `Set<String>` of Elasticsearch field names that use `nested` mappings:

--- a/ent/README.md
+++ b/ent/README.md
@@ -86,6 +86,11 @@ Collection attributes lower into correlated subqueries. A relation may reach thr
 tables with `Via`, so a flattened chain such as `R.attr.mainCategory.subCategories` joins its
 intermediate table inside the subquery while only the resource row correlates outwards.
 
+Those subqueries read the mapped table bare. If your own reads of it apply a predicate — a
+soft-delete flag, a tenant column, a subtype discriminator — declare it as `SubqueryFilter` on the
+relation so the subquery sees the same rows the application serialised. See
+[Mapping hazards](#mapping-hazards).
+
 ### NULL representation
 
 The planner emits the same `eq(attr, null)` node whether the caller sends a NULL column as an
@@ -123,6 +128,61 @@ Go's `time.Time` carries nanoseconds, so those instants survive translation exac
 
 The eight fail-closed shapes return an error wrapping `ErrUnsupported` rather than a broader
 predicate. `matches()` is rejected because SQL regex dialects do not guarantee CEL/RE2 semantics.
+
+### Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the filter select
+the rows `check()` allows. The other half is the *mapping*: **the rows the subquery reads must be
+the rows the application put into the resource attributes.** Six ways that can break are catalogued
+in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter builds a **bare-table subquery.** A `Relation` is a table name plus a source and a
+target column; there is no association metadata for the translator to consult, so nothing the
+application applies to its own reads reaches the generated subquery. Where the application narrows
+those reads, declare the same predicate as `SubqueryFilter` on the relation (or on the `Hop`, for an
+intermediate table) and the translator reproduces it. Declaring nothing emits exactly the SQL this
+adapter emitted before the field existed — it cannot detect the omission, so silence is not a
+warning.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | **Caller-owned**, reproducible with `SubqueryFilter` | Ent interceptors (`client.Intercept(intercept.TraverseFunc(…))` calling `q.WhereP`), privacy filter rules (`privacy.FilterFunc`), and the `.Where(...)` predicates a repository helper always applies. All of those rewrite the Ent query they are attached to; none of them reach inside the raw correlated subquery this adapter builds, which is given `Table`, `SourceColumn` and `TargetColumn` and reads the table bare |
+| Default scope on the target model | **Caller-owned**, reproducible with `SubqueryFilter` | A soft-delete column (`deleted_at IS NULL`), a tenant column, a `published` flag — anything every application read of that table filters on. Go has no default-scope construct here, so the convention lives in your own query code and only you can see it |
+| Subtype discrimination | **Caller-owned**, reproducible with `SubqueryFilter` | A `type`/`kind` discriminator column where one table holds several row kinds. Declare `{Column: "kind", Value: "…"}`, or `RestrictIn` over the kinds the association admits |
+| To-one relation used as a collection | **Caller-owned** | A relation whose `TargetColumn` has no unique index. The mapping carries no cardinality at all — every relation lowers to the same correlated subquery — so nothing makes the database enforce the single row the application saw. Add the unique constraint, or accept that the subquery examines every matching row |
+| Composite association key | **Rejected by the type system** | `SourceColumn` and `TargetColumn` are each one `string`, so a two-column key cannot be expressed. This is a compile error, not a wrong join |
+| Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain` and siblings) | None — every operator reached through a `Via` chain requires its intermediate hops separately, so a missing parent is UNKNOWN under both polarities ([#309](https://github.com/cerbos/query-plan-adapters/issues/309), [#315](https://github.com/cerbos/query-plan-adapters/issues/315)). Declaring `SubqueryFilter` on a `Hop` extends that to a parent the application *hides*, which for this purpose is equally absent |
+
+#### Declaring the application's own predicate
+
+```go
+tags := &cerbosent.Relation{
+    Table:        "contact_tag",
+    SourceColumn: "id",
+    TargetColumn: "contact_id",
+    Field:        &cerbosent.Entry{Column: "name"},
+    // Exactly the predicate your own reads of contact_tag apply.
+    SubqueryFilter: []cerbosent.Restriction{
+        {Column: "deleted_at", Op: cerbosent.RestrictIsNull},
+        {Column: "kind", Value: "label"},
+    },
+}
+```
+
+The vocabulary is deliberately narrow — `RestrictEq`, `RestrictNe`, `RestrictIsNull`,
+`RestrictIsNotNull`, `RestrictIn`, `RestrictNotIn` over a single column — because that is what these
+hazards look like in practice. A predicate that does not fit is a signal that the mapping cannot
+faithfully reproduce the application's read, and the honest response is to not map that relation
+rather than to declare an approximation.
+
+Restrictions are ANDed into the subquery's correlation predicate, so they narrow the rows the
+subquery *examines* rather than the rows it returns. That is what keeps them right under negation:
+`all` lowers to a false-witness `EXISTS`, and restricting the scan turns it into "every visible row
+satisfies the body" instead of "every row in the table does". They apply to every shape built on the
+relation — the truth witnesses, the UNKNOWN witness, the counts, and the hop-existence guard.
+
+Values are bound as query parameters, never interpolated. An empty `Values` list is read as CEL
+reads it: `RestrictIn` then hides every row, `RestrictNotIn` hides none.
 
 ### Dialect coverage
 

--- a/ent/adapter.go
+++ b/ent/adapter.go
@@ -31,6 +31,11 @@ type (
 	Relation = queryplan.Relation
 	// Hop is one intermediate table in a flattened relation chain.
 	Hop = queryplan.Hop
+	// Restriction is one caller-declared predicate on the rows a relation subquery may see.
+	// See Relation.SubqueryFilter and "Mapping hazards" in the README.
+	Restriction = queryplan.Restriction
+	// RestrictOp is the comparison a Restriction applies.
+	RestrictOp = queryplan.RestrictOp
 	// Mapper resolves plan variables to storage.
 	Mapper = queryplan.Mapper
 	// MapperMap is a static reference-to-entry table.
@@ -45,6 +50,16 @@ type (
 const (
 	ValueDefault   = queryplan.ValueDefault
 	ValueTimestamp = queryplan.ValueTimestamp
+)
+
+// Restriction comparisons, for Relation.SubqueryFilter and Hop.SubqueryFilter.
+const (
+	RestrictEq        = queryplan.RestrictEq
+	RestrictNe        = queryplan.RestrictNe
+	RestrictIsNull    = queryplan.RestrictIsNull
+	RestrictIsNotNull = queryplan.RestrictIsNotNull
+	RestrictIn        = queryplan.RestrictIn
+	RestrictNotIn     = queryplan.RestrictNotIn
 )
 
 // NULL-attribute representations.

--- a/ent/internal/queryplan/mapper.go
+++ b/ent/internal/queryplan/mapper.go
@@ -32,6 +32,23 @@ type Relation struct {
 	// for a direct relation and non-empty for a flattened chain such as
 	// `mainCategory.subCategories`, which reaches the resource through its category table.
 	Via []Hop
+	// SubqueryFilter is the predicate the application itself applies when it reads Table — a
+	// soft-delete flag, a tenant column, a subtype discriminator, whatever narrows the rows that
+	// became the resource attributes.
+	//
+	// The translator reads Table bare. It is given a table name and two column names and has no
+	// association metadata to consult, so nothing that narrows the application's own read reaches
+	// the generated subquery, and the subquery then examines rows the application never
+	// serialised — a filter that returns rows the PDP denies. Declaring the predicate here
+	// restores the equality. It is optional because the translator cannot detect the omission;
+	// leaving it empty emits exactly the SQL it emitted before the field existed. See "Mapping
+	// hazards" in the adapter's README.
+	//
+	// Entries are ANDed into the subquery's correlation predicate, so the restriction narrows the
+	// rows the subquery EXAMINES rather than the rows it returns. That is what keeps it right
+	// under negation: `all` lowers to a false-witness EXISTS, and restricting the scan turns it
+	// into "every visible row satisfies the body" instead of "every row in the table does".
+	SubqueryFilter []Restriction
 }
 
 // Hop is one intermediate table in a flattened relation chain.
@@ -43,6 +60,54 @@ type Hop struct {
 	ChildColumn string
 	// JoinColumn is the referenced column on this hop's table.
 	JoinColumn string
+	// SubqueryFilter restricts this hop's table the same way Relation.SubqueryFilter restricts
+	// the element table. A hop is read bare too, and it is the to-ONE parent whose absence must
+	// deny (#309) — a row the application's own reads hide is, for this purpose, absent.
+	SubqueryFilter []Restriction
+}
+
+// RestrictOp is the comparison a Restriction applies.
+type RestrictOp uint8
+
+const (
+	// RestrictEq is `column = value`. It is the zero value, so a Restriction that names only a
+	// column and a value is an equality.
+	RestrictEq RestrictOp = iota
+	// RestrictNe is `column <> value`. It does not match NULL columns; pair it with
+	// RestrictIsNull under an OR if the application's own predicate treats NULL as matching.
+	RestrictNe
+	// RestrictIsNull is `column IS NULL` — the usual soft-delete spelling.
+	RestrictIsNull
+	// RestrictIsNotNull is `column IS NOT NULL`.
+	RestrictIsNotNull
+	// RestrictIn is `column IN (values…)`. An empty Values list hides every row.
+	RestrictIn
+	// RestrictNotIn is `column NOT IN (values…)`. An empty Values list hides none.
+	RestrictNotIn
+)
+
+// Restriction is one caller-declared predicate on the rows a relation subquery may see.
+//
+// The vocabulary is deliberately narrow — equality, inequality, null tests and membership over a
+// single column — because that is what the hazards it exists for look like: a `deleted_at IS
+// NULL` soft delete, a `tenant_id = $1` scope, a `kind IN (…)` discriminator. A predicate that
+// does not fit is a signal that the mapping cannot faithfully reproduce the application's read,
+// and the honest response is to not map that relation rather than to declare an approximation.
+//
+// Value and Values are read according to Op, and the pairing is not enforced at compile time. It
+// does not need to be, because every way of getting it wrong FAILS CLOSED: Values alongside
+// RestrictEq leaves Value nil and renders `column = NULL`, which is UNKNOWN and admits nothing,
+// and Value alongside RestrictIn leaves Values empty, which folds to FALSE. A mismatched pairing
+// therefore hides rows rather than exposing them. TestRestrictionMismatchFailsClosed pins it.
+type Restriction struct {
+	// Value is compared with Column. Ignored by RestrictIsNull and RestrictIsNotNull.
+	Value any
+	// Column is a column on the table this restriction applies to, unqualified.
+	Column string
+	// Values is the membership list for RestrictIn and RestrictNotIn.
+	Values []any
+	// Op is the comparison. The zero value is RestrictEq.
+	Op RestrictOp
 }
 
 // ValueType marks an attribute whose stored representation needs special handling.

--- a/ent/internal/queryplan/translate.go
+++ b/ent/internal/queryplan/translate.go
@@ -395,6 +395,7 @@ func (b *builder) relationScope(rel *Relation, alias, parent string) ([]FromItem
 	from := make([]FromItem, 0, len(rel.Via)+1)
 	from = append(from, FromItem{Table: rel.Table, Alias: alias})
 	preds := make([]Expr, 0, len(rel.Via)+1)
+	preds = appendRestrictions(preds, alias, rel.SubqueryFilter)
 
 	inner := alias
 	for _, hop := range rel.Via {
@@ -405,6 +406,7 @@ func (b *builder) relationScope(rel *Relation, alias, parent string) ([]FromItem
 			L:  Column{Qualifier: inner, Name: hop.ChildColumn},
 			R:  Column{Qualifier: hopAlias, Name: hop.JoinColumn},
 		})
+		preds = appendRestrictions(preds, hopAlias, hop.SubqueryFilter)
 		inner = hopAlias
 	}
 
@@ -415,6 +417,46 @@ func (b *builder) relationScope(rel *Relation, alias, parent string) ([]FromItem
 	})
 
 	return from, and(preds...)
+}
+
+// appendRestrictions lowers the caller-declared store-side predicates for one table into the
+// conjunction that correlates its subquery.
+//
+// They go in beside the join rather than around the subquery so every shape built on the scope —
+// the truth witnesses, the UNKNOWN witness, the counts, the hop guard — inherits them without
+// each one having to remember to.
+func appendRestrictions(preds []Expr, alias string, restrictions []Restriction) []Expr {
+	for _, r := range restrictions {
+		col := Column{Qualifier: alias, Name: r.Column}
+		switch r.Op {
+		case RestrictEq:
+			preds = append(preds, Cmp{Op: OpEq, L: col, R: Lit{V: r.Value}})
+		case RestrictNe:
+			preds = append(preds, Cmp{Op: OpNe, L: col, R: Lit{V: r.Value}})
+		case RestrictIsNull:
+			preds = append(preds, IsNull{X: col})
+		case RestrictIsNotNull:
+			preds = append(preds, IsNull{X: col, Negate: true})
+		case RestrictIn, RestrictNotIn:
+			// CEL's own identities: membership in an empty list is false, so an empty IN hides
+			// every row and an empty NOT IN hides none. Spelling them as constants also keeps
+			// the renderer away from `IN ()`, which is a syntax error.
+			if len(r.Values) == 0 {
+				preds = append(preds, BoolConst{V: r.Op == RestrictNotIn})
+				continue
+			}
+			vs := make([]Expr, 0, len(r.Values))
+			for _, v := range r.Values {
+				vs = append(vs, Lit{V: v})
+			}
+			in := Expr(InList{X: col, Vs: vs})
+			if r.Op == RestrictNotIn {
+				in = Not{X: in}
+			}
+			preds = append(preds, in)
+		}
+	}
+	return preds
 }
 
 // hopsExist builds "every intermediate table of a flattened chain has a row", or nil when the
@@ -448,6 +490,9 @@ func (b *builder) hopsExist(rel *Relation, parent string) Expr {
 				R:  Column{Qualifier: hopAlias, Name: hop.JoinColumn},
 			})
 		}
+		// A hop the application's own reads hide is a hop that does not exist as far as the
+		// resource attributes are concerned, so the guard has to agree with relationScope here.
+		preds = appendRestrictions(preds, hopAlias, hop.SubqueryFilter)
 		inner = hopAlias
 	}
 

--- a/ent/translate_test.go
+++ b/ent/translate_test.go
@@ -1,0 +1,225 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package cerbosent_test
+
+import (
+	"strings"
+	"testing"
+
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	enginev1 "github.com/cerbos/cerbos/api/genpb/cerbos/engine/v1"
+	responsev1 "github.com/cerbos/cerbos/api/genpb/cerbos/response/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	cerbosent "github.com/cerbos/query-plan-adapters/ent"
+)
+
+// Unit tests over hand-built plans, complementing the adversarial suite: the corpus proves
+// semantics against a real PDP but only ever feeds the adapter plans the planner actually emits.
+// Everything here runs without Docker.
+
+type operand = enginev1.PlanResourcesFilter_Expression_Operand
+
+func val(t *testing.T, v any) *operand {
+	t.Helper()
+	pb, err := structpb.NewValue(v)
+	require.NoError(t, err)
+	return &operand{Node: &enginev1.PlanResourcesFilter_Expression_Operand_Value{Value: pb}}
+}
+
+func variable(name string) *operand {
+	return &operand{Node: &enginev1.PlanResourcesFilter_Expression_Operand_Variable{Variable: name}}
+}
+
+func expr(op string, operands ...*operand) *operand {
+	return &operand{Node: &enginev1.PlanResourcesFilter_Expression_Operand_Expression{
+		Expression: &enginev1.PlanResourcesFilter_Expression{Operator: op, Operands: operands},
+	}}
+}
+
+func conditional(cond *operand) *responsev1.PlanResourcesResponse {
+	return &responsev1.PlanResourcesResponse{
+		Filter: &enginev1.PlanResourcesFilter{
+			Kind:      enginev1.PlanResourcesFilter_KIND_CONDITIONAL,
+			Condition: cond,
+		},
+	}
+}
+
+func tagRelation(filter ...cerbosent.Restriction) *cerbosent.Relation {
+	return &cerbosent.Relation{
+		Table:          "tag",
+		SourceColumn:   "id",
+		TargetColumn:   "resource_id",
+		Field:          &cerbosent.Entry{Column: "name"},
+		Fields:         map[string]cerbosent.Entry{"name": {Column: "name"}},
+		SubqueryFilter: filter,
+	}
+}
+
+// translateWith translates a plan and renders the resulting predicate to SQL and bound args.
+func translateWith(t *testing.T, mapper cerbosent.Mapper, cond *operand) (string, []any) {
+	t.Helper()
+	result, err := cerbosent.Translate(conditional(cond), "resource", mapper)
+	require.NoError(t, err)
+	require.Equal(t, cerbosent.KindConditional, result.Kind)
+
+	selector := entsql.Dialect(dialect.SQLite).Select("id").From(entsql.Table("resource"))
+	selector.Where(result.Predicate)
+	query, args := selector.Query()
+	return query, args
+}
+
+// tagsExists is `R.attr.tags.exists(t, t.name == "x")`.
+func tagsExists(t *testing.T) *operand {
+	t.Helper()
+	return expr("exists", variable("request.resource.attr.tags"),
+		expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))
+}
+
+// TestSubqueryFilterNarrowsEveryShapeBuiltOnTheRelation is the class 1 mapping-hazard contract
+// (README, "Mapping hazards"). This adapter is handed a table name and two column names, so
+// nothing the application applies to its own reads of that table reaches the generated subquery.
+// Relation.SubqueryFilter closes that gap (cerbos/query-plan-adapters#323) — and it has to reach
+// every subquery the translator builds over the relation, not just the one the author of the
+// feature happened to look at. A shape that misses it silently reverts to reading the table bare.
+func TestSubqueryFilterNarrowsEveryShapeBuiltOnTheRelation(t *testing.T) {
+	t.Parallel()
+
+	visible := cerbosent.Restriction{Column: "deleted_at", Op: cerbosent.RestrictIsNull}
+	mapperFor := func(rel *cerbosent.Relation) cerbosent.Mapper {
+		return cerbosent.MapperMap{
+			"request.resource.attr.name": {Column: "name"},
+			"request.resource.attr.tags": {Relation: rel},
+		}
+	}
+
+	cases := []struct {
+		cond *operand
+		name string
+	}{
+		{name: "exists", cond: tagsExists(t)},
+		{name: "negated exists", cond: expr("not", tagsExists(t))},
+		{name: "all", cond: expr("all", variable("request.resource.attr.tags"),
+			expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))},
+		{name: "except", cond: expr("except", variable("request.resource.attr.tags"),
+			expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))},
+		{name: "exists_one", cond: expr("exists_one", variable("request.resource.attr.tags"),
+			expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))},
+		{name: "count", cond: expr("gt", expr("size", variable("request.resource.attr.tags")), val(t, 2))},
+		{name: "membership", cond: expr("in", val(t, "x"), variable("request.resource.attr.tags"))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bare, _ := translateWith(t, mapperFor(tagRelation()), tc.cond)
+			require.NotContains(t, bare, "deleted_at",
+				"undeclared must emit exactly what it emitted before the field existed")
+
+			subqueries := strings.Count(bare, "FROM `tag`")
+			require.NotZero(t, subqueries, "sanity: this shape must build a subquery at all")
+
+			// A shape typically renders the relation more than once — a true witness and an
+			// UNKNOWN witness, or a count beside a guard. Counting the restriction against the
+			// number of subqueries catches one that picks it up only in some of them.
+			declared, _ := translateWith(t, mapperFor(tagRelation(visible)), tc.cond)
+			require.Equal(t, subqueries, strings.Count(declared, "`deleted_at` IS NULL"),
+				"every subquery over the relation must carry the declared restriction")
+		})
+	}
+}
+
+// TestSubqueryFilterRestrictsIntermediateHops covers the flattened chain. A hop is read bare too,
+// and it is the to-ONE parent whose absence must deny (#309) — a row the application hides is,
+// for that purpose, absent, so the hop guard has to agree with the element subquery.
+func TestSubqueryFilterRestrictsIntermediateHops(t *testing.T) {
+	t.Parallel()
+
+	mapper := cerbosent.MapperMap{
+		"request.resource.attr.chain": {Relation: &cerbosent.Relation{
+			Table:        "sub_category",
+			SourceColumn: "id",
+			TargetColumn: "category_id",
+			Fields:       map[string]cerbosent.Entry{"name": {Column: "name"}},
+			Via: []cerbosent.Hop{{
+				Table:          "category",
+				ChildColumn:    "category_id",
+				JoinColumn:     "id",
+				SubqueryFilter: []cerbosent.Restriction{{Column: "kind", Value: "main"}},
+			}},
+		}},
+	}
+	cond := expr("not", expr("exists", variable("request.resource.attr.chain"),
+		expr("lambda", expr("eq", variable("s.name"), val(t, "x")), variable("s"))))
+
+	query, _ := translateWith(t, mapper, cond)
+
+	// The negated macro renders the element subquery twice (true and UNKNOWN witnesses) and the
+	// hop-existence guard once, and all three read `category`. The guard is the one that matters:
+	// without the restriction it answers "the parent exists" for a parent the application hides,
+	// which is what turns the #309 fix back into an over-grant.
+	require.Equal(t, 3, strings.Count(query, "`category` AS "))
+	require.Equal(t, 3, strings.Count(query, "`kind` = "),
+		"the hop guard must restrict the hop the same way the element subquery does")
+}
+
+// TestSubqueryFilterMembershipEdges pins the two list identities. `IN ()` is a syntax error, so
+// the empty cases have to fold to constants rather than reach the renderer.
+func TestSubqueryFilterMembershipEdges(t *testing.T) {
+	t.Parallel()
+
+	mapperFor := func(rel *cerbosent.Relation) cerbosent.Mapper {
+		return cerbosent.MapperMap{"request.resource.attr.tags": {Relation: rel}}
+	}
+	cond := tagsExists(t)
+
+	// ent's builder spells the boolean constants `1 = 0` / `1 = 1`; they lead the subquery's
+	// WHERE because the restrictions are prepended to the correlation conjunction.
+	empty, _ := translateWith(t, mapperFor(tagRelation(
+		cerbosent.Restriction{Column: "kind", Op: cerbosent.RestrictIn})), cond)
+	require.NotContains(t, empty, "IN ()")
+	require.Contains(t, empty, "WHERE (1 = 0 AND", "membership in an empty list hides every row")
+
+	emptyNot, _ := translateWith(t, mapperFor(tagRelation(
+		cerbosent.Restriction{Column: "kind", Op: cerbosent.RestrictNotIn})), cond)
+	require.NotContains(t, emptyNot, "IN ()")
+	require.Contains(t, emptyNot, "WHERE (1 = 1 AND", "non-membership in an empty list hides none")
+
+	listed, args := translateWith(t, mapperFor(tagRelation(
+		cerbosent.Restriction{Column: "kind", Op: cerbosent.RestrictIn, Values: []any{"a", "b"}})), cond)
+	require.Contains(t, listed, "`kind` IN (")
+	require.NotContains(t, listed, "'a'", "the declared values are bound, never interpolated")
+	require.Contains(t, args, "a")
+	require.Contains(t, args, "b")
+}
+
+// TestRestrictionMismatchFailsClosed pins the safety property that makes Restriction's
+// Value/Values pairing safe to leave unenforced: getting it wrong hides rows, never exposes them.
+// A sum type with a constructor would be tidier, but this is the property that actually matters
+// for an authorization filter, so it is asserted rather than assumed.
+func TestRestrictionMismatchFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	mapperFor := func(rel *cerbosent.Relation) cerbosent.Mapper {
+		return cerbosent.MapperMap{"request.resource.attr.tags": {Relation: rel}}
+	}
+	cond := tagsExists(t)
+
+	// Values supplied where Op reads Value: the comparison renders against NULL, which is
+	// UNKNOWN, so the subquery matches nothing.
+	valuesOnEq, args := translateWith(t, mapperFor(tagRelation(
+		cerbosent.Restriction{Column: "kind", Op: cerbosent.RestrictEq, Values: []any{"a"}})), cond)
+	require.Contains(t, valuesOnEq, "`kind` = NULL")
+	require.NotContains(t, args, "a")
+
+	// Value supplied where Op reads Values: the empty list folds to FALSE.
+	valueOnIn, args := translateWith(t, mapperFor(tagRelation(
+		cerbosent.Restriction{Column: "kind", Op: cerbosent.RestrictIn, Value: "a"})), cond)
+	require.Contains(t, valueOnIn, "WHERE (1 = 0 AND")
+	require.NotContains(t, args, "a")
+}

--- a/langchain-chromadb/README.md
+++ b/langchain-chromadb/README.md
@@ -103,6 +103,21 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 Chroma metadata filters are limited to flat scalar comparisons and membership. Nested collections, field-to-field and arithmetic expressions, string helpers, hierarchy/timestamp operations, ternaries, nullable inequality, and other shapes that cannot be represented faithfully throw before a filter is returned.
 
+## Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the filter select the documents `check()` allows. The other half is the *mapping*: **the documents the filter reads must be the documents the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter **builds no subquery**, and has nothing to build one over: a Chroma `where` clause compares flat scalar metadata on the document being matched. Every shape that would need to reach a second record is already in the fail-closed set above.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | Not applicable — no subquery | — |
+| Default scope on the target model | Not applicable — no second collection is read | — |
+| Subtype discrimination | **Caller-owned** | The Chroma collection you pass the `where` clause to. The adapter is handed a plan, never a collection, so it cannot check that the collection you query is the one whose metadata became the resource attributes. If one collection mixes document kinds, add the discriminating metadata key to the `where` yourself |
+| To-one relation used as a collection | Not applicable — a metadata key holds exactly what the application stored | — |
+| Composite association key | Not applicable — no join, so no key to compose | — |
+| Absent to-one parent | **Rejected** — `w1-all-chain`, `w1-not-exists-chain` and the eight other chained shapes are in `adapterUnsupported` and throw | None — Chroma metadata is flat, so a chain has nowhere to resolve to and the adapter refuses the plan rather than flattening it ([#309](https://github.com/cerbos/query-plan-adapters/issues/309)) |
+
 ## Requirements
 
 - Cerbos > v0.16

--- a/mongoose/README.md
+++ b/mongoose/README.md
@@ -77,6 +77,21 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 The fail-closed set covers exact-one cardinality, aggregation expressions or outer-document references inside `$elemMatch`, nested collection counts, correlated variable-in-variable membership, unsafe division/non-finite arithmetic, and negated nullable collection predicates that cannot preserve CEL's three-valued error semantics. These plans throw instead of silently degrading to a weaker MongoDB filter.
 
+## Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the filter select the documents `check()` allows. The other half is the *mapping*: **the documents the filter reads must be the documents the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter **builds no subquery.** A relation is a path inside the same document, so `find()` reads exactly the document the application serialised. The adapter emits no `$lookup` and no `$graphLookup`, and never calls `populate()` or `aggregate()` — `src/adversarial.test.ts` ("emits no `$lookup` and reaches no second collection") asserts that against both the source and every emitted filter, because five of the six rows below are only "not applicable" for as long as it stays true.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | Not applicable — no subquery | — |
+| Default scope on the target model | Not applicable — no second collection is read | — |
+| Subtype discrimination | **Caller-owned** | `Model.discriminator(...)`. Run the filter on the same model the application read the attributes from. Discriminated models share one collection, so a filter executed against the *base* model matches the other subtypes' documents — the `__t` criterion Mongoose adds for the discriminator model is not in the filter the adapter returns, and cannot be: the plan does not say which model the caller will use |
+| To-one relation used as a collection | Not applicable — a document path holds exactly what the application stored | — |
+| Composite association key | Not applicable — no join, so no key to compose | — |
+| Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain` and siblings) | `relation.requiresParent` — declare the optional to-one parent a flattened path is reached through, so `size(chain)` comparisons yield null rather than 0 for a document that has no parent ([#309](https://github.com/cerbos/query-plan-adapters/issues/309)) |
+
 ## Requirements
 
 - Cerbos > v0.16 plus either the `@cerbos/http` or `@cerbos/grpc` client

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -1062,6 +1062,50 @@ describe("adversarial conformance corpus", () => {
     expect(await filteredIdsFor(compare("lt", 2))).toEqual(withParent);
   });
 
+  // The mapping-hazard contract in README.md ("Mapping hazards") rests on ONE structural fact:
+  // this adapter builds no subquery. A relation is a path inside the same document, so the filter
+  // and the application read the same document and the five subquery hazards
+  // (conformance/README.md, "Mapping hazards: the rows the subquery sees") cannot arise. The day
+  // the adapter reaches a second collection — a `$lookup` stage, a `populate()` call — every one
+  // of them arrives at once and the README's "not applicable" rows become over-grants, silently.
+  // This is the test that stops that landing unnoticed (cerbos/query-plan-adapters#323).
+  test("emits no $lookup and reaches no second collection", async () => {
+    const forbidden = /\$lookup|\$graphLookup|\bpopulate\s*\(|\baggregate\s*\(/;
+
+    // The claim is about the adapter, not about the corpus's mapper: a filter walk alone would
+    // pass for a `$lookup` the corpus mapper never triggers. Reading the source is what makes the
+    // guard total over mapper shapes.
+    const source = fs.readFileSync(path.join(__dirname, "index.ts"), "utf8");
+    // Prose about the guard is not a violation of it, so comments come off first — including
+    // trailing ones, or this very file's vocabulary would trip the scan the moment someone
+    // wrote `// never calls populate()` next to a line of code.
+    const stripComments = (line: string): string =>
+      /^(\/\/|\/\*|\*)/.test(line.trimStart())
+        ? ""
+        : line.replace(/\/\/.*$/, "").replace(/\/\*.*?\*\//g, "");
+    const offendingLines = source
+      .split("\n")
+      .map((line, index) => [index + 1, stripComments(line)] as const)
+      .filter(([, code]) => forbidden.test(code));
+    expect(offendingLines).toEqual([]);
+
+    // And the emitted filters, so a `$lookup` assembled from string fragments cannot slip past
+    // the source scan.
+    for (const action of ORACLE_ACTIONS) {
+      const queryPlan = await cerbos.planResources({
+        principal: seedsFile.principal,
+        resource: { kind: seedsFile.resourceKind },
+        action,
+      });
+      const result = queryPlanToMongoose({ queryPlan, mapper: MAPPER });
+      if (result.kind !== PlanKind.CONDITIONAL) continue;
+      expect([action, JSON.stringify(result.filters)]).toEqual([
+        action,
+        expect.not.stringMatching(forbidden),
+      ]);
+    }
+  });
+
   test("oracle is not degenerate", async () => {
     // The #309/#312/#311/#315/#316 additions. w1-size-zero-chain, w1-not-size-chain and the
     // two string-cast actions are deliberately absent: their oracles are empty by

--- a/pgx/README.md
+++ b/pgx/README.md
@@ -73,6 +73,11 @@ Collection attributes lower into correlated subqueries. A relation may reach thr
 tables with `Via`, so a flattened chain such as `R.attr.mainCategory.subCategories` joins its
 intermediate table inside the subquery while only the resource row correlates outwards.
 
+Those subqueries read the mapped table bare. If your own reads of it apply a predicate — a
+soft-delete flag, a tenant column, a subtype discriminator — declare it as `SubqueryFilter` on the
+relation so the subquery sees the same rows the application serialised. See
+[Mapping hazards](#mapping-hazards).
+
 ### NULL representation
 
 The planner emits the same `eq(attr, null)` node whether the caller sends a NULL column as an
@@ -109,6 +114,61 @@ Go's `time.Time` carries nanoseconds, so those instants survive translation exac
 
 The eight fail-closed shapes return an error wrapping `ErrUnsupported` rather than a broader SQL
 filter. `matches()` is rejected because SQL regex dialects do not guarantee CEL/RE2 semantics.
+
+### Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the filter select
+the rows `check()` allows. The other half is the *mapping*: **the rows the subquery reads must be
+the rows the application put into the resource attributes.** Six ways that can break are catalogued
+in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter builds a **bare-table subquery.** A `Relation` is a table name plus a source and a
+target column; there is no association metadata for the translator to consult, so nothing the
+application applies to its own reads reaches the generated subquery. Where the application narrows
+those reads, declare the same predicate as `SubqueryFilter` on the relation (or on the `Hop`, for an
+intermediate table) and the translator reproduces it. Declaring nothing emits exactly the SQL this
+adapter emitted before the field existed — it cannot detect the omission, so silence is not a
+warning.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | **Caller-owned**, reproducible with `SubqueryFilter` | The `WHERE` clause of the query your application runs to load the relation when it builds the resource attributes. There is no ORM here to consult, so that clause exists only in your own code — the translator is given `Table`, `SourceColumn` and `TargetColumn` and reads the table bare |
+| Default scope on the target model | **Caller-owned**, reproducible with `SubqueryFilter` | A soft-delete column (`deleted_at IS NULL`), a tenant column, a `published` flag — anything every application read of that table filters on. Go has no default-scope construct here, so the convention lives in your own query code and only you can see it |
+| Subtype discrimination | **Caller-owned**, reproducible with `SubqueryFilter` | A `type`/`kind` discriminator column where one table holds several row kinds. Declare `{Column: "kind", Value: "…"}`, or `RestrictIn` over the kinds the association admits |
+| To-one relation used as a collection | **Caller-owned** | A relation whose `TargetColumn` has no unique index. The mapping carries no cardinality at all — every relation lowers to the same correlated subquery — so nothing makes the database enforce the single row the application saw. Add the unique constraint, or accept that the subquery examines every matching row |
+| Composite association key | **Rejected by the type system** | `SourceColumn` and `TargetColumn` are each one `string`, so a two-column key cannot be expressed. This is a compile error, not a wrong join |
+| Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain` and siblings) | None — every operator reached through a `Via` chain requires its intermediate hops separately, so a missing parent is UNKNOWN under both polarities ([#309](https://github.com/cerbos/query-plan-adapters/issues/309), [#315](https://github.com/cerbos/query-plan-adapters/issues/315)). Declaring `SubqueryFilter` on a `Hop` extends that to a parent the application *hides*, which for this purpose is equally absent |
+
+#### Declaring the application's own predicate
+
+```go
+tags := &cerbospgx.Relation{
+    Table:        "contact_tag",
+    SourceColumn: "id",
+    TargetColumn: "contact_id",
+    Field:        &cerbospgx.Entry{Column: "name"},
+    // Exactly the predicate your own reads of contact_tag apply.
+    SubqueryFilter: []cerbospgx.Restriction{
+        {Column: "deleted_at", Op: cerbospgx.RestrictIsNull},
+        {Column: "kind", Value: "label"},
+    },
+}
+```
+
+The vocabulary is deliberately narrow — `RestrictEq`, `RestrictNe`, `RestrictIsNull`,
+`RestrictIsNotNull`, `RestrictIn`, `RestrictNotIn` over a single column — because that is what these
+hazards look like in practice. A predicate that does not fit is a signal that the mapping cannot
+faithfully reproduce the application's read, and the honest response is to not map that relation
+rather than to declare an approximation.
+
+Restrictions are ANDed into the subquery's correlation predicate, so they narrow the rows the
+subquery *examines* rather than the rows it returns. That is what keeps them right under negation:
+`all` lowers to a false-witness `EXISTS`, and restricting the scan turns it into "every visible row
+satisfies the body" instead of "every row in the table does". They apply to every shape built on the
+relation — the truth witnesses, the UNKNOWN witness, the counts, and the hop-existence guard.
+
+Values are bound as query parameters, never interpolated. An empty `Values` list is read as CEL
+reads it: `RestrictIn` then hides every row, `RestrictNotIn` hides none.
 
 ### Known gaps
 

--- a/pgx/adapter.go
+++ b/pgx/adapter.go
@@ -29,6 +29,11 @@ type (
 	Relation = queryplan.Relation
 	// Hop is one intermediate table in a flattened relation chain.
 	Hop = queryplan.Hop
+	// Restriction is one caller-declared predicate on the rows a relation subquery may see.
+	// See Relation.SubqueryFilter and "Mapping hazards" in the README.
+	Restriction = queryplan.Restriction
+	// RestrictOp is the comparison a Restriction applies.
+	RestrictOp = queryplan.RestrictOp
 	// Mapper resolves plan variables to storage.
 	Mapper = queryplan.Mapper
 	// MapperMap is a static reference-to-entry table.
@@ -43,6 +48,16 @@ type (
 const (
 	ValueDefault   = queryplan.ValueDefault
 	ValueTimestamp = queryplan.ValueTimestamp
+)
+
+// Restriction comparisons, for Relation.SubqueryFilter and Hop.SubqueryFilter.
+const (
+	RestrictEq        = queryplan.RestrictEq
+	RestrictNe        = queryplan.RestrictNe
+	RestrictIsNull    = queryplan.RestrictIsNull
+	RestrictIsNotNull = queryplan.RestrictIsNotNull
+	RestrictIn        = queryplan.RestrictIn
+	RestrictNotIn     = queryplan.RestrictNotIn
 )
 
 // NULL-attribute representations.

--- a/pgx/internal/queryplan/mapper.go
+++ b/pgx/internal/queryplan/mapper.go
@@ -32,6 +32,23 @@ type Relation struct {
 	// for a direct relation and non-empty for a flattened chain such as
 	// `mainCategory.subCategories`, which reaches the resource through its category table.
 	Via []Hop
+	// SubqueryFilter is the predicate the application itself applies when it reads Table — a
+	// soft-delete flag, a tenant column, a subtype discriminator, whatever narrows the rows that
+	// became the resource attributes.
+	//
+	// The translator reads Table bare. It is given a table name and two column names and has no
+	// association metadata to consult, so nothing that narrows the application's own read reaches
+	// the generated subquery, and the subquery then examines rows the application never
+	// serialised — a filter that returns rows the PDP denies. Declaring the predicate here
+	// restores the equality. It is optional because the translator cannot detect the omission;
+	// leaving it empty emits exactly the SQL it emitted before the field existed. See "Mapping
+	// hazards" in the adapter's README.
+	//
+	// Entries are ANDed into the subquery's correlation predicate, so the restriction narrows the
+	// rows the subquery EXAMINES rather than the rows it returns. That is what keeps it right
+	// under negation: `all` lowers to a false-witness EXISTS, and restricting the scan turns it
+	// into "every visible row satisfies the body" instead of "every row in the table does".
+	SubqueryFilter []Restriction
 }
 
 // Hop is one intermediate table in a flattened relation chain.
@@ -43,6 +60,54 @@ type Hop struct {
 	ChildColumn string
 	// JoinColumn is the referenced column on this hop's table.
 	JoinColumn string
+	// SubqueryFilter restricts this hop's table the same way Relation.SubqueryFilter restricts
+	// the element table. A hop is read bare too, and it is the to-ONE parent whose absence must
+	// deny (#309) — a row the application's own reads hide is, for this purpose, absent.
+	SubqueryFilter []Restriction
+}
+
+// RestrictOp is the comparison a Restriction applies.
+type RestrictOp uint8
+
+const (
+	// RestrictEq is `column = value`. It is the zero value, so a Restriction that names only a
+	// column and a value is an equality.
+	RestrictEq RestrictOp = iota
+	// RestrictNe is `column <> value`. It does not match NULL columns; pair it with
+	// RestrictIsNull under an OR if the application's own predicate treats NULL as matching.
+	RestrictNe
+	// RestrictIsNull is `column IS NULL` — the usual soft-delete spelling.
+	RestrictIsNull
+	// RestrictIsNotNull is `column IS NOT NULL`.
+	RestrictIsNotNull
+	// RestrictIn is `column IN (values…)`. An empty Values list hides every row.
+	RestrictIn
+	// RestrictNotIn is `column NOT IN (values…)`. An empty Values list hides none.
+	RestrictNotIn
+)
+
+// Restriction is one caller-declared predicate on the rows a relation subquery may see.
+//
+// The vocabulary is deliberately narrow — equality, inequality, null tests and membership over a
+// single column — because that is what the hazards it exists for look like: a `deleted_at IS
+// NULL` soft delete, a `tenant_id = $1` scope, a `kind IN (…)` discriminator. A predicate that
+// does not fit is a signal that the mapping cannot faithfully reproduce the application's read,
+// and the honest response is to not map that relation rather than to declare an approximation.
+//
+// Value and Values are read according to Op, and the pairing is not enforced at compile time. It
+// does not need to be, because every way of getting it wrong FAILS CLOSED: Values alongside
+// RestrictEq leaves Value nil and renders `column = NULL`, which is UNKNOWN and admits nothing,
+// and Value alongside RestrictIn leaves Values empty, which folds to FALSE. A mismatched pairing
+// therefore hides rows rather than exposing them. TestRestrictionMismatchFailsClosed pins it.
+type Restriction struct {
+	// Value is compared with Column. Ignored by RestrictIsNull and RestrictIsNotNull.
+	Value any
+	// Column is a column on the table this restriction applies to, unqualified.
+	Column string
+	// Values is the membership list for RestrictIn and RestrictNotIn.
+	Values []any
+	// Op is the comparison. The zero value is RestrictEq.
+	Op RestrictOp
 }
 
 // ValueType marks an attribute whose stored representation needs special handling.

--- a/pgx/internal/queryplan/translate.go
+++ b/pgx/internal/queryplan/translate.go
@@ -395,6 +395,7 @@ func (b *builder) relationScope(rel *Relation, alias, parent string) ([]FromItem
 	from := make([]FromItem, 0, len(rel.Via)+1)
 	from = append(from, FromItem{Table: rel.Table, Alias: alias})
 	preds := make([]Expr, 0, len(rel.Via)+1)
+	preds = appendRestrictions(preds, alias, rel.SubqueryFilter)
 
 	inner := alias
 	for _, hop := range rel.Via {
@@ -405,6 +406,7 @@ func (b *builder) relationScope(rel *Relation, alias, parent string) ([]FromItem
 			L:  Column{Qualifier: inner, Name: hop.ChildColumn},
 			R:  Column{Qualifier: hopAlias, Name: hop.JoinColumn},
 		})
+		preds = appendRestrictions(preds, hopAlias, hop.SubqueryFilter)
 		inner = hopAlias
 	}
 
@@ -415,6 +417,46 @@ func (b *builder) relationScope(rel *Relation, alias, parent string) ([]FromItem
 	})
 
 	return from, and(preds...)
+}
+
+// appendRestrictions lowers the caller-declared store-side predicates for one table into the
+// conjunction that correlates its subquery.
+//
+// They go in beside the join rather than around the subquery so every shape built on the scope —
+// the truth witnesses, the UNKNOWN witness, the counts, the hop guard — inherits them without
+// each one having to remember to.
+func appendRestrictions(preds []Expr, alias string, restrictions []Restriction) []Expr {
+	for _, r := range restrictions {
+		col := Column{Qualifier: alias, Name: r.Column}
+		switch r.Op {
+		case RestrictEq:
+			preds = append(preds, Cmp{Op: OpEq, L: col, R: Lit{V: r.Value}})
+		case RestrictNe:
+			preds = append(preds, Cmp{Op: OpNe, L: col, R: Lit{V: r.Value}})
+		case RestrictIsNull:
+			preds = append(preds, IsNull{X: col})
+		case RestrictIsNotNull:
+			preds = append(preds, IsNull{X: col, Negate: true})
+		case RestrictIn, RestrictNotIn:
+			// CEL's own identities: membership in an empty list is false, so an empty IN hides
+			// every row and an empty NOT IN hides none. Spelling them as constants also keeps
+			// the renderer away from `IN ()`, which is a syntax error.
+			if len(r.Values) == 0 {
+				preds = append(preds, BoolConst{V: r.Op == RestrictNotIn})
+				continue
+			}
+			vs := make([]Expr, 0, len(r.Values))
+			for _, v := range r.Values {
+				vs = append(vs, Lit{V: v})
+			}
+			in := Expr(InList{X: col, Vs: vs})
+			if r.Op == RestrictNotIn {
+				in = Not{X: in}
+			}
+			preds = append(preds, in)
+		}
+	}
+	return preds
 }
 
 // hopsExist builds "every intermediate table of a flattened chain has a row", or nil when the
@@ -448,6 +490,9 @@ func (b *builder) hopsExist(rel *Relation, parent string) Expr {
 				R:  Column{Qualifier: hopAlias, Name: hop.JoinColumn},
 			})
 		}
+		// A hop the application's own reads hide is a hop that does not exist as far as the
+		// resource attributes are concerned, so the guard has to agree with relationScope here.
+		preds = appendRestrictions(preds, hopAlias, hop.SubqueryFilter)
 		inner = hopAlias
 	}
 

--- a/pgx/translate_test.go
+++ b/pgx/translate_test.go
@@ -453,3 +453,173 @@ func TestMapperQualifierCannotShadowGeneratedAliases(t *testing.T) {
 		"resource", mapper)
 	require.ErrorIs(t, err, cerbospgx.ErrUnsupported)
 }
+
+// -- mapping hazards: the caller-declared store-side predicate -------------------------------------
+
+// The class 1 mapping-hazard contract (README, "Mapping hazards"). This adapter is handed a table
+// name and two column names, so nothing the application applies to its own reads of that table
+// reaches the generated subquery. Relation.SubqueryFilter is how the caller closes that gap
+// (cerbos/query-plan-adapters#323).
+
+func hazardMapper(rel *cerbospgx.Relation) cerbospgx.Mapper {
+	return cerbospgx.MapperMap{
+		"request.resource.attr.name": {Column: "name"},
+		"request.resource.attr.tags": {Relation: rel},
+	}
+}
+
+func tagRelation(filter ...cerbospgx.Restriction) *cerbospgx.Relation {
+	return &cerbospgx.Relation{
+		Table:          "tag",
+		SourceColumn:   "id",
+		TargetColumn:   "resource_id",
+		Field:          &cerbospgx.Entry{Column: "name"},
+		Fields:         map[string]cerbospgx.Entry{"name": {Column: "name"}},
+		SubqueryFilter: filter,
+	}
+}
+
+func translateWith(t *testing.T, mapper cerbospgx.Mapper, cond *operand) cerbospgx.Result {
+	t.Helper()
+	result, err := cerbospgx.Translate(conditional(cond), "resource", mapper)
+	require.NoError(t, err)
+	return result
+}
+
+// tagsExists is `R.attr.tags.exists(t, t.name == "x")`.
+func tagsExists(t *testing.T) *operand {
+	t.Helper()
+	return expr("exists", variable("request.resource.attr.tags"),
+		expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))
+}
+
+// TestSubqueryFilterNarrowsEveryShapeBuiltOnTheRelation is the load-bearing assertion: the
+// declaration has to reach every subquery the translator builds over the relation, not just the
+// one the author of the feature happened to look at. A shape that misses it silently reverts to
+// reading the table bare.
+func TestSubqueryFilterNarrowsEveryShapeBuiltOnTheRelation(t *testing.T) {
+	t.Parallel()
+
+	visible := cerbospgx.Restriction{Column: "deleted_at", Op: cerbospgx.RestrictIsNull}
+
+	cases := []struct {
+		cond *operand
+		name string
+	}{
+		{name: "exists", cond: tagsExists(t)},
+		{name: "negated exists", cond: expr("not", tagsExists(t))},
+		{name: "all", cond: expr("all", variable("request.resource.attr.tags"),
+			expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))},
+		{name: "except", cond: expr("except", variable("request.resource.attr.tags"),
+			expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))},
+		{name: "exists_one", cond: expr("exists_one", variable("request.resource.attr.tags"),
+			expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))},
+		{name: "count", cond: expr("gt", expr("size", variable("request.resource.attr.tags")), val(t, 2))},
+		{name: "membership", cond: expr("in", val(t, "x"), variable("request.resource.attr.tags"))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bare := translateWith(t, hazardMapper(tagRelation()), tc.cond)
+			require.NotContains(t, bare.Where, "deleted_at",
+				"undeclared must emit exactly what it emitted before the field existed")
+
+			subqueries := strings.Count(bare.Where, `FROM "tag"`)
+			require.NotZero(t, subqueries, "sanity: this shape must build a subquery at all")
+
+			// A shape typically renders the relation more than once — a true witness and an
+			// UNKNOWN witness, or a count beside a guard. Counting the restriction against the
+			// number of subqueries is what catches one that picks it up only in some of them.
+			declared := translateWith(t, hazardMapper(tagRelation(visible)), tc.cond)
+			require.Equal(t, subqueries,
+				strings.Count(declared.Where, `"deleted_at" IS NULL`),
+				"every subquery over the relation must carry the declared restriction")
+		})
+	}
+}
+
+// TestSubqueryFilterRestrictsIntermediateHops covers the flattened chain. A hop is read bare too,
+// and it is the to-ONE parent whose absence must deny (#309) — a row the application hides is,
+// for that purpose, absent, so the hop guard has to agree with the element subquery.
+func TestSubqueryFilterRestrictsIntermediateHops(t *testing.T) {
+	t.Parallel()
+
+	rel := &cerbospgx.Relation{
+		Table:        "sub_category",
+		SourceColumn: "id",
+		TargetColumn: "category_id",
+		Fields:       map[string]cerbospgx.Entry{"name": {Column: "name"}},
+		Via: []cerbospgx.Hop{{
+			Table:          "category",
+			ChildColumn:    "category_id",
+			JoinColumn:     "id",
+			SubqueryFilter: []cerbospgx.Restriction{{Column: "kind", Value: "main"}},
+		}},
+	}
+	mapper := cerbospgx.MapperMap{
+		"request.resource.attr.chain": {Relation: rel},
+	}
+	cond := expr("not", expr("exists", variable("request.resource.attr.chain"),
+		expr("lambda", expr("eq", variable("s.name"), val(t, "x")), variable("s"))))
+
+	result, err := cerbospgx.Translate(conditional(cond), "resource", mapper)
+	require.NoError(t, err)
+
+	// The negated macro renders the element subquery twice (true and UNKNOWN witnesses) and the
+	// hop-existence guard once, and all three read `category`. The guard is the one that matters:
+	// without the restriction it answers "the parent exists" for a parent the application hides,
+	// which is what turns the #309 fix back into an over-grant.
+	require.Equal(t, 3, strings.Count(result.Where, `"category" AS `))
+	require.Equal(t, 3, strings.Count(result.Where, `"kind" = `),
+		"the hop guard must restrict the hop the same way the element subquery does")
+}
+
+// TestSubqueryFilterMembershipEdges pins the two list identities. `IN ()` is a syntax error, so
+// the empty cases have to fold to constants rather than reach the renderer.
+func TestSubqueryFilterMembershipEdges(t *testing.T) {
+	t.Parallel()
+
+	cond := tagsExists(t)
+
+	empty := translateWith(t, hazardMapper(tagRelation(
+		cerbospgx.Restriction{Column: "kind", Op: cerbospgx.RestrictIn})), cond)
+	require.NotContains(t, empty.Where, "IN ()")
+	require.Contains(t, empty.Where, "FALSE", "membership in an empty list hides every row")
+
+	emptyNot := translateWith(t, hazardMapper(tagRelation(
+		cerbospgx.Restriction{Column: "kind", Op: cerbospgx.RestrictNotIn})), cond)
+	require.NotContains(t, emptyNot.Where, "IN ()")
+	require.Contains(t, emptyNot.Where, "TRUE", "non-membership in an empty list hides none")
+
+	listed := translateWith(t, hazardMapper(tagRelation(
+		cerbospgx.Restriction{Column: "kind", Op: cerbospgx.RestrictIn, Values: []any{"a", "b"}})), cond)
+	require.Contains(t, listed.Where, `"kind" IN (`)
+	require.NotContains(t, listed.Where, "'a'", "the declared values are bound, never interpolated")
+	require.Contains(t, listed.Args, "a")
+	require.Contains(t, listed.Args, "b")
+}
+
+// TestRestrictionMismatchFailsClosed pins the safety property that makes Restriction's
+// Value/Values pairing safe to leave unenforced: getting it wrong hides rows, never exposes them.
+// A sum type with a constructor would be tidier, but this is the property that actually matters
+// for an authorization filter, so it is asserted rather than assumed.
+func TestRestrictionMismatchFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cond := tagsExists(t)
+
+	// Values supplied where Op reads Value: the comparison renders against NULL, which is
+	// UNKNOWN, so the subquery matches nothing.
+	valuesOnEq := translateWith(t, hazardMapper(tagRelation(
+		cerbospgx.Restriction{Column: "kind", Op: cerbospgx.RestrictEq, Values: []any{"a"}})), cond)
+	require.Contains(t, valuesOnEq.Where, `"kind" = NULL`)
+	require.NotContains(t, valuesOnEq.Args, "a")
+
+	// Value supplied where Op reads Values: the empty list folds to FALSE.
+	valueOnIn := translateWith(t, hazardMapper(tagRelation(
+		cerbospgx.Restriction{Column: "kind", Op: cerbospgx.RestrictIn, Value: "a"})), cond)
+	require.Contains(t, valueOnIn.Where, "FALSE")
+	require.NotContains(t, valueOnIn.Args, "a")
+}

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -141,6 +141,46 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `checkResource` d
 
 The fail-closed set consists of literal `LIKE` cases Prisma cannot escape safely, cross-model field references, arbitrary relation counts and string lengths, `exists_one`, unsolved column arithmetic, sub-millisecond `now()` thresholds, and the reference probes for regex, ordered indexing, and `timestamp()` over a string field. Supported timestamp plans require a mapper entry with `valueType: "dateTime"` and a strict, millisecond-exact RFC 3339 literal in CEL's supported instant range. These shapes throw instead of producing a broader authorization filter.
 
+### Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the filter select the rows `check()` allows. The other half is the *mapping*: **the records the nested filter reads must be the records the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter names a Prisma relation, so the mapping *looks* as though the ORM will apply the application's own narrowing to the nested `some`/`every`/`none`. **It will not.** Prisma has no schema-level filtered relation and no `@Where` equivalent; a `where` injected by a client extension or by `$extends`/middleware rewrites the top-level query and leaves nested relation filters untouched. In corpus terms this adapter is class 1 — a **bare-table subquery** — despite naming a relation.
+
+Where the application narrows its own reads of a related model, declare the same predicate as [`subqueryFilter`](#declaring-the-applications-own-predicate) on the relation and the adapter reproduces it. Declaring nothing emits exactly the filter this adapter emitted before the field existed — it cannot detect the omission, so silence is not a warning.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | **Caller-owned**, reproducible with `subqueryFilter` | A `$extends`/`$use` client extension or middleware that injects a `where` for the related model, or a repository helper that always appends one. None of them rewrite the nested filter this adapter returns |
+| Default scope on the target model | **Caller-owned**, reproducible with `subqueryFilter` | A soft-delete column (`deletedAt: null`), a tenant column, a `published` flag — anything every application read of the related model filters on. Prisma has no default-scope construct, so the convention lives in your own query code and only you can see it |
+| Subtype discrimination | **Caller-owned**, reproducible with `subqueryFilter` | A `type`/`kind` discriminator column where one model holds several row kinds. Declare `{ type: "…" }` |
+| To-one relation used as a collection | **Rejected by Prisma** | A `type: "one"` mapping compiles to `is`, an argument Prisma only accepts on a relation its own schema declares to-one, and `@relation(references: …)` must already point at a unique field. Mapping a to-many relation as `type: "one"` is therefore a query-validation error from Prisma, not a silently wider subquery |
+| Composite association key | **Reproduced by Prisma** | Prisma resolves multi-column foreign keys itself from `@relation(fields: […], references: […])`. The mapping names the relation, never its columns, so there is no key for the adapter to get wrong |
+| Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain` and siblings) | None — every operator reached through a relation chain requires its intermediate hops separately, so a missing parent stays denied under both polarities ([#309](https://github.com/cerbos/query-plan-adapters/issues/309), [#315](https://github.com/cerbos/query-plan-adapters/issues/315)) |
+
+#### Declaring the application's own predicate
+
+```ts
+const result = queryPlanToPrisma({
+  queryPlan,
+  mapper: {
+    "request.resource.attr.tags": {
+      relation: {
+        name: "tags",
+        type: "many",
+        field: "name",
+        // Exactly the predicate your own reads of `Tag` apply.
+        subqueryFilter: { deletedAt: null, kind: "label" },
+      },
+    },
+  },
+});
+```
+
+`subqueryFilter` is a Prisma where-input over the *related* model. It is ANDed into the nested filter, so it narrows the records the subquery *examines* rather than the records it requires, and it applies to every operator reached through the relation — `exists`, `all`, `except`, membership, `hasIntersection`, emptiness checks — and to the hop-existence guard, so an intermediate hop must exist *and* be visible.
+
+`all()` is the one operator that cannot simply absorb the predicate: `every: AND(declared, P)` would *require* every record to satisfy the declaration, which is the opposite of ignoring what the application hides. It is rewritten to `none: AND(declared, NOT P)` — no visible record violates `P`. Note the consequence, which is correct rather than surprising: if the declaration hides every record of a relation, `all()` over it is vacuously true, exactly as it is for the application, which sends `check()` an empty list for the same reason.
+
 ## Requirements
 
 - Cerbos > v0.40
@@ -320,7 +360,9 @@ const result = queryPlanToPrisma({
 
 ### Relations Mapping
 
-Relations are mapped with their types and optional field configurations. Fields can be automatically inferred from the path if not explicitly mapped:
+Relations are mapped with their types and optional field configurations. Fields can be automatically inferred from the path if not explicitly mapped.
+
+The nested filters this produces read the related model unfiltered — Prisma has no schema-level filtered relation, and an injected `where` does not reach them. If your own reads of that model apply a predicate, declare it as `subqueryFilter` on the relation. See [Mapping hazards](#mapping-hazards).
 
 ```ts
 const result = queryPlanToPrisma({

--- a/prisma/src/index.test.ts
+++ b/prisma/src/index.test.ts
@@ -1,4 +1,5 @@
 import { queryPlanToPrisma, PlanKind, QueryPlanToPrismaResult } from ".";
+import type { Mapper } from ".";
 import {
   beforeAll,
   beforeEach,
@@ -8984,5 +8985,147 @@ describe("Promoted adversarial planner shapes", () => {
     }
     expect(JSON.stringify(result.filters)).toContain('"name":null');
     expect(JSON.stringify(result.filters)).toContain('"NOT":{"categories"');
+  });
+});
+
+// The class 1 mapping-hazard contract (README, "Mapping hazards"). Prisma names a relation, so
+// the mapping LOOKS as if the ORM will apply the application's own narrowing to the nested
+// filter. It does not: Prisma has no schema-level filtered relation, and a `where` injected by a
+// client extension or middleware rewrites the top-level query only. `subqueryFilter` is how the
+// caller closes that gap (cerbos/query-plan-adapters#323).
+describe("relation subqueryFilter", () => {
+  // The application's own reads of `tags` hide the "hidden" tag; the resource attributes it
+  // sends to check() therefore never mention it.
+  const VISIBLE_ONLY = { name: { not: "hidden" } };
+
+  const mapperFor = (subqueryFilter?: Record<string, unknown>): Mapper => ({
+    "request.resource.attr.tags": {
+      relation: {
+        name: "tags",
+        type: "many",
+        fields: { name: { field: "name" } },
+        ...(subqueryFilter ? { subqueryFilter } : {}),
+      },
+    },
+  });
+
+  const lambda = (operator: string, value: string): PlanExpressionOperand =>
+    ({
+      operator: "lambda",
+      operands: [
+        { operator, operands: [{ name: "t.name" }, { value }] },
+        { name: "t" },
+      ],
+    }) as PlanExpressionOperand;
+
+  const macro = (
+    name: string,
+    body: PlanExpressionOperand
+  ): PlanResourcesResponse =>
+    createConditionalPlan({
+      operator: name,
+      operands: [{ name: "request.resource.attr.tags" }, body],
+    } as PlanExpressionOperand);
+
+  const idsFor = async (
+    queryPlan: PlanResourcesResponse,
+    subqueryFilter?: Record<string, unknown>
+  ): Promise<string[]> => {
+    const result = queryPlanToPrisma({
+      queryPlan,
+      mapper: mapperFor(subqueryFilter),
+    });
+    if (result.kind !== PlanKind.CONDITIONAL) {
+      throw new Error(`Expected CONDITIONAL result, got ${result.kind}`);
+    }
+    const rows = await prisma.resource.findMany({
+      where: result.filters,
+      select: { id: true },
+    });
+    return rows.map((row) => row.id).sort();
+  };
+
+  beforeEach(async () => {
+    await prisma.tag.create({ data: { id: "tagHidden", name: "hidden" } });
+    // resource1's visible tags are ["public"]; resource4 has nothing visible at all.
+    await prisma.resource.update({
+      where: { id: "resource1" },
+      data: { tags: { connect: [{ id: "tagHidden" }] } },
+    });
+    await prisma.resource.create({
+      data: {
+        id: "resource4",
+        aBool: true,
+        aNumber: 4,
+        aString: "string4",
+        createdBy: { connect: { id: "user1" } },
+        nested: { connect: { id: "nested1" } },
+        tags: { connect: [{ id: "tagHidden" }] },
+      },
+    });
+  });
+
+  test("declared: exists() sees only the records the application serialised", async () => {
+    const plan = macro("exists", lambda("eq", "hidden"));
+
+    // Undeclared, the nested `some` matches records the application's own reads hide — the
+    // over-grant cerbos/query-plan-adapters#314 catalogues.
+    expect(await idsFor(plan)).toEqual(["resource1", "resource4"]);
+    expect(await idsFor(plan, VISIBLE_ONLY)).toEqual([]);
+  });
+
+  test("declared: all() narrows the records examined, not the records required", async () => {
+    const plan = macro("all", lambda("eq", "public"));
+
+    // `every: AND(visible, P)` would REQUIRE every record to be visible, excluding resource1
+    // for holding a hidden tag. The rewrite to `none: AND(visible, NOT P)` is what makes the
+    // declaration mean "ignore what the application hides".
+    //
+    // resource4 is the empty-collection case and belongs in the allowed set: once the hidden
+    // tag is excluded it has no tags at all, and CEL's all() over an empty collection is
+    // vacuously TRUE — which is exactly what check() answers, because the application sends it
+    // an empty `tags` list for the same reason.
+    expect(await idsFor(plan)).toEqual([]);
+    expect(await idsFor(plan, VISIBLE_ONLY)).toEqual(["resource1", "resource4"]);
+  });
+
+  test("declared: an emptiness check counts only the visible records", async () => {
+    const plan = createConditionalPlan({
+      operator: "gt",
+      operands: [
+        {
+          operator: "size",
+          operands: [{ name: "request.resource.attr.tags" }],
+        },
+        { value: 0 },
+      ],
+    } as PlanExpressionOperand);
+
+    expect(await idsFor(plan)).toContain("resource4");
+    expect(await idsFor(plan, VISIBLE_ONLY)).not.toContain("resource4");
+  });
+
+  test("undeclared: the emitted filter is identical to before the field existed", async () => {
+    // The non-breaking guarantee. Silence must not add a clause, and must not warn.
+    const plan = macro("exists", lambda("eq", "public"));
+    const withoutField = queryPlanToPrisma({
+      queryPlan: plan,
+      mapper: {
+        "request.resource.attr.tags": {
+          relation: {
+            name: "tags",
+            type: "many",
+            fields: { name: { field: "name" } },
+          },
+        },
+      },
+    });
+    const withUndefined = queryPlanToPrisma({
+      queryPlan: plan,
+      mapper: mapperFor(undefined),
+    });
+
+    expect(withUndefined).toStrictEqual(withoutField);
+    expect(JSON.stringify(withoutField)).not.toContain("hidden");
   });
 });

--- a/prisma/src/index.ts
+++ b/prisma/src/index.ts
@@ -135,6 +135,29 @@ export type MapperConfig = {
     model?: string;
     field?: string;
     fields?: Record<string, MapperConfig>;
+    /**
+     * The predicate the application itself applies when it reads this relation — a soft-delete
+     * flag, a tenant column, a subtype discriminator, whatever narrows the rows that became the
+     * resource attributes.
+     *
+     * Prisma has no schema-level filtered relation. A `where` injected by a client extension or
+     * middleware rewrites the *top-level* query, never the nested `some`/`every`/`none` this
+     * adapter generates, so a narrowing the application applies to its own reads does not reach
+     * the subquery — and the subquery then matches records the application never serialised, a
+     * filter that returns rows the PDP denies. Declaring the predicate here restores the
+     * equality; the adapter cannot detect the omission, which is why the field is optional and
+     * silence is not a warning. See "Mapping hazards" in the README.
+     *
+     * It is a Prisma where-input over the RELATED model, ANDed into the nested filter, and it
+     * constrains every operator reached through this relation under both polarities. `every` is
+     * rewritten to the equivalent `none` so the restriction narrows the records examined rather
+     * than the records required to match.
+     *
+     * ```ts
+     * relation: { name: "tags", type: "many", subqueryFilter: { deletedAt: null } }
+     * ```
+     */
+    subqueryFilter?: PrismaFilter;
   };
 };
 
@@ -447,6 +470,7 @@ type RelationConfig = {
   model?: string;
   field?: string;
   nestedMapper?: Record<string, MapperConfig>;
+  subqueryFilter?: PrismaFilter;
 };
 
 type ResolvedFieldReference = {
@@ -1050,6 +1074,7 @@ function resolveFieldReference(
         model: activeConfig.relation.model,
         field: activeConfig.relation.field,
         nestedMapper: fields,
+        subqueryFilter: activeConfig.relation.subqueryFilter,
       },
     ];
 
@@ -1076,6 +1101,7 @@ function resolveFieldReference(
             model: nextConfig.relation.model,
             field: nextConfig.relation.field,
             nestedMapper: nextConfig.relation.fields,
+            subqueryFilter: nextConfig.relation.subqueryFilter,
           });
           currentMapper = nextConfig.relation.fields || {};
           currentParts = currentParts.slice(1);
@@ -1116,6 +1142,39 @@ function getPrismaRelationOperator(relation: {
 }
 
 /**
+ * One relation-scoped filter (`{ tags: { some: … } }`), narrowed by the store-side predicate the
+ * caller declared on the mapping.
+ *
+ * Every nested relation filter the adapter emits goes through here, so a declared
+ * `subqueryFilter` reaches the collection macros, the membership shapes, the emptiness checks and
+ * the hop-existence guard alike. Adding a new relation shape means routing it through here, or
+ * the declaration silently stops applying to it.
+ *
+ * `every` is the one operator that cannot simply absorb the predicate. `{ every: AND(W, P) }`
+ * would REQUIRE every record to satisfy W, which is the opposite of "ignore the records W hides",
+ * so it is rewritten to `{ none: AND(W, NOT P) }` — no visible record violates P. Both agree with
+ * `every` when nothing is declared, and both stay vacuously true over an empty relation.
+ */
+function relationFilter(
+  relation: RelationConfig,
+  operator: string,
+  inner: PrismaFilter
+): PrismaFilter {
+  const declared = relation.subqueryFilter;
+  if (declared === undefined) {
+    return { [relation.name]: { [operator]: inner } };
+  }
+  const narrow = (filter: PrismaFilter): PrismaFilter =>
+    Object.keys(filter).length === 0 ? declared : { AND: [declared, filter] };
+  if (operator === "every") {
+    return Object.keys(inner).length === 0
+      ? { [relation.name]: { every: inner } }
+      : { [relation.name]: { none: { AND: [declared, { NOT: inner }] } } };
+  }
+  return { [relation.name]: { [operator]: narrow(inner) } };
+}
+
+/**
  * Builds a nested relation filter for Prisma queries.
  */
 /**
@@ -1144,9 +1203,9 @@ function buildLeadingHopsExistFilter(
       restRelations[i],
       "Relation mapping is missing"
     );
-    inner = { [relation.name]: { [getPrismaRelationOperator(relation)]: inner } };
+    inner = relationFilter(relation, getPrismaRelationOperator(relation), inner);
   }
-  return { [head.name]: { [getPrismaRelationOperator(head)]: inner } };
+  return relationFilter(head, getPrismaRelationOperator(head), inner);
 }
 
 /**
@@ -1248,7 +1307,7 @@ function buildNestedRelationFilter(
       }
     }
 
-    currentFilter = { [relation.name]: { [relationOperator]: currentFilter } };
+    currentFilter = relationFilter(relation, relationOperator, currentFilter);
   }
 
   return currentFilter;
@@ -2049,7 +2108,7 @@ function handleSizeComparison(
   }
 
   const prismaOp = isNonEmpty ? "some" : "none";
-  const leafFilter = { [deepest.name]: { [prismaOp]: {} } };
+  const leafFilter = relationFilter(deepest, prismaOp, {});
 
   if (relations.length === 1) {
     return leafFilter;
@@ -2778,7 +2837,7 @@ function wrapCollectionElementFilter(
     parts.restRelations.length > 0
       ? buildNestedRelationFilter(parts.restRelations, elementFilter)
       : elementFilter;
-  return { [parts.head.name]: { some: inner } };
+  return relationFilter(parts.head, "some", inner);
 }
 
 function throwUnsupportedCollectionOperator(operator: string): never {
@@ -2823,7 +2882,7 @@ function handleCollectionOperator(
     case "exists": {
       // A NULL element keeps the per-element predicate UNKNOWN, so it can never create a
       // false positive here; a CEL error (deny) coincides with "no match" — no guard needed.
-      const filter = { [head.name]: { some: filterValue } };
+      const filter = relationFilter(head, "some", filterValue);
       const unknownElement = buildUnknownElementFilter(parts);
       if (unknownElement !== undefined) {
         recordNestedCollectionUnknownFilter({
@@ -2836,14 +2895,14 @@ function handleCollectionOperator(
       return filter;
     }
     case "except":
-      return { [head.name]: { some: { NOT: filterValue } } };
+      return relationFilter(head, "some", { NOT: filterValue });
     case "all": {
       if (parts.restRelations.length > 0) {
         throw new Error(
           "all() over a multi-hop relation chain is not supported"
         );
       }
-      const base = { [head.name]: { every: filterValue } };
+      const base = relationFilter(head, "every", filterValue);
       if (nullableFields.size === 0) {
         return base;
       }
@@ -2854,7 +2913,7 @@ function handleCollectionOperator(
       return {
         AND: [
           base,
-          { [head.name]: { none: buildNullWitnessFilter(nullableFields) } },
+          relationFilter(head, "none", buildNullWitnessFilter(nullableFields)),
         ],
       };
     }
@@ -2902,7 +2961,7 @@ function buildNegatedCollectionFilter(
   switch (operator) {
     case "exists": {
       const base = requireLeadingHops({
-        NOT: { [head.name]: { some: filterValue } },
+        NOT: relationFilter(head, "some", filterValue),
       });
       const unknownElement = buildUnknownElementFilter(parts);
       if (unknownElement === undefined) {
@@ -2925,19 +2984,19 @@ function buildNegatedCollectionFilter(
     case "all":
       // !all is TRUE only with a definitive false witness, which also absorbs error
       // elements — exactly `some(NOT P)` in SQL (NULL columns keep NOT P UNKNOWN).
-      return { [head.name]: { some: { NOT: filterValue } } };
+      return relationFilter(head, "some", { NOT: filterValue });
     case "except": {
       // !except(c,P) = every element definitively matches P.
-      const base = requireLeadingHops({
-        [head.name]: { none: { NOT: filterValue } },
-      });
+      const base = requireLeadingHops(
+        relationFilter(head, "none", { NOT: filterValue })
+      );
       if (nullableFields.size === 0) {
         return base;
       }
       return {
         AND: [
           base,
-          { [head.name]: { none: buildNullWitnessFilter(nullableFields) } },
+          relationFilter(head, "none", buildNullWitnessFilter(nullableFields)),
         ],
       };
     }

--- a/spring-data/README.md
+++ b/spring-data/README.md
@@ -175,6 +175,8 @@ Map each `request.resource.attr.<name>` to a JPA path or a relation:
 
 `Field("nested.aBool")` traverses embeddables via JPA `Path.get(...)`. Use it for both simple columns and `@Embedded` paths.
 
+`relation(...)` names a JPA association, so the correlated subquery is a criteria association join and Hibernate applies the association's own `@SQLRestriction` and discriminator to it. That is why there is no option here to declare a store-side predicate — see [Mapping hazards](#mapping-hazards).
+
 ## Supported operators
 
 | Cerbos operator                  | JPA Criteria translation                                            |
@@ -292,6 +294,27 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 | Known planner divergence | `has()` on a missing attribute is folded by the Cerbos planner to `ALWAYS_ALLOWED`, while `check()` denies the missing-attribute rows; this is pinned separately as an upstream divergence |
 
 The oracle coverage includes value-first and field-to-field comparisons, literal-safe string matching, nested and correlated collection macros, three-valued null/error propagation, arithmetic and ternaries, hierarchy operations, timestamp comparisons on supported absolute-instant columns, and multi-hop relations. Unsupported shapes throw before a predicate can be used — including the two conformance shapes this reference cannot express itself (`cr-div-then-add`, `cr-div-then-add-ne`): CEL carries a NaN through the surrounding arithmetic and SQL has no value that does.
+
+## Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the predicate select the rows `check()` allows. The other half is the *mapping*: **the rows the subquery reads must be the rows the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+This adapter builds an **ORM-association subquery.** `AttributeMapping.relation("tags")` names a JPA association, and the correlated subquery reaches it with `correlate(root).join("tags")` — a criteria association join, not a query over a bare table. Everything Hibernate applies to that association it applies here too, which closes most of the grid without any work by the caller.
+
+**There is deliberately no option to declare a store-side predicate on the mapping**, unlike the bare-table adapters (drizzle, ent, pgx, prisma). If there were, a caller could declare a filter Hibernate already applies; it would then be applied twice, silently removing rows the PDP permits — an under-grant nothing in the differential suite would catch, because the caller's own reads would still show the rows. **Your association filters are already applied; do not re-declare them.**
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | **Reproduced by Hibernate** | `@SQLRestriction` (`@Where` before 6.3) on the collection attribute is applied however the collection is reached, including an explicit join, so the subquery sees exactly the association's rows. The exception is `@Filter`, which only applies while it is *enabled on the session*: enable it on the same session that runs the `Specification`, and note that Hibernate does not apply filters to `EntityManager.find()`, so an application that builds attributes through `find()` and filters through queries has two views and the adapter follows the query one |
+| Default scope on the target model | **Reproduced by Hibernate** | `@SQLRestriction` on the target *entity* is applied to every query that loads it, this subquery included. A soft-delete implemented as a repository convention rather than an annotation is not — move it to `@SQLRestriction` so both sides see it |
+| Subtype discrimination | **Reproduced by Hibernate** | The single-table discriminator restriction is added whenever the join's target type is a subclass, so an association typed to a `@DiscriminatorValue` subclass is restricted to it. Declaring the association to the *base* type sees the siblings — which is also what the application sees, so the two still agree |
+| To-one relation used as a collection | **Caller-owned** | A `@OneToOne(mappedBy = …)` whose foreign key carries no unique constraint. JPA believes the cardinality the mapping declares; the database is what has to enforce it. Add the unique constraint |
+| Composite association key | **Reproduced by JPA** | The mapping names the association, never its columns, so Hibernate resolves `@JoinColumns` itself. There is no key for the adapter to get wrong |
+| Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain` and siblings) | None — a chained relation requires its intermediate hops separately, so a missing parent is UNKNOWN under both polarities ([#309](https://github.com/cerbos/query-plan-adapters/issues/309)) |
+
+The three "Reproduced by Hibernate" rows are claims about Hibernate, not about this adapter, so they are worth being able to check: entity- and collection-level `@SQLRestriction` are documented in the [Hibernate user guide](https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#pc-where), and Hibernate's own `OneToManySQLRestrictionTests` pins the collection restriction being applied however the collection is reached, an explicit join included. Verify against the Hibernate version you actually run before relying on a row here — a wrong claim in this table is worse than no claim.
+
+One consequence of being an association subquery rather than a bare-table one is worth stating: this adapter is only as correct as the mapping is honest. A `@SQLRestriction` you add for the query side but not for the read path that builds the resource attributes makes the two disagree in the *other* direction. Keep one definition of what the association contains.
 
 ## Gotchas
 

--- a/sqlalchemy/README.md
+++ b/sqlalchemy/README.md
@@ -50,6 +50,61 @@ The adapter is differentially tested against Cerbos PDP 0.54.0 `check()` decisio
 
 The conformance harness supplies the same public `operator_override_fns` mechanism available to applications for schema-specific collection translations. Regex `matches()` fails closed by default because SQL dialect regex engines do not guarantee CEL/RE2 semantics; applications may provide an override only when their database translation is known to be equivalent. Timestamp literals must use strict RFC 3339 grammar, resolve inside CEL's supported year 0001–9999 instant range, and be exactly representable at Python/SQLAlchemy microsecond precision: discarded fractional digits must be zero, and the mapped column/database must preserve microseconds. Unsupported shapes raise instead of producing a broader query.
 
+## Mapping hazards
+
+The conformance contract above proves the *plan* side — given a policy shape, does the query select the rows `check()` allows. The other half is the *mapping*: **the rows a subquery reads must be the rows the application put into the resource attributes.** Six ways that can break are catalogued in the shared corpus, and every adapter has to record a position on each of them.
+
+**`get_query` has no relation model.** `attr_map` maps attribute references to columns; a collection-valued attribute reaches its rows entirely through [`operator_override_fns`](#overriding-default-predicates), which means *you* write the correlated subquery. Every hazard below is therefore caller-owned here, and which of them apply depends on how you write it:
+
+- Through a mapped **`relationship()`** — `Model.rel.any(...)`, `Model.rel.has(...)`, `select(...).join(Model.rel)` — SQLAlchemy applies the relationship's `primaryjoin` and, for a single-table-inheritance target, the discriminator criteria. Those hazards are closed by the ORM.
+- Through a **hand-written correlated `select()`** over columns, which is what the adversarial harness does, none of that applies. You are reading the table bare and the invariant is yours end to end.
+
+The single-table-inheritance half of that is [documented here](https://docs.sqlalchemy.org/en/20/orm/queryguide/inheritance.html#single-inheritance-mappings) — a `select(Subclass)` adds the discriminator to the `WHERE`. Check both against the SQLAlchemy version you actually run before relying on a row below.
+
+| Hazard | Position | Mechanism to check |
+|---|---|---|
+| Filtered association | **Caller-owned** | `relationship(primaryjoin=…)` and `relationship(secondaryjoin=…)`. Going through `.any()`/`.has()` applies them; a hand-written `select()` over the target's columns does not, and must repeat the predicate in its own `where()` |
+| Default scope on the target model | **Caller-owned** | A soft-delete column (`deleted_at IS NULL`), a tenant column, a `published` flag, or a `with_loader_criteria` you register on the session. SQLAlchemy applies none of those to a subquery you build yourself |
+| Subtype discrimination | **Caller-owned** | `polymorphic_identity` on a single-table-inheritance subclass. `select(Subclass)` carries the discriminator; `select(literal(1)).where(subclass_table.c.x == …)` over the shared table does not, and sees the sibling subtypes |
+| To-one relation used as a collection | **Caller-owned** | A `relationship(uselist=False)` whose foreign key has no unique constraint. Nothing in the override mechanism makes the database enforce the single row the application saw — add the constraint |
+| Composite association key | **Caller-owned** | A multi-column foreign key. Unlike the adapters that take one source and one target column, an override is arbitrary SQLAlchemy, so a composite key *is* expressible — which also means nothing stops you writing half of it. Conjoin every column pair |
+| Absent to-one parent | **Reproduced by `require_hops`**, and proved by the corpus (`w1-all-chain` and siblings) | `cerbos_sqlalchemy.require_hops` — see below. Call it from every override that reaches a collection through an intermediate to-one hop |
+
+### `require_hops`: the one hazard with a library helper
+
+CEL cannot dot through a list, so every intermediate segment of `a.b.c` is a to-ONE parent. When it is absent the application sends no attribute at all and CEL raises a missing-path error, which denies — but a subquery rooted at the resource row cannot tell an absent parent from a childless one, so `all` reads TRUE, `!exists` reads TRUE and the count reads 0, each admitting rows the PDP denies ([#309](https://github.com/cerbos/query-plan-adapters/issues/309)).
+
+That requirement is mechanical, identical for every caller, and easy to get subtly wrong, so it ships in the library rather than being left as advice:
+
+```python
+from cerbos_sqlalchemy import get_query, require_hops
+from sqlalchemy import exists, literal, select
+
+# `mainCategory.subCategories`: the collection is reached THROUGH the category hop.
+HOP = [Category.resource_id == Resource.id]
+CORRELATE = [Resource]
+
+def sub_categories_exists(collection, body):
+    subquery = (
+        select(literal(1))
+        .where(SubCategory.category_id == Category.id)
+        .where(Category.resource_id == Resource.id)
+        .where(body)
+        .correlate(*CORRELATE)
+    )
+    return require_hops(exists(subquery), HOP, CORRELATE)
+
+query = get_query(
+    plan, Resource, attr_map, operator_override_fns={"exists": sub_categories_exists}
+)
+```
+
+`require_hops` wraps the answer in a `CASE` with **no `ELSE`**: a missing hop yields NULL, and `NOT NULL` is still NULL, so the row stays excluded under both polarities. A direct relation — an empty `hop_correlation` — is returned unchanged, so `!tags.exists(...)` over zero tags is still TRUE.
+
+Every operator whose answer comes off a chain has to go through it, not just the collection macros. A bare `EXISTS` is two-valued, so it is FALSE for an absent parent and its negation is TRUE — which is how plain membership and `hasIntersection` kept readmitting every parentless row after the macros alone were fixed ([#315](https://github.com/cerbos/query-plan-adapters/issues/315)), and how `!(size(chain) > 0)` did the same ([#316](https://github.com/cerbos/query-plan-adapters/issues/316)).
+
+It is **optional**, and calling it is not enforced: a caller wiring a join chain today gets exactly the query it got before the helper existed. Making it mandatory would mean raising for every such caller, a consumer-visible break to guard a hazard many of them do not have.
+
 ## Requirements
 - Cerbos > v0.16
 - SQLAlchemy >= 1.4 / 2.0

--- a/sqlalchemy/src/cerbos_sqlalchemy/__init__.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/__init__.py
@@ -1,7 +1,8 @@
 import importlib.metadata
 
 from cerbos_sqlalchemy.query import get_query
+from cerbos_sqlalchemy.relations import require_hops
 
 __version__ = importlib.metadata.version(__package__ or __name__)
 
-__all__ = ["get_query"]
+__all__ = ["get_query", "require_hops"]

--- a/sqlalchemy/src/cerbos_sqlalchemy/relations.py
+++ b/sqlalchemy/src/cerbos_sqlalchemy/relations.py
@@ -1,0 +1,74 @@
+"""Helpers for the parts of a mapping this adapter cannot own.
+
+``get_query`` has no relation model. A collection-valued attribute reaches its rows
+entirely through ``operator_override_fns``: the caller writes the correlated
+subquery, so the caller owns the invariant that the subquery sees exactly the rows
+the application serialised into the resource attributes. That is the right split —
+only the caller knows whether its association is a ``relationship()``, a Core join
+or a soft-deleted table — but one part of it is not a judgement call, it is a
+mechanical requirement every join chain has, and every caller has to get it right
+the same way. This module holds that part.
+
+See "Mapping hazards" in the README, and ``conformance/README.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from sqlalchemy import case, exists, literal, select
+
+__all__ = ["require_hops"]
+
+
+def require_hops(
+    expression: Any,
+    hop_correlation: Sequence[Any],
+    correlate: Sequence[Any] = (),
+) -> Any:
+    """Make ``expression`` UNKNOWN unless every intermediate to-one hop exists.
+
+    CEL cannot dot through a list, so every intermediate segment of ``a.b.c`` is a
+    to-ONE parent: when it is absent the application sends no attribute at all and
+    CEL raises a missing-path error, which denies. A subquery rooted at the resource
+    row cannot see that -- an absent parent and a childless parent both return
+    nothing -- so ``all`` reads TRUE, ``!exists`` reads TRUE and the count reads 0,
+    each admitting rows the PDP denies (cerbos/query-plan-adapters#309).
+
+    Wrapping the answer in this guard restores the distinction. The ``CASE`` has no
+    ``ELSE`` on purpose: a missing hop yields NULL, and ``NOT NULL`` is still NULL,
+    so the row stays excluded under BOTH polarities.
+
+    **Every** operator whose answer comes off a chain has to go through here, not
+    just the collection macros. A bare ``EXISTS`` is two-valued, so it is FALSE for
+    an absent to-one parent and its negation is TRUE -- which is how plain
+    membership and ``hasIntersection`` kept readmitting every parentless row after
+    the macros alone were fixed (cerbos/query-plan-adapters#315), and how the
+    negated count spelling ``!(size(chain) > 0)`` did the same (#316). Guarding the
+    chain rather than each operator is what closes all of them at once.
+
+    :param expression: the answer the chain produces -- an ``EXISTS``, a scalar
+        count subquery, a ``CASE`` over either.
+    :param hop_correlation: the join predicates for the INTERMEDIATE hops alone,
+        excluding the element table. Empty for a direct relation, in which case
+        ``expression`` is returned unchanged so a direct collection keeps its
+        empty-collection semantics (``!tags.exists(...)`` over zero tags is still
+        TRUE).
+    :param correlate: entities the guard subquery must correlate against
+        explicitly. SQLAlchemy's auto-correlation only reaches the immediately
+        enclosing SELECT, so a reference to an outer entity from inside a nested
+        lambda subquery would otherwise pull that entity into the inner FROM as a
+        cartesian product -- silently comparing against EVERY row of it.
+
+    Optional by design: a caller wiring a join chain today gets the same query it
+    got before this helper existed. Making it mandatory would mean throwing for
+    every such caller, which is a consumer-visible break to guard a hazard many of
+    them do not have.
+    """
+    if not hop_correlation:
+        return expression
+
+    guard = select(literal(1))
+    for predicate in hop_correlation:
+        guard = guard.where(predicate)
+    return case((exists(guard.correlate(*correlate)), expression))

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -28,7 +28,7 @@ from cerbos.sdk.client import CerbosClient
 from cerbos.sdk.container import CerbosContainer
 from cerbos.sdk.model import PlanResourcesFilterKind, Principal, Resource, ResourceDesc
 
-from cerbos_sqlalchemy import get_query
+from cerbos_sqlalchemy import get_query, require_hops
 from sqlalchemy import (
     Boolean,
     Column,
@@ -324,11 +324,13 @@ class _Relation:
         # both return nothing — so `all` reads TRUE, `!exists` reads TRUE and the
         # count reads 0, each admitting rows the PDP denies
         # (cerbos/query-plan-adapters#309). Requiring the hop separately restores
-        # the distinction. This lives in the MAPPING because the SQLAlchemy
-        # adapter has no relation model of its own: collection semantics are
-        # entirely caller-supplied through operator overrides, so the caller owns
-        # the invariant that its subquery sees exactly the rows the application
-        # serialised into the resource attributes.
+        # the distinction. The requirement itself is `cerbos_sqlalchemy.
+        # require_hops`; what stays in the MAPPING is only which predicates the
+        # hops are, because the SQLAlchemy adapter has no relation model of its
+        # own: collection semantics are entirely caller-supplied through operator
+        # overrides, so the caller owns the invariant that its subquery sees
+        # exactly the rows the application serialised into the resource
+        # attributes.
         self.hop_correlation = hop_correlation or []
 
     def __repr__(self) -> str:  # pragma: no cover - diagnostics only
@@ -408,33 +410,18 @@ def _count_subquery(rel: _Relation, *conds: Any):
     return q.correlate(*rel.correlate_targets).scalar_subquery()
 
 
-def _hop_exists(rel: _Relation):
-    """EXISTS over the intermediate hops alone, or None for a direct relation."""
-    if not rel.hop_correlation:
-        return None
-    q = select(literal(1))
-    for pred in rel.hop_correlation:
-        q = q.where(pred)
-    return exists(q.correlate(*rel.correlate_targets))
-
-
 def _require_hops(rel: _Relation, expr: Any):
     """Make ``expr`` UNKNOWN unless every intermediate to-one hop exists.
 
-    The CASE has no ELSE on purpose: a missing hop yields NULL, and NOT NULL is
-    still NULL, so the row stays excluded under BOTH polarities — matching CEL
-    treating the missing path as an error (a deny).
-
-    EVERY operator whose answer comes off a chain has to go through here, not
-    just the collection macros. A bare ``_exists_where`` is two-valued, so it is
-    FALSE for an absent to-one parent and its negation is TRUE — which is how
-    membership and ``hasIntersection`` kept readmitting every parentless row
-    after the macros were fixed (cerbos/query-plan-adapters#315).
+    The invariant lives in the library as ``cerbos_sqlalchemy.require_hops``; this
+    is only the unpacking of the harness's ``_Relation`` marker into its arguments.
+    The harness using the shipped helper rather than a private copy is what proves
+    the helper: every chained corpus action — ``w1-all-chain``,
+    ``w1-not-exists-chain``, ``w1-size-zero-chain``, ``w1-not-in-chain``,
+    ``w1-not-hasint-chain`` and the rest — is an oracle comparison against a real
+    PDP that runs through this call.
     """
-    guard = _hop_exists(rel)
-    if guard is None:
-        return expr
-    return case((guard, expr))
+    return require_hops(expr, rel.hop_correlation, rel.correlate_targets)
 
 
 def _require_relation(op: str, coll: Any) -> _Relation:

--- a/sqlalchemy/tests/test_relations.py
+++ b/sqlalchemy/tests/test_relations.py
@@ -1,0 +1,90 @@
+"""Unit tests for the mapping helpers a caller wires into ``operator_override_fns``.
+
+The adversarial harness is the semantic proof of ``require_hops`` — every chained
+corpus action is an oracle comparison against a real PDP that routes through it.
+These pin the two structural properties that proof depends on and that a refactor
+could quietly break: the guard is a ``CASE`` with no ``ELSE``, and a direct relation
+gets no guard at all.
+"""
+
+from cerbos_sqlalchemy import require_hops
+from sqlalchemy import Column, Integer, MetaData, String, Table, literal, select
+from sqlalchemy.sql.elements import Case
+
+_metadata = MetaData()
+resource = Table(
+    "hazard_resource",
+    _metadata,
+    Column("id", Integer, primary_key=True),
+)
+category = Table(
+    "hazard_category",
+    _metadata,
+    Column("id", Integer, primary_key=True),
+    Column("resource_id", Integer),
+    Column("kind", String),
+)
+
+
+def _sql(expression) -> str:
+    return str(expression.compile(compile_kwargs={"literal_binds": True}))
+
+
+def test_direct_relation_is_returned_unchanged():
+    # A direct collection keeps its empty-collection semantics: `!tags.exists(...)`
+    # over zero tags is TRUE, and a guard here would wrongly turn it UNKNOWN.
+    answer = literal(True)
+    assert require_hops(answer, []) is answer
+    assert require_hops(answer, ()) is answer
+
+
+def test_guard_has_no_else_branch():
+    # The whole point. A missing hop must yield NULL, because NOT NULL is still
+    # NULL and that is what keeps the row excluded under BOTH polarities. An ELSE
+    # of FALSE would be TRUE once negated — the #309 over-grant, restored.
+    guarded = require_hops(literal(True), [category.c.resource_id == resource.c.id])
+    assert isinstance(guarded, Case)
+    assert guarded.else_ is None
+
+    sql = _sql(guarded)
+    assert "CASE WHEN (EXISTS" in sql
+    assert "ELSE" not in sql
+    assert "hazard_category.resource_id = hazard_resource.id" in sql
+
+
+def test_every_hop_predicate_is_required():
+    # Several predicates conjoin inside one guard subquery rather than producing
+    # several guards, so a chain is required whole.
+    guarded = require_hops(
+        literal(True),
+        [
+            category.c.resource_id == resource.c.id,
+            category.c.kind == "main",
+        ],
+    )
+    sql = _sql(guarded)
+    assert sql.count("EXISTS") == 1
+    assert "hazard_category.resource_id = hazard_resource.id" in sql
+    assert "hazard_category.kind = 'main'" in sql
+
+
+def test_correlate_targets_keep_the_outer_entity_out_of_the_inner_from():
+    # SQLAlchemy's auto-correlation only reaches the immediately enclosing SELECT.
+    # Without the explicit correlate, the outer table joins into the guard's FROM
+    # as a cartesian product — silently comparing against EVERY resource row.
+    # Correlation is only observable once the guard sits inside an enclosing SELECT,
+    # which is where a real override puts it.
+    def outer(*correlate):
+        guarded = require_hops(
+            literal(True), [category.c.resource_id == resource.c.id], correlate
+        )
+        return _sql(select(resource.c.id).where(guarded))
+
+    uncorrelated = outer()
+    correlated = outer(resource)
+
+    assert "FROM hazard_category, hazard_resource" in uncorrelated
+    assert "FROM hazard_category, hazard_resource" not in correlated
+    assert "FROM hazard_category \n" in correlated or correlated.endswith(
+        "FROM hazard_category"
+    )


### PR DESCRIPTION
Closes #323.

`conformance/README.md` requires every adapter to decide explicitly about the six mapping hazards — filtered associations, default scopes, subtype discrimination, to-one-as-collection, composite keys, the absent to-one parent — and to record the decision next to its `Conformance contract` table. **No adapter README had a hazard section**, so all ten were emitting best-effort subqueries by default, which is the one outcome the invariant forbids.

Three commits, in the order the issue's decision comment prescribes.

## Affected adapters

All ten. `prisma`, `drizzle`, `ent`, `pgx` and `sqlalchemy` change behaviourally (additively); `mongoose`, `convex`, `langchain-chromadb`, `elasticsearch-java` and `spring-data` are documentation plus one test.

## 1 — Corpus + class 3 (`f6d165e`)

The corpus sanctioned two outcomes: reproduce the store-side filtering, or reject the mapping. Neither covers the common case, because **rejection presupposes a detection that mostly does not exist** — an adapter handed a table name and two column names cannot see a Prisma client extension, a Drizzle caller's soft-delete convention, or a Mongoose discriminator.

So the corpus gains a third sanctioned outcome, **declared caller-owned**, with two guards: it is available only where the adapter cannot detect the hazard, and the row **must name the exact ORM feature the caller has to go and check**. A row that only says "caller-owned" does not pass review, for the same reason `"cannot express this shape faithfully"` is not an acceptable `adapterUnsupported` reason.

"Not applicable" is recorded as a fourth *answer* and explicitly is not a decision — it is only honest when the row can say structurally why, and that reason is load-bearing enough to be worth a test.

Two mechanism names in the corpus hazard table were wrong and are corrected:

- **Prisma filtered relations** do not exist at the schema level. The real mechanism is a client extension or middleware injecting `where`, which does not rewrite a nested `some`/`every`/`none`.
- **Mongoose discriminators** are not a subquery hazard here, because mongoose builds no subquery. The exposure is which model the caller hands to `find()`.

The four class 3 adapters get their tables, and mongoose's harness now asserts the fact its five "not applicable" rows rest on: no `$lookup`, no `$graphLookup`, no `populate()`, no `aggregate()`, checked against **both the source and every emitted filter**. The day the adapter reaches a second collection, five rows silently become over-grants; this is what stops that landing unnoticed.

The triage brief's "discriminated Mongoose model" test is deliberately **not** added — mongoose builds no subquery, so it would prove nothing about the adapter.

## 2 — Class 1: the optional declaration (`145813f`)

`drizzle`, `ent`, `pgx` and **`prisma`** are class 1: their relation subquery reads a bare table. Prisma looks like class 2 because the mapping names a relation, but it has no `@Where` equivalent, so nothing store-side reaches the nested filter.

| Adapter | New optional field |
|---|---|
| drizzle | `relation.subqueryFilter?: SQL` |
| prisma | `relation.subqueryFilter?: PrismaFilter` (a where-input over the related model) |
| ent / pgx | `Relation.SubqueryFilter []Restriction`, plus `Hop.SubqueryFilter` |

`Hop.SubqueryFilter` is there because a hop is read bare too, and it is the to-one parent whose absence must deny (#309) — a row the application *hides* is, for that purpose, absent, so the hop guard has to agree with the element subquery.

The declaration narrows the rows the subquery **examines**, not the rows it returns. That is what keeps it right under negation: `all` compiles to a false-witness `EXISTS`, and restricting the scan turns it into "every visible row satisfies the body" instead of "every row in the table does". Prisma needs an explicit rewrite for this — `every: AND(declared, P)` would *require* every record to satisfy the declaration, so it becomes `none: AND(declared, NOT P)`.

Every emission site routes through one helper per adapter (`relationCorrelation`, `relationFilter`, `appendRestrictions`) so a declaration cannot reach some shapes and miss others. The tests **count restrictions against subqueries** across `exists` / negated `exists` / `all` / `except` / `exists_one` / counts / membership, which is what catches a shape that picks it up only once.

The Go `Restriction` vocabulary is deliberately narrow (eq, ne, is-null, is-not-null, in, not-in over one column), and a mismatched `Value`/`Values` pairing **fails closed** — pinned by a test rather than assumed.

A required field was considered and rejected: strictly correct, but it breaks every existing caller of four adapters to guard a hazard most of them do not have. Each README records that we chose not to pay for it.

## 3 — Class 2: the sqlalchemy helper (`6520dfd`)

`get_query` has no relation model — collections are reached entirely through `operator_override_fns`, so the caller writes the subquery. That split is right, but the absent-to-one-parent requirement (#309) is mechanical, identical for every caller, and lived only in the adversarial harness. A real consumer wiring a join chain got **no #309 protection from the library**, and nothing said so.

It ships as `cerbos_sqlalchemy.require_hops`, and the harness migrates onto it — which is also its proof: every chained corpus action (`w1-all-chain`, `w1-not-exists-chain`, `w1-not-in-chain`, …) is an oracle comparison against a real PDP that now routes through the shipped helper. It is **optional**, matching mongoose's `requiresParent`.

`spring-data` deliberately gets **no** field, and its README says why: a caller re-declaring a filter Hibernate already applies would have it applied twice, silently removing rows the PDP permits — an under-grant nothing in the differential suite would catch, because the caller's own reads would still show the rows.

The class 2 claims about what Hibernate and SQLAlchemy apply automatically were checked against the ORMs rather than asserted, and each carries its source so a reviewer can re-check it against the version they run.

## Not a breaking change

**When the caller declares nothing, every adapter emits the filter it emits today.** That is asserted per adapter, not just intended:

- drizzle — the rendered SQL is byte-identical to a mapper built without the field
- prisma — the emitted filter object is `toStrictEqual` to one built without the field
- ent / pgx — the bare rendering contains no trace of the restriction

There is no runtime warning on silence: the adapter cannot tell a safe mapper from an unsafe one, and a warning that fires on every correct mapping trains callers to ignore warnings.

No corpus action is added — the corpus deliberately cannot express these — so `conformance/actions.json`, the tripwires and the wire fixtures are untouched.

## Verification

| Suite | Result |
|---|---|
| `conformance/scripts/validate-corpus.sh` | 143 actions, 20 seeds — valid |
| drizzle `npm test` / `test:adversarial` | 127 / 147 pass |
| prisma `npm test` / `test:adversarial` | 211 / 148 pass; `typecheck` clean on v6 and v7 |
| mongoose `npm test` / `test:adversarial` | 104 / 148 pass |
| ent `go test ./...` | pass (SQLite + PostgreSQL + MySQL containers) |
| pgx `go test ./...` | pass (PostgreSQL container) |
| sqlalchemy `pdm run test` | 301 pass |
| `gofmt` / `golangci-lint run ./...` (ent, pgx) | clean |

`ent/internal/queryplan/{mapper,translate}.go` and the pgx copies are verified byte-identical, as the vendoring rule requires.

**Reviewer setup:** Docker for the Go and sqlalchemy suites (testcontainers), MongoDB on 27017 for mongoose, and the Cerbos CLI for every TypeScript suite. The Java adapters are README-only here, so no Gradle run is needed.

The mongoose structural guard was mutation-tested both ways — it fails on a real `$lookup` in the source and tolerates a comment that merely mentions `populate()`.

## Deliberately out of scope

`convex`, `langchain-chromadb`, `elasticsearch-java` and `spring-data` get README positions with **no executable assertion**. The issue's decision comment named exactly three tests and pruned the rest, so this stops there — but mongoose's own argument for its guard applies verbatim to the other three class 3 adapters, and spring-data's "Reproduced by Hibernate" rows have nothing pinning them. Worth a follow-up.
