### PR TITLE
conformance: hold the ent and pgx vendored translators to one set of invariants

### DIFF
--- a/.github/workflows/ent.yaml
+++ b/.github/workflows/ent.yaml
@@ -43,6 +43,15 @@ jobs:
           golangci-lint fmt ./...
           git diff --exit-code
 
+      # The unit suite covers the translator and the renderer over hand-built plans — the malformed
+      # and hostile shapes no planner emits, and the per-dialect spellings. It is run on its own
+      # first for two reasons: it fails in seconds where the container-backed suite takes minutes,
+      # and running it with the adversarial test skipped is what keeps "these tests need no Docker"
+      # a checked claim. Under `./...` a unit test that grew a container dependency would be
+      # invisible, because the suite that follows starts Docker anyway.
+      - name: Unit suite (no Docker)
+        run: go test -race -skip TestAdversarialConformance ./...
+
       # The harness starts its own Cerbos PDP with testcontainers, reading the pinned version from
       # conformance/CERBOS_VERSION — there is no separate sidecar to set up, and the version is
       # never hardcoded here. The corpus is replayed against an in-memory SQLite database and

--- a/.github/workflows/pgx.yaml
+++ b/.github/workflows/pgx.yaml
@@ -43,6 +43,15 @@ jobs:
           golangci-lint fmt ./...
           git diff --exit-code
 
+      # The unit suite covers the translator and the renderer over hand-built plans — the malformed
+      # and hostile shapes no planner emits. It is run on its own first for two reasons: it fails in
+      # seconds where the container-backed suite takes minutes, and running it with the adversarial
+      # test skipped is what keeps "these tests need no Docker" a checked claim. Under `./...` a unit
+      # test that grew a container dependency would be invisible, because the suite that follows
+      # starts Docker anyway.
+      - name: Unit suite (no Docker)
+        run: go test -race -skip TestAdversarialConformance ./...
+
       # The harness starts its own Cerbos PDP with testcontainers, reading the pinned version from
       # conformance/CERBOS_VERSION — there is no separate sidecar to set up, and the version is
       # never hardcoded here. It also seeds a PostgreSQL testcontainer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,13 @@ golangci-lint fmt ./...
 ```
 
 Both Go modules are standalone: each vendors its own translator under `internal/queryplan` and
-depends on nothing else in this repository, so a consumer only ever pulls in the one module. The
-harnesses need Docker (testcontainers) and read the pinned PDP image from
-`conformance/CERBOS_VERSION` and `conformance/CERBOS_IMAGE_DIGEST`.
+depends on nothing else in this repository, so a consumer only ever pulls in the one module. The two
+vendored trees are held **byte-identical** and diffed by `validate-corpus.sh` — a semantic fix has to
+land in both copies, and anything genuinely per-engine goes in that module's `render.go`, outside the
+shared tree. Their unit suites (`translate_test.go`, `render_test.go`) mirror each other for the same
+reason and need no Docker: `go test -skip TestAdversarialConformance ./...`. The adversarial harnesses
+do need Docker (testcontainers) and read the pinned PDP image from `conformance/CERBOS_VERSION` and
+`conformance/CERBOS_IMAGE_DIGEST`.
 
 ### Java (Elasticsearch, Spring Data)
 ```bash

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -525,6 +525,26 @@ hand, deliberately, alongside whatever re-verification the bump needs. That is t
 trade — reproducibility now, staleness to be watched for — and re-enabling Docker updates is a
 maintainer decision, not a drive-by one.
 
+#### Vendored code stays byte-identical
+
+The ent and pgx modules are standalone: each vendors the translator under its own
+`internal/queryplan` so a consumer pulls in only the one. That means the same source exists twice,
+and a semantic fix can land in one copy alone. Nothing downstream notices — the corpus catches it
+only if some action happens to exercise the fixed shape, and the hostile-plan invariants the two unit
+suites pin never come off a real planner wire at all
+([#319](https://github.com/cerbos/query-plan-adapters/issues/319)).
+
+So `validate-corpus.sh` diffs `ent/internal/queryplan` against `pgx/internal/queryplan` and fails on
+any difference. Both adapter workflows already run the script, and each triggers on `conformance/**`
+as well as its own directory, so a one-sided edit fails whichever side it lands on. **Byte-identical,
+not identical-modulo-an-allowlist**: an allowlist is a place for a real divergence to hide as a
+comment tweak, so anything genuinely per-engine goes in that module's `render.go`, which is outside
+the shared tree.
+
+Two copies of the same code also need two copies of the same proof, which is why
+`ent/translate_test.go` and `pgx/translate_test.go` share their test names, section order and shapes.
+Keep them in step when you add an invariant to either.
+
 8. **Document the contract** in the adapter's README with a `Conformance contract` table
    (oracle-tested / fail-closed / known divergence counts). Each adapter is published
    independently, so its README must stand alone — a consumer should not need this monorepo to

--- a/conformance/scripts/validate-corpus.sh
+++ b/conformance/scripts/validate-corpus.sh
@@ -362,6 +362,38 @@ if [[ "${image_drift}" -ne 0 ]]; then
   exit 1
 fi
 
+# The two Go modules are standalone — each vendors the translator under its own
+# internal/queryplan so a consumer pulls in only the one — which means the same source exists
+# twice and a semantic fix can land in one copy alone. Nothing else notices: the corpus catches it
+# only if some action happens to exercise the fixed shape, and the hostile-plan invariants pinned
+# by the unit suites never come off a real planner wire at all
+# (cerbos/query-plan-adapters#319). So the trees are held byte-identical and diffed here, in the
+# script both adapter workflows already run — including on a change under the other adapter's
+# directory, since each workflow triggers on `conformance/**` as well as its own.
+#
+# Byte-identical rather than identical-modulo-an-allowlist on purpose: an allowlist is a place for
+# a real divergence to hide as a comment tweak. Anything genuinely per-module belongs in that
+# module's render.go, which is outside this tree.
+VENDORED_TRANSLATOR="internal/queryplan"
+
+# A tree that is not there would make the diff below pass by comparing nothing, so assert both
+# exist first — the same vacuity guard the image scan applies to a repository nothing references.
+for module in ent pgx; do
+  if [[ ! -d "${REPO_ROOT}/${module}/${VENDORED_TRANSLATOR}" ]]; then
+    echo "${module}/${VENDORED_TRANSLATOR} is missing: the sync check below would guard nothing."
+    exit 1
+  fi
+done
+
+if ! diff -ru \
+  --label "ent/${VENDORED_TRANSLATOR}" --label "pgx/${VENDORED_TRANSLATOR}" \
+  "${REPO_ROOT}/ent/${VENDORED_TRANSLATOR}" "${REPO_ROOT}/pgx/${VENDORED_TRANSLATOR}"; then
+  echo "The vendored translator trees have drifted. Both modules must carry the identical"
+  echo "${VENDORED_TRANSLATOR}: apply the change to both copies, or move whatever is genuinely"
+  echo "per-module into that module's render.go."
+  exit 1
+fi
+
 # The Go modules pin the Cerbos wire gencode (cerbos/api/genpb) separately from the PDP
 # image; a CERBOS_VERSION bump that leaves a stale genpb would silently test new planner
 # output against old generated types.

--- a/ent/README.md
+++ b/ent/README.md
@@ -196,14 +196,30 @@ reads it: `RestrictIn` then hides every row, `RestrictNotIn` hides none.
 
 The three proved dialects are not the same test three times: SQLite stores instants as text and
 booleans as integers, PostgreSQL has real types for both, MySQL needs `CONCAT` rather than `||`
-(which it reads as logical OR outside `PIPES_AS_CONCAT`), `CHAR_LENGTH` rather than `LENGTH` (which
-counts bytes), and `TRUNCATE` before an integer cast — and each needs a different null-safe
-equality operator and different cast spellings. Running all three is what makes `WithDialect` a
-checked claim rather than an assertion.
+(which it reads as logical OR outside `PIPES_AS_CONCAT`) and `CHAR_LENGTH` rather than `LENGTH`
+(which counts bytes) — and each needs a different null-safe equality operator (`IS`, `IS NOT
+DISTINCT FROM`, `<=>`) and different cast spellings (`real`, `double precision`, `double`).
+Running all three is what makes `WithDialect` a checked claim rather than an assertion.
 
 The MySQL schema pins a **binary collation** on every string column. MySQL's default
 `utf8mb4_0900_ai_ci` is both case- and accent-insensitive, which over-grants on `cs-eq`,
 `unicode-eq` and every hierarchy prefix probe — see [Collation](#collation) below.
+
+### Identifier quoting
+
+This is about the names in your `Mapper`, not about the rows a subquery sees, so it is not one of the
+hazards above.
+
+Table, column and qualifier names are passed to Ent's `sql.Builder.Ident`, which quotes for the
+dialect in use. `Ident` treats a name that already contains the dialect's own quote character — a
+backtick on SQLite and MySQL, a double quote on PostgreSQL — as pre-quoted and writes it through
+unchanged, so a column named ``we`ird`` is emitted bare rather than escaped. **Name your columns with
+ordinary identifiers.**
+
+No plan data reaches an identifier: every value from the query plan is a bound parameter, which the
+unit suite asserts against deliberately hostile policy strings. A `Mapper` is your own code, so this
+is a naming constraint rather than an injection surface. It is written down because it is a real
+difference from the [pgx adapter](../pgx), which quotes defensively.
 
 ### Known gaps
 
@@ -241,14 +257,27 @@ the adapter cannot detect. Treat collation as part of your policy contract.
 ## Development
 
 ```bash
-go test ./...          # adversarial conformance suite (needs Docker for testcontainers)
+go test -skip TestAdversarialConformance ./...   # unit suite, no Docker
+go test ./...                                    # adds the adversarial conformance suite (Docker)
 golangci-lint run ./...
 golangci-lint fmt ./...
 ```
 
-The suite starts one Cerbos container, reading the pinned PDP version from
-`conformance/CERBOS_VERSION`, then replays the whole corpus against an in-memory SQLite database
-and a PostgreSQL testcontainer in turn.
+The adversarial suite starts one Cerbos container, reading the pinned PDP version from
+`conformance/CERBOS_VERSION`, then replays the whole corpus against an in-memory SQLite database and
+PostgreSQL and MySQL testcontainers in turn.
+
+The unit suite is everything else, and needs nothing running. It covers what the corpus structurally
+cannot: malformed and hostile plans no planner emits (a `mod` that used to panic, typed-nil oneof
+wrappers, policy data chosen to be SQL syntax), and the per-dialect spellings, where a wrong choice
+is often still valid SQL — `||` is legal MySQL, where it means logical OR. CI runs it as its own step
+before the container-backed one, so "these tests need no Docker" stays a checked claim.
+
+The translator under `internal/queryplan` is vendored byte-for-byte into the
+[pgx module](../pgx) as well, so that a consumer of either pulls in only the one.
+`conformance/scripts/validate-corpus.sh` diffs the two trees and fails on any difference: a
+semantic fix has to land in both copies. Anything genuinely per-engine belongs in `render.go`, which
+is outside the shared tree.
 
 ## License
 

--- a/ent/adversarial_test.go
+++ b/ent/adversarial_test.go
@@ -647,7 +647,15 @@ func (h *harness) adapterFilteredIDs(t *testing.T, action string, opts ...cerbos
 		selector.Where(result.Predicate)
 	}
 
+	// Query() runs the predicate's closure — the second write pass. Translate already surfaced a
+	// render error from its own probe pass, so a failure here is one only this pass can reach, and
+	// the builder reports it by collecting it on the selector rather than by returning it. Ignoring
+	// it would execute whatever partial SQL the failed pass left behind: a truncated WHERE clause
+	// still parses, so the run would compare the wrong row set against the oracle instead of
+	// failing (cerbos/query-plan-adapters#319).
 	query, args := selector.Query()
+	require.NoError(t, selector.Err(), "building the translated query for %s\nSQL: %s", action, query)
+
 	rows, err := h.db.QueryContext(t.Context(), query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("executing translated predicate for %s: %w\nSQL: %s", action, err, query)

--- a/ent/internal/queryplan/expr.go
+++ b/ent/internal/queryplan/expr.go
@@ -4,11 +4,16 @@
 package queryplan
 
 // The SQL expression tree the translator produces. It carries no dialect syntax: nothing here
-// decides how an identifier is quoted, how a parameter is spelled, or how a cast is written.
-// render.go owns all of that, and delegates the dialect-sensitive parts to ent's sql.Builder.
+// decides how an identifier is quoted, how a parameter is spelled, or how a cast is written. Each
+// module's own render.go owns all of that.
 //
 // The separation exists so the parts that are easy to get subtly wrong — operand order, escaping,
 // three-valued logic — can be read and tested without wading through string building.
+//
+// This package is vendored byte-for-byte into both the ent and pgx modules, so that a consumer of
+// either pulls in only the one. `conformance/scripts/validate-corpus.sh` diffs the two trees and
+// fails on any difference: the same semantic fix has to land in both copies, and nothing else
+// notices when it lands in only one.
 
 // Expr is any node of the abstract expression tree. Expressions are either predicates (boolean
 // results) or values; the translator tracks which is which by construction rather than by type,
@@ -61,10 +66,14 @@ const (
 // CastType is an abstract target type for a CEL type conversion.
 type CastType string
 
+// There is deliberately no integer cast: CEL's int() fails closed rather than lowering to SQL
+// CAST (see the "double", "int" arm in translate.go), so a CastInt would be a constant no
+// translation reaches and a render path no test could reach either
+// (cerbos/query-plan-adapters#319). Re-introducing it belongs with the corpus action that drives
+// it and the caller-declared numeric ValueType it needs.
 const (
 	CastText  CastType = "text"
 	CastFloat CastType = "float"
-	CastInt   CastType = "int"
 )
 
 // Column references a mapped column, optionally qualified by a table or subquery alias.

--- a/ent/render.go
+++ b/ent/render.go
@@ -41,11 +41,22 @@ func render(e queryplan.Expr, d string) (*sql.Predicate, error) {
 		return nil, err
 	}
 
+	return predicateFor(e), nil
+}
+
+// predicateFor wraps the tree in the lazy predicate ent hands to a selector.
+//
+// A failure on this pass can only be reported by recording it on the builder — the callback returns
+// nothing — and it has to be recorded on the builder the callback was *given*: sql.Builder.Wrap
+// hands nested callbacks a fresh builder and copies back only its string and args, so an error
+// added there is dropped. write therefore carries errors out through wrap's return value rather than
+// calling AddError itself. See TestRenderErrorsEscapeNestedParentheses.
+func predicateFor(e queryplan.Expr) *sql.Predicate {
 	return sql.P(func(b *sql.Builder) {
 		if err := write(b, e); err != nil {
 			b.AddError(err)
 		}
-	}), nil
+	})
 }
 
 // bindValue records a parameter, applying the two dialect-specific adjustments a bound plan value
@@ -386,24 +397,9 @@ func writeSeparated(b *sql.Builder, args []queryplan.Expr, separator string) err
 }
 
 func writeCast(b *sql.Builder, t queryplan.Cast) error {
-	// CEL's int() truncates toward zero. SQLite's CAST does the same, but PostgreSQL and MySQL
-	// round to nearest — `int(1.9)` is 1 in CEL and 2 there — so truncate explicitly first.
-	if t.To == queryplan.CastInt && b.Dialect() != dialect.SQLite {
-		if b.Dialect() == dialect.MySQL {
-			b.WriteString("CAST(TRUNCATE(")
-			if err := write(b, t.X); err != nil {
-				return err
-			}
-			b.WriteString(", 0) AS ").WriteString(castType(b.Dialect(), t.To)).WriteString(")")
-			return nil
-		}
-
-		b.WriteString("CAST(trunc(")
-		if err := write(b, t.X); err != nil {
-			return err
-		}
-		b.WriteString(") AS ").WriteString(castType(b.Dialect(), t.To)).WriteString(")")
-		return nil
+	target, err := castType(b.Dialect(), t.To)
+	if err != nil {
+		return err
 	}
 
 	b.WriteString("CAST")
@@ -411,7 +407,7 @@ func writeCast(b *sql.Builder, t queryplan.Cast) error {
 		if err := write(b, t.X); err != nil {
 			return err
 		}
-		b.WriteString(" AS ").WriteString(castType(b.Dialect(), t.To))
+		b.WriteString(" AS ").WriteString(target)
 		return nil
 	})
 }
@@ -452,36 +448,34 @@ func writeSubquery(b *sql.Builder, s queryplan.Subquery) error {
 }
 
 // castType spells a CEL conversion for the dialect in use. The three engines ent targets disagree
-// on every one of these: MySQL has no `bigint`/`double precision` in CAST, PostgreSQL has no
-// `signed`, and SQLite's `real` is its only floating type. Getting the float cast wrong is not
-// cosmetic — PostgreSQL's `real` is single precision and would silently round a CEL double.
-func castType(d string, to queryplan.CastType) string {
+// on both of these: MySQL spells the text target `char` and has no `double precision`, while
+// SQLite's `real` is its only floating type. Getting the float cast wrong is not cosmetic —
+// PostgreSQL's `real` is single precision and would silently round a CEL double.
+//
+// Only the two casts the translator emits have a spelling; see the CastType constants for why there
+// is no integer target. A target this does not know is an error rather than a nearest guess: an
+// unspelled cast that fell through to a float would compare against a value the policy never named,
+// which is the class of quiet over-grant this adapter refuses on principle.
+func castType(d string, to queryplan.CastType) (string, error) {
 	switch to {
 	case queryplan.CastText:
 		if d == dialect.MySQL {
-			return "char"
+			return "char", nil
 		}
-		return "text"
+		return "text", nil
 
 	case queryplan.CastFloat:
 		switch d {
 		case dialect.MySQL:
-			return "double"
+			return "double", nil
 		case dialect.SQLite:
-			return "real"
+			return "real", nil
 		default:
-			return "double precision"
+			return "double precision", nil
 		}
 
 	default:
-		switch d {
-		case dialect.MySQL:
-			return "signed"
-		case dialect.SQLite:
-			return "integer"
-		default:
-			return "bigint"
-		}
+		return "", fmt.Errorf("cannot render cast to %q", to)
 	}
 }
 

--- a/ent/render_test.go
+++ b/ent/render_test.go
@@ -1,0 +1,112 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package cerbosent
+
+import (
+	"testing"
+
+	"entgo.io/ent/dialect"
+	"entgo.io/ent/dialect/sql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cerbos/query-plan-adapters/ent/internal/queryplan"
+)
+
+// The renderer's error path is the one thing translate_test.go cannot reach through the public API.
+// Every node the translator emits renders, and the two nodes that do not — an Expr type the switch
+// does not know, a Call naming a function the dialect table does not spell — are unconstructible
+// from a plan: nothing outside the internal package can add an Expr type, and every FuncName the
+// translator uses is handled. So these live here, in the package's own test binary, where a node
+// the walk never produces can be built by hand.
+//
+// They are not decoration. render() writes the tree twice — once into a throwaway builder so the
+// failure surfaces from Translate, once inside the lazy predicate — and ent's sql.Builder.Wrap
+// silently discards errors recorded on the nested builder it hands the callback. Everything the
+// renderer emits is parenthesised, so an error raised more than one level down is exactly the case
+// that would be lost. No Docker required.
+
+// unrenderable is a Call whose FuncName has no dialect spelling. FuncName is an exported string
+// type, so this is buildable here while being something the translator never emits.
+var unrenderable = queryplan.Call{Name: queryplan.FuncName("notAFunction")}
+
+// TestRenderRejectsUnrenderableNodesBeforeReturning pins the probe pass: the failure has to come
+// back from render (and so from Translate) rather than from the caller's query builder, where it
+// would read as a malformed statement rather than a refusal to translate.
+func TestRenderRejectsUnrenderableNodesBeforeReturning(t *testing.T) {
+	t.Parallel()
+
+	for _, d := range []string{dialect.SQLite, dialect.Postgres, dialect.MySQL} {
+		t.Run(d, func(t *testing.T) {
+			t.Parallel()
+
+			predicate, err := render(unrenderable, d)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "notAFunction")
+			require.Nil(t, predicate, "a predicate that cannot render must not be handed back")
+		})
+	}
+}
+
+// TestUnknownCastTargetIsRejected pins that the cast spelling table fails closed. Only the two
+// targets the translator emits have a spelling, and CastType is an exported string type, so a third
+// is buildable here. Falling through to the float spelling would compare against a value the policy
+// never named — a wrong filter where an error is the whole contract.
+func TestUnknownCastTargetIsRejected(t *testing.T) {
+	t.Parallel()
+
+	cast := queryplan.Cast{X: queryplan.Column{Name: "count"}, To: queryplan.CastType("decimal")}
+
+	for _, d := range []string{dialect.SQLite, dialect.Postgres, dialect.MySQL} {
+		t.Run(d, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := render(cast, d)
+			require.ErrorContains(t, err, `cannot render cast to "decimal"`)
+		})
+	}
+}
+
+// TestRenderErrorsEscapeNestedParentheses is the assertion that makes the probe pass trustworthy.
+// sql.Builder.Wrap gives the callback a fresh builder and copies back only its string and args, so
+// an error recorded inside a Wrap is dropped. render's helper therefore has to carry the error out
+// of the closure and return it instead of calling AddError on the builder it was handed. Nesting
+// the bad node under a comparison under a negation puts it two Wraps deep, where the difference
+// between the two designs is the difference between a refusal and a silently truncated query.
+func TestRenderErrorsEscapeNestedParentheses(t *testing.T) {
+	t.Parallel()
+
+	nested := queryplan.Not{X: queryplan.Cmp{
+		Op: queryplan.OpEq,
+		L:  queryplan.Column{Qualifier: "resource", Name: "name"},
+		R:  unrenderable,
+	}}
+
+	_, err := render(nested, dialect.SQLite)
+	require.ErrorContains(t, err, "notAFunction")
+}
+
+// TestSelectorReportsPredicateErrors pins the contract the adversarial harness depends on when it
+// checks selector.Err() after Query() (cerbos/query-plan-adapters#319).
+//
+// The predicate is lazy, so its second write pass runs inside the caller's Query(). ent reports a
+// failure there by collecting it on the selector rather than by returning it, and Query() still
+// hands back the SQL the failed pass left behind — which parses, so it executes, and a truncated
+// WHERE clause returns rows nothing authorised. Only Err() distinguishes the two, which is why the
+// harness has to read it; this test fails if a future ent stops propagating and that check goes
+// quiet.
+func TestSelectorReportsPredicateErrors(t *testing.T) {
+	t.Parallel()
+
+	// The predicate render installs, over a tree that fails on the write pass. Built through
+	// predicateFor rather than restated here, so the test cannot drift from what render does.
+	predicate := predicateFor(unrenderable)
+
+	selector := sql.Dialect(dialect.SQLite).Select("id").From(sql.Table("resource"))
+	selector.Where(predicate)
+
+	query, _ := selector.Query()
+	require.Contains(t, query, "SELECT", "Query() hands back runnable SQL regardless")
+	require.ErrorContains(t, selector.Err(), "notAFunction",
+		"a predicate failure must be readable from the selector, or the harness check is vacuous")
+}

--- a/ent/translate_test.go
+++ b/ent/translate_test.go
@@ -6,6 +6,7 @@ package cerbosent_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
@@ -18,8 +19,18 @@ import (
 )
 
 // Unit tests over hand-built plans, complementing the adversarial suite: the corpus proves
-// semantics against a real PDP but only ever feeds the adapter plans the planner actually emits.
-// Everything here runs without Docker.
+// semantics against a real PDP but only ever feeds the adapter plans the planner actually emits, so
+// it cannot say what happens to a malformed or hostile one. Everything here runs without Docker.
+//
+// The translator this file exercises is vendored byte-for-byte into the pgx module as well, so the
+// invariants below are deliberately kept in step with pgx/translate_test.go — same names, same
+// section order, same shapes — and `conformance/scripts/validate-corpus.sh` fails if the two
+// vendored trees drift. Two copies of the same code need two copies of the same proof: a fix landed
+// in one tree and not the other is otherwise caught only when a corpus action happens to exercise
+// it, and none of the hostile shapes here come off a real planner wire at all
+// (cerbos/query-plan-adapters#319).
+
+// -- plan builders -------------------------------------------------------------------------------
 
 type operand = enginev1.PlanResourcesFilter_Expression_Operand
 
@@ -60,17 +71,55 @@ func tagRelation(filter ...cerbosent.Restriction) *cerbosent.Relation {
 	}
 }
 
-// translateWith translates a plan and renders the resulting predicate to SQL and bound args.
-func translateWith(t *testing.T, mapper cerbosent.Mapper, cond *operand) (string, []any) {
+func testMapper() cerbosent.Mapper {
+	return cerbosent.MapperMap{
+		"request.resource.attr.name":      {Column: "name"},
+		"request.resource.attr.count":     {Column: "count"},
+		"request.resource.attr.owner":     {Column: "owner"},
+		"request.resource.attr.createdAt": {Column: "created_at", ValueType: cerbosent.ValueTimestamp},
+		"request.resource.attr.tags":      {Relation: tagRelation()},
+	}
+}
+
+func translate(t *testing.T, cond *operand, opts ...cerbosent.Option) (cerbosent.Result, error) {
 	t.Helper()
-	result, err := cerbosent.Translate(conditional(cond), "resource", mapper)
+	return cerbosent.Translate(conditional(cond), "resource", testMapper(), opts...)
+}
+
+// renderWhere renders a predicate through ent's builder and returns just the WHERE fragment.
+//
+// pgx's Result carries that fragment directly, so returning it here rather than the whole SELECT is
+// what keeps the two suites' assertions readable side by side. It also checks selector.Err(): the
+// predicate is lazy, so this is the pass that actually runs it, and ent reports a failure there by
+// collecting it on the selector rather than by returning it — see TestSelectorReportsPredicateErrors
+// in render_test.go.
+func renderWhere(t *testing.T, d string, predicate *entsql.Predicate) (string, []any) {
+	t.Helper()
+
+	selector := entsql.Dialect(d).Select("id").From(entsql.Table("resource"))
+	selector.Where(predicate)
+	query, args := selector.Query()
+	require.NoError(t, selector.Err(), "building the query: %s", query)
+
+	_, where, found := strings.Cut(query, " WHERE ")
+	require.True(t, found, "rendered query has no WHERE clause: %s", query)
+	return where, args
+}
+
+// whereFor translates a plan against a mapper and renders it for one dialect.
+func whereFor(t *testing.T, d string, mapper cerbosent.Mapper, cond *operand, opts ...cerbosent.Option) (string, []any) {
+	t.Helper()
+
+	result, err := cerbosent.Translate(conditional(cond), "resource", mapper, append(opts, cerbosent.WithDialect(d))...)
 	require.NoError(t, err)
 	require.Equal(t, cerbosent.KindConditional, result.Kind)
+	return renderWhere(t, d, result.Predicate)
+}
 
-	selector := entsql.Dialect(dialect.SQLite).Select("id").From(entsql.Table("resource"))
-	selector.Where(result.Predicate)
-	query, args := selector.Query()
-	return query, args
+// translateWith is whereFor on the default dialect, which is what most assertions want.
+func translateWith(t *testing.T, mapper cerbosent.Mapper, cond *operand) (string, []any) {
+	t.Helper()
+	return whereFor(t, dialect.SQLite, mapper, cond)
 }
 
 // tagsExists is `R.attr.tags.exists(t, t.name == "x")`.
@@ -79,6 +128,680 @@ func tagsExists(t *testing.T) *operand {
 	return expr("exists", variable("request.resource.attr.tags"),
 		expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))
 }
+
+// -- malformed plans must error, never panic -----------------------------------------------------
+
+// A plan reaches this adapter over the wire. A panic in a library that sits on the authorization
+// path takes the caller's process down, so every shape below must come back as an error.
+func TestMalformedPlansReturnErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		cond *operand
+		name string
+	}{
+		{name: "nil condition", cond: nil},
+		{name: "nil operand inside expression", cond: expr("eq", nil, nil)},
+		{name: "empty expression", cond: expr("")},
+		{name: "unknown operator", cond: expr("frobnicate", variable("request.resource.attr.name"))},
+		{name: "and with no operands", cond: expr("and")},
+		{name: "not with two operands", cond: expr("not", variable("request.resource.attr.name"), variable("request.resource.attr.count"))},
+		{name: "eq with one operand", cond: expr("eq", variable("request.resource.attr.name"))},
+		{name: "eq with three operands", cond: expr("eq", variable("request.resource.attr.name"), variable("request.resource.attr.count"), variable("request.resource.attr.owner"))},
+		{name: "if with two operands", cond: expr("if", variable("request.resource.attr.name"), variable("request.resource.attr.count"))},
+		{name: "exists with one operand", cond: expr("exists", variable("request.resource.attr.tags"))},
+		{name: "exists with a non-lambda second operand", cond: expr("exists", variable("request.resource.attr.tags"), variable("request.resource.attr.name"))},
+		{name: "lambda with no variable", cond: expr("exists", variable("request.resource.attr.tags"), expr("lambda", expr("eq", variable("t.name"), val(t, "x"))))},
+		{name: "lambda outside a macro", cond: expr("lambda", val(t, true), variable("t"))},
+		{name: "size with no operands", cond: expr("gt", expr("size"), val(t, 1))},
+		{name: "hierarchy with three operands", cond: expr("ancestorOf", expr("hierarchy", variable("request.resource.attr.name"), val(t, "."), val(t, ".")), expr("hierarchy", val(t, "a")))},
+		{name: "non-boolean constant as a predicate", cond: val(t, "not a bool")},
+		{name: "unmapped attribute", cond: expr("eq", variable("request.resource.attr.nope"), val(t, "x"))},
+		{name: "relation used as a scalar", cond: expr("eq", variable("request.resource.attr.tags"), val(t, "x"))},
+		{name: "column used as a collection", cond: expr("exists", variable("request.resource.attr.name"), expr("lambda", val(t, true), variable("t")))},
+		{name: "macro over a literal that is not a list", cond: expr("exists", val(t, "scalar"), expr("lambda", val(t, true), variable("t")))},
+		{name: "exists_one over a literal list", cond: expr("exists_one", val(t, []any{"a", "b"}), expr("lambda", val(t, true), variable("t")))},
+		{name: "lambda field missing from the element", cond: expr("exists", val(t, []any{map[string]any{"other": 1}}), expr("lambda", expr("eq", variable("t.name"), val(t, "x")), variable("t")))},
+		{name: "hierarchy operands with different delimiters", cond: expr("ancestorOf", expr("hierarchy", val(t, "a"), val(t, ".")), expr("hierarchy", val(t, "a.b"), val(t, ":")))},
+		{name: "hierarchy operator without hierarchy operands", cond: expr("ancestorOf", val(t, "a"), val(t, "a.b"))},
+		{name: "empty hierarchy delimiter", cond: expr("ancestorOf", expr("hierarchy", val(t, "a"), val(t, "")), expr("hierarchy", val(t, "a.b"), val(t, "")))},
+		{name: "invalid timestamp literal", cond: expr("gt", expr("timestamp", val(t, "not-a-timestamp")), val(t, 1))},
+		{name: "timestamp over an untyped column", cond: expr("gt", expr("timestamp", variable("request.resource.attr.name")), val(t, 1))},
+		{name: "regex", cond: expr("matches", variable("request.resource.attr.name"), val(t, ".*"))},
+		{name: "filter outside size", cond: expr("filter", variable("request.resource.attr.tags"), expr("lambda", val(t, true), variable("t")))},
+		{name: "hasIntersection between two stored collections", cond: expr("hasIntersection", variable("request.resource.attr.tags"), variable("request.resource.attr.tags"))},
+		{name: "modulus by zero", cond: expr("eq", expr("mod", val(t, 4), val(t, 0)), val(t, 0))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// The assertion is as much that this line does not panic as that it errors.
+			_, err := translate(t, tc.cond)
+			require.Error(t, err)
+			require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+		})
+	}
+}
+
+// TestNilConditionIsNotAnAllow pins the fail-closed direction of a filter with no condition: it
+// must never widen into "no filter", which would return every row.
+func TestNilConditionIsNotAnAllow(t *testing.T) {
+	t.Parallel()
+
+	result, err := cerbosent.Translate(&responsev1.PlanResourcesResponse{}, "resource", testMapper())
+	require.NoError(t, err)
+	require.Equal(t, cerbosent.KindAlwaysDenied, result.Kind)
+	require.Nil(t, result.Predicate)
+}
+
+func TestPlanKinds(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		kind enginev1.PlanResourcesFilter_Kind
+		want cerbosent.PlanKind
+	}{
+		{name: "denied", kind: enginev1.PlanResourcesFilter_KIND_ALWAYS_DENIED, want: cerbosent.KindAlwaysDenied},
+		{name: "allowed", kind: enginev1.PlanResourcesFilter_KIND_ALWAYS_ALLOWED, want: cerbosent.KindAlwaysAllowed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			plan := &responsev1.PlanResourcesResponse{Filter: &enginev1.PlanResourcesFilter{Kind: tc.kind}}
+			result, err := cerbosent.Translate(plan, "resource", testMapper())
+			require.NoError(t, err)
+			require.Equal(t, tc.want, result.Kind)
+			require.Nil(t, result.Predicate, "only KindConditional carries a predicate")
+		})
+	}
+}
+
+// TestUnrecognisedFilterKindIsRejected covers the remaining wire value: an unset kind is neither of
+// the constants above and must not be read as one of them.
+func TestUnrecognisedFilterKindIsRejected(t *testing.T) {
+	t.Parallel()
+
+	plan := &responsev1.PlanResourcesResponse{
+		Filter: &enginev1.PlanResourcesFilter{Kind: enginev1.PlanResourcesFilter_KIND_UNSPECIFIED},
+	}
+	_, err := cerbosent.Translate(plan, "resource", testMapper())
+	require.ErrorContains(t, err, "unrecognised filter kind")
+}
+
+// -- emitted SQL ---------------------------------------------------------------------------------
+
+// TestNoPlanDataReachesSQLText is the injection guard. Every value in the plan below is chosen to
+// be SQL syntax if it were ever interpolated rather than bound.
+func TestNoPlanDataReachesSQLText(t *testing.T) {
+	t.Parallel()
+
+	hostile := `'; DROP TABLE resource; --`
+	for _, d := range []string{dialect.SQLite, dialect.Postgres, dialect.MySQL} {
+		t.Run(d, func(t *testing.T) {
+			t.Parallel()
+
+			query, args := whereFor(t, d, testMapper(), expr("or",
+				expr("eq", variable("request.resource.attr.name"), val(t, hostile)),
+				expr("contains", variable("request.resource.attr.owner"), val(t, hostile)),
+				expr("in", variable("request.resource.attr.name"), val(t, []any{hostile, `" OR 1=1 --`})),
+			))
+
+			require.NotContains(t, query, "DROP TABLE")
+			require.NotContains(t, query, "--")
+			require.NotContains(t, query, "'")
+			require.Contains(t, args, hostile)
+		})
+	}
+}
+
+// TestValueFirstComparisonsMirror pins the operand-order rule that shipped as the same bug to two
+// adapters (cerbos/query-plan-adapters#257): the planner preserves policy source order, so
+// `3 <= R.attr.count` arrives value-first and must become `count >= 3`, not `count <= 3`.
+func TestValueFirstComparisonsMirror(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ operator, want string }{
+		{operator: "lt", want: ">"},
+		{operator: "le", want: ">="},
+		{operator: "gt", want: "<"},
+		{operator: "ge", want: "<="},
+	} {
+		t.Run(tc.operator, func(t *testing.T) {
+			t.Parallel()
+
+			query, args := translateWith(t, testMapper(), expr(tc.operator, val(t, 3), variable("request.resource.attr.count")))
+			require.Equal(t, "(`resource`.`count` "+tc.want+" ?)", query)
+			require.Equal(t, []any{float64(3)}, args)
+		})
+	}
+}
+
+// TestSymmetricComparisonsNormaliseToColumnFirst covers the other half of the rule: eq/ne/in mean
+// the same thing either way round, so they normalise rather than mirror.
+func TestSymmetricComparisonsNormaliseToColumnFirst(t *testing.T) {
+	t.Parallel()
+
+	query, _ := translateWith(t, testMapper(), expr("eq", val(t, "x"), variable("request.resource.attr.name")))
+	require.Equal(t, "(`resource`.`name` = ?)", query)
+}
+
+// TestOperatorSymbols pins the two lookup tables the renderer spells operators through.
+//
+// They are the kind of thing nothing else catches: a `+` written where `-` belongs, or `<` where
+// `<=` belongs, is valid SQL that quietly returns a different row set, and the corpus only notices
+// if some action happens to straddle the boundary the wrong symbol moves. Every arm is asserted so
+// there is no operator whose spelling is taken on trust.
+func TestOperatorSymbols(t *testing.T) {
+	t.Parallel()
+
+	t.Run("comparisons", func(t *testing.T) {
+		t.Parallel()
+
+		for operator, symbol := range map[string]string{
+			"eq": "=", "ne": "<>", "lt": "<", "le": "<=", "gt": ">", "ge": ">=",
+		} {
+			query, _ := translateWith(t, testMapper(), expr(operator, variable("request.resource.attr.count"), val(t, 2)))
+			require.Equal(t, "(`resource`.`count` "+symbol+" ?)", query, operator)
+		}
+	})
+
+	t.Run("arithmetic", func(t *testing.T) {
+		t.Parallel()
+
+		// A column dividend keeps `div` and `mod` from folding to a constant, and the division
+		// shapes wrap the arithmetic in the guards that keep a zero divisor UNKNOWN — so these
+		// assert the operator appears rather than pinning the whole surrounding CASE.
+		for operator, symbol := range map[string]string{
+			"add": "+", "sub": "-", "mult": "*", "div": "/", "mod": "%",
+		} {
+			query, _ := translateWith(t, testMapper(), expr("gt",
+				expr(operator, variable("request.resource.attr.count"), val(t, 2)), val(t, 1)))
+			require.Contains(t, query, " "+symbol+" ", operator+": "+query)
+		}
+	})
+}
+
+// TestReceiverSensitiveOperatorsKeepWireOrder is the reason eq/ne/in are normalised by name rather
+// than by "put the column first": swapping `"const".contains(col)` would silently exchange the
+// haystack and the needle.
+func TestReceiverSensitiveOperatorsKeepWireOrder(t *testing.T) {
+	t.Parallel()
+
+	query, args := translateWith(t, testMapper(), expr("contains", val(t, "haystack"), variable("request.resource.attr.name")))
+	require.True(t, strings.HasPrefix(query, "(? LIKE"), "the constant is the receiver: %s", query)
+	require.Equal(t, "haystack", args[0])
+}
+
+// TestLikeMetacharactersAreEscaped pins that policy data cannot act as a wildcard.
+func TestLikeMetacharactersAreEscaped(t *testing.T) {
+	t.Parallel()
+
+	query, args := translateWith(t, testMapper(), expr("startsWith", variable("request.resource.attr.name"), val(t, `100%_a[b\`)))
+	require.Equal(t, `100\%\_a\[b\\%`, args[0])
+	require.Contains(t, query, "ESCAPE")
+}
+
+// TestNullComparisonBecomesIsNull pins the default (explicit-null) representation.
+func TestNullComparisonBecomesIsNull(t *testing.T) {
+	t.Parallel()
+
+	query, args := translateWith(t, testMapper(), expr("eq", variable("request.resource.attr.owner"), val(t, nil)))
+	require.Equal(t, "(`resource`.`owner` IS NULL)", query)
+	require.Empty(t, args)
+}
+
+// TestNullOperandsRejectedUnderOmitted pins the rejection, and that it matches on the operand
+// rather than an allowlist of operators — a null carried in a value LIST must be caught too.
+func TestNullOperandsRejectedUnderOmitted(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		cond *operand
+		name string
+	}{
+		{name: "eq", cond: expr("eq", variable("request.resource.attr.owner"), val(t, nil))},
+		{name: "ne", cond: expr("ne", variable("request.resource.attr.owner"), val(t, nil))},
+		{name: "in list containing null", cond: expr("in", variable("request.resource.attr.owner"), val(t, []any{"a", nil}))},
+		{name: "nested under not", cond: expr("not", expr("eq", variable("request.resource.attr.owner"), val(t, nil)))},
+		{name: "nested under and", cond: expr("and",
+			expr("eq", variable("request.resource.attr.name"), val(t, "x")),
+			expr("eq", variable("request.resource.attr.owner"), val(t, nil)),
+		)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := translate(t, tc.cond, cerbosent.WithNullRepresentation(cerbosent.NullOmitted))
+			require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+			require.Contains(t, err.Error(), "null operand")
+
+			// The same plan translates fine under the default representation, so the rejection is
+			// the option talking rather than an unrelated failure.
+			_, err = translate(t, tc.cond)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestPredicateComposesAfterTheCallersOwnArguments is the ent counterpart of pgx's placeholder
+// offset. pgx hands back a text fragment and has to be told where the caller's numbering left off;
+// ent hands back a predicate the builder renumbers itself. Either way the hazard is the same — a
+// filter appended to a query that already binds arguments must not reuse the caller's placeholders
+// — so it is pinned on the dialect where the numbering is visible.
+func TestPredicateComposesAfterTheCallersOwnArguments(t *testing.T) {
+	t.Parallel()
+
+	result, err := cerbosent.Translate(
+		conditional(expr("eq", variable("request.resource.attr.name"), val(t, "plan"))),
+		"resource", testMapper(), cerbosent.WithDialect(dialect.Postgres))
+	require.NoError(t, err)
+
+	selector := entsql.Dialect(dialect.Postgres).Select("id").From(entsql.Table("resource"))
+	selector.Where(entsql.And(entsql.EQ("tenant", "caller"), result.Predicate))
+	query, args := selector.Query()
+	require.NoError(t, selector.Err())
+
+	require.Contains(t, query, `"tenant" = $1`)
+	require.Contains(t, query, `"name" = $2`)
+	require.Equal(t, []any{"caller", "plan"}, args)
+}
+
+// TestIdentifiersAreQuoted pins that a mapped column is quoted for the dialect in use rather than
+// pasted in bare — the qualifier and the column name both, since the qualified form is what makes
+// the predicate composable inside a correlated subquery.
+func TestIdentifiersAreQuoted(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ dialect, want string }{
+		{dialect: dialect.SQLite, want: "(`resource`.`odd column` = ?)"},
+		{dialect: dialect.MySQL, want: "(`resource`.`odd column` = ?)"},
+		{dialect: dialect.Postgres, want: `("resource"."odd column" = $1::text)`},
+	} {
+		t.Run(tc.dialect, func(t *testing.T) {
+			t.Parallel()
+
+			mapper := cerbosent.MapperMap{"request.resource.attr.name": {Column: "odd column"}}
+			query, _ := whereFor(t, tc.dialect, mapper,
+				expr("eq", variable("request.resource.attr.name"), val(t, "x")))
+			require.Equal(t, tc.want, query)
+		})
+	}
+}
+
+// TestMapperColumnCarryingTheDialectQuoteIsNotRequoted records a documented divergence from pgx
+// rather than an invariant shared with it. pgx quotes defensively, doubling an embedded quote; ent
+// delegates quoting to sql.Builder.Ident, which treats a name already containing the dialect's
+// quote character as pre-quoted and passes it through verbatim.
+//
+// Neither is an injection boundary — a mapper is caller-supplied, and no plan data reaches an
+// identifier (TestNoPlanDataReachesSQLText) — so this is pinned as the behaviour a caller has to
+// know about, and stated as a hazard in the README, not silently relied upon. It is what makes
+// "name your columns with ordinary identifiers" part of this adapter's mapping contract.
+func TestMapperColumnCarryingTheDialectQuoteIsNotRequoted(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ dialect, column, want string }{
+		{dialect: dialect.SQLite, column: "we`ird", want: "(`resource`.we`ird = ?)"},
+		{dialect: dialect.MySQL, column: "we`ird", want: "(`resource`.we`ird = ?)"},
+		{dialect: dialect.Postgres, column: `we"ird`, want: `("resource".we"ird = $1::text)`},
+	} {
+		t.Run(tc.dialect, func(t *testing.T) {
+			t.Parallel()
+
+			mapper := cerbosent.MapperMap{"request.resource.attr.name": {Column: tc.column}}
+			query, _ := whereFor(t, tc.dialect, mapper,
+				expr("eq", variable("request.resource.attr.name"), val(t, "x")))
+			require.Equal(t, tc.want, query)
+		})
+	}
+}
+
+// TestTranslateRejectsMissingArguments covers the API preconditions.
+func TestTranslateRejectsMissingArguments(t *testing.T) {
+	t.Parallel()
+
+	cond := expr("eq", variable("request.resource.attr.name"), val(t, "x"))
+
+	_, err := cerbosent.Translate(nil, "resource", testMapper())
+	require.Error(t, err)
+
+	_, err = cerbosent.Translate(conditional(cond), "", testMapper())
+	require.Error(t, err)
+
+	_, err = cerbosent.Translate(conditional(cond), "resource", nil)
+	require.Error(t, err)
+}
+
+// TestRootTableCannotShadowGeneratedAliases pins the guard against a resource table named like a
+// generated subquery alias. Without it the inner alias would shadow the outer table and the
+// correlation would silently compare the subquery's row against itself.
+func TestRootTableCannotShadowGeneratedAliases(t *testing.T) {
+	t.Parallel()
+
+	cond := tagsExists(t)
+
+	_, err := cerbosent.Translate(conditional(cond), "cerbos_rel_1", testMapper())
+	require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+	require.Contains(t, err.Error(), "reserved for generated subquery aliases")
+
+	// Any other table name still works, so the guard is narrow.
+	_, err = cerbosent.Translate(conditional(cond), "resource", testMapper())
+	require.NoError(t, err)
+}
+
+// -- regressions from the adversarial review ------------------------------------------------------
+
+// TestModulusRejectsNonIntegerOperands pins a panic fix: `mod(4, 0.5)` passed the zero-divisor
+// check, then truncated the divisor to zero and panicked with an integer divide by zero.
+func TestModulusRejectsNonIntegerOperands(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		l, r any
+	}{
+		{name: "fractional divisor", l: 4, r: 0.5},
+		{name: "fractional dividend", l: 4.5, r: 2},
+		{name: "zero divisor", l: 4, r: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := translate(t, expr("eq", expr("mod", val(t, tc.l), val(t, tc.r)), val(t, 0)))
+			require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+		})
+	}
+}
+
+// TestTypedNilOperandsAreRejected pins the other panic fix: a oneof wrapper can be a typed nil,
+// which the type switch still matches and which was then dereferenced.
+func TestTypedNilOperandsAreRejected(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		cond *operand
+		name string
+	}{
+		{name: "expression", cond: &operand{Node: (*enginev1.PlanResourcesFilter_Expression_Operand_Expression)(nil)}},
+		{name: "variable", cond: &operand{Node: (*enginev1.PlanResourcesFilter_Expression_Operand_Variable)(nil)}},
+		{name: "value", cond: &operand{Node: (*enginev1.PlanResourcesFilter_Expression_Operand_Value)(nil)}},
+		{name: "unset value", cond: &operand{Node: &enginev1.PlanResourcesFilter_Expression_Operand_Value{}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := translate(t, tc.cond)
+			require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+		})
+	}
+}
+
+// TestNestedNullsRejectedUnderOmitted pins that the NullOmitted scan sees a null nested inside a
+// literal collection. Lambda substitution extracts it long after the scan runs, so a shallow check
+// let `IS NULL` through and returned exactly the rows the PDP denies.
+func TestNestedNullsRejectedUnderOmitted(t *testing.T) {
+	t.Parallel()
+
+	cond := expr("exists",
+		val(t, []any{map[string]any{"v": nil}}),
+		expr("lambda", expr("eq", variable("x.v"), variable("request.resource.attr.owner")), variable("x")))
+
+	_, err := translate(t, cond, cerbosent.WithNullRepresentation(cerbosent.NullOmitted))
+	require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+	require.Contains(t, err.Error(), "null operand")
+}
+
+// TestRelationMembershipRespectsNullRepresentation pins that null-safe equality is used only under
+// the explicit convention. Under NullOmitted a NULL column carries no attribute, so CEL errors and
+// denies; treating it as a definite non-match would make `!(x in coll)` true for exactly those rows.
+//
+// The operator is spelled three different ways across the dialects ent supports, so the assertion
+// runs on all of them: a dialect whose null-safe spelling is wrong silently falls back to plain
+// equality, which is the bug this test exists to catch.
+func TestRelationMembershipRespectsNullRepresentation(t *testing.T) {
+	t.Parallel()
+
+	cond := expr("in", variable("request.resource.attr.owner"), variable("request.resource.attr.tags"))
+
+	for _, tc := range []struct{ dialect, nullSafe, plain string }{
+		{dialect: dialect.SQLite, nullSafe: "`cerbos_rel_1`.`name` IS `resource`.`owner`", plain: "`cerbos_rel_1`.`name` = `resource`.`owner`"},
+		{dialect: dialect.Postgres, nullSafe: `"cerbos_rel_1"."name" IS NOT DISTINCT FROM "resource"."owner"`, plain: `"cerbos_rel_1"."name" = "resource"."owner"`},
+		{dialect: dialect.MySQL, nullSafe: "`cerbos_rel_1`.`name` <=> `resource`.`owner`", plain: "`cerbos_rel_1`.`name` = `resource`.`owner`"},
+	} {
+		t.Run(tc.dialect, func(t *testing.T) {
+			t.Parallel()
+
+			explicit, _ := whereFor(t, tc.dialect, testMapper(), cond)
+			require.Contains(t, explicit, tc.nullSafe)
+
+			omitted, _ := whereFor(t, tc.dialect, testMapper(), cond,
+				cerbosent.WithNullRepresentation(cerbosent.NullOmitted))
+			require.NotContains(t, omitted, tc.nullSafe)
+			require.Contains(t, omitted, tc.plain)
+		})
+	}
+}
+
+// TestNumericCastsAreRejected pins the fail-closed answer to CEL's int()/double()
+// (cerbos/query-plan-adapters#311).
+//
+// The adapter used to render `CAST(trunc(...))`, which is exactly right for a numeric column —
+// int(1.9) is 1 to CEL while PostgreSQL's plain float-to-bigint cast rounds to 2, and MySQL needs
+// TRUNCATE() to say the same thing. It is wrong for a string one: CEL reads a WHOLE string or
+// raises, and an error denies the row, while SQL reads whatever numeric prefix parses. Nothing in
+// the plan says which kind of column the operand is, so the corpus actions cast-int-string /
+// cast-double-string cannot be told apart from cast-int-double at translation time and the whole
+// family fails closed. Re-enabling the numeric direction needs a caller-declared numeric ValueType,
+// the way timestamp() already works — and the integer render path was removed with the rest of it,
+// so re-enabling means writing it again rather than reviving an untested branch (#319).
+func TestNumericCastsAreRejected(t *testing.T) {
+	t.Parallel()
+
+	for _, operator := range []string{"int", "double"} {
+		t.Run(operator, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := translate(t, expr("eq", expr(operator, variable("request.resource.attr.count")), val(t, 2)))
+			require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+			require.ErrorContains(t, err, "cannot be lowered to SQL CAST")
+		})
+	}
+}
+
+// TestMapperQualifierCannotShadowGeneratedAliases covers the other half of the alias guard: the
+// collision can come from an Entry's own qualifier, not just the resource table.
+func TestMapperQualifierCannotShadowGeneratedAliases(t *testing.T) {
+	t.Parallel()
+
+	mapper := cerbosent.MapperMap{
+		"request.resource.attr.name": {Column: "name", Qualifier: "cerbos_rel_1"},
+	}
+	_, err := cerbosent.Translate(
+		conditional(expr("eq", variable("request.resource.attr.name"), val(t, "x"))),
+		"resource", mapper)
+	require.ErrorIs(t, err, cerbosent.ErrUnsupported)
+}
+
+// -- dialect coverage ----------------------------------------------------------------------------
+
+// Everything in this section is ent-specific: pgx renders for one engine, while this adapter's
+// renderer spells the same tree three ways. The adversarial suite proves each spelling against a
+// real server, but only for the shapes the corpus happens to plan and only when Docker is
+// available. These pin the divergences themselves, so a wrong spelling fails in a second.
+
+// TestDialectSpellings covers each construct the renderer spells per dialect. A wrong spelling is
+// not a syntax error on every engine — `||` is valid MySQL (it means OR) and `LENGTH` is valid
+// everywhere (it counts bytes on MySQL) — so the shapes that would still run, wrongly, are the
+// point.
+func TestDialectSpellings(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		want map[string]string
+		cond *operand
+		name string
+	}{
+		{
+			// CEL reads a whole string; MySQL spells the text target `char`.
+			name: "string() cast",
+			cond: expr("eq", expr("string", variable("request.resource.attr.count")), val(t, "2")),
+			want: map[string]string{
+				dialect.SQLite:   "CAST(`resource`.`count` AS text)",
+				dialect.Postgres: `CAST("resource"."count" AS text)`,
+				dialect.MySQL:    "CAST(`resource`.`count` AS char)",
+			},
+		},
+		{
+			// The float cast guards the division shapes. PostgreSQL's `real` is single precision and
+			// would silently round a CEL double, which is why `double precision` is spelled out.
+			name: "float cast",
+			cond: expr("gt", expr("div", variable("request.resource.attr.count"), val(t, 2)), val(t, 1)),
+			want: map[string]string{
+				dialect.SQLite:   "CAST(`resource`.`count` AS real)",
+				dialect.Postgres: `CAST("resource"."count" AS double precision)`,
+				dialect.MySQL:    "CAST(`resource`.`count` AS double)",
+			},
+		},
+		{
+			// CEL's size() counts code points. MySQL's LENGTH() counts bytes — "héllo🚀" is 6 to CEL
+			// and 10 to MySQL — so it needs CHAR_LENGTH.
+			name: "size() over a string",
+			cond: expr("gt", expr("size", variable("request.resource.attr.name")), val(t, 2)),
+			want: map[string]string{
+				dialect.SQLite:   "length(`resource`.`name`)",
+				dialect.Postgres: `length("resource"."name")`,
+				dialect.MySQL:    "char_length(`resource`.`name`)",
+			},
+		},
+		{
+			// A dynamic LIKE pattern concatenates. MySQL reads `||` as logical OR outside
+			// PIPES_AS_CONCAT, which would collapse the pattern to a boolean and match nothing;
+			// its CONCAT() propagates NULL where PostgreSQL's skips NULLs, so each engine gets the
+			// spelling that keeps a missing attribute UNKNOWN.
+			name: "concat in a dynamic LIKE pattern",
+			cond: expr("contains", variable("request.resource.attr.name"), variable("request.resource.attr.owner")),
+			want: map[string]string{
+				dialect.SQLite:   "LIKE (? || replace(",
+				dialect.Postgres: `LIKE ($1::text || replace(`,
+				dialect.MySQL:    "LIKE CONCAT(?, replace(",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Len(t, tc.want, 3, "every case must state all three dialects")
+			for d, want := range tc.want {
+				query, _ := whereFor(t, d, testMapper(), tc.cond)
+				require.Contains(t, query, want, "%s: %s", d, query)
+			}
+		})
+	}
+}
+
+// TestPostgresBindsTypedParameters pins the `::type` annotations. PostgreSQL infers an untyped `$n`
+// from the context it appears in, and in `CAST(col AS double precision) / $1` there is nothing to
+// infer from — it falls back to text and the query dies with "operator does not exist". The plan is
+// the only thing that knows a literal's type, so it is stated. SQLite and MySQL infer from the
+// bound value and must carry no annotation, or the SQL is invalid there.
+func TestPostgresBindsTypedParameters(t *testing.T) {
+	t.Parallel()
+
+	cond := expr("and",
+		expr("eq", variable("request.resource.attr.name"), val(t, "x")),
+		expr("gt", variable("request.resource.attr.count"), val(t, 2)),
+	)
+
+	postgres, _ := whereFor(t, dialect.Postgres, testMapper(), cond)
+	require.Contains(t, postgres, "$1::text")
+	require.Contains(t, postgres, "$2::double precision")
+
+	for _, d := range []string{dialect.SQLite, dialect.MySQL} {
+		query, _ := whereFor(t, d, testMapper(), cond)
+		require.NotContains(t, query, "::", "%s infers from the bound value: %s", d, query)
+	}
+}
+
+// TestRestrictionValuesAreTypedForPostgres covers the other source of bound values: a caller's
+// Restriction carries `any`, so the parameter-type table has to handle the Go types a plan never
+// produces. CEL numbers are always doubles, so an int or a bool reaches bindValue only from here.
+func TestRestrictionValuesAreTypedForPostgres(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		value any
+		want  string
+	}{
+		{value: 42, want: "$1::bigint"},
+		{value: true, want: "$1::boolean"},
+		{value: "main", want: "$1::text"},
+		{value: 1.5, want: "$1::double precision"},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+
+			mapper := cerbosent.MapperMap{
+				"request.resource.attr.tags": {Relation: tagRelation(
+					cerbosent.Restriction{Column: "kind", Value: tc.value})},
+			}
+			query, args := whereFor(t, dialect.Postgres, mapper, tagsExists(t))
+			require.Contains(t, query, tc.want)
+			require.Contains(t, args, tc.value)
+		})
+	}
+}
+
+// TestTimestampsAreBoundForTheDialect pins the SQLite timestamp convention. SQLite has no temporal
+// type, so an instant is stored and compared as text, and lexicographic order only agrees with
+// chronological order when every value is fixed width and in the same zone — Go's RFC3339Nano trims
+// trailing zeros from the fraction and would order "…:05.5Z" after "…:05.12Z". PostgreSQL and MySQL
+// have real temporal types and take the time.Time itself.
+func TestTimestampsAreBoundForTheDialect(t *testing.T) {
+	t.Parallel()
+
+	instant := time.Date(2024, time.June, 1, 0, 0, 0, 500000000, time.UTC)
+	cond := expr("gt", variable("request.resource.attr.createdAt"),
+		expr("timestamp", val(t, instant.Format(time.RFC3339Nano))))
+
+	sqlite, args := whereFor(t, dialect.SQLite, testMapper(), cond)
+	require.Equal(t, "(`resource`.`created_at` > ?)", sqlite)
+	require.Equal(t, []any{"2024-06-01T00:00:00.500000000Z"}, args,
+		"a fixed-width UTC layout is what makes text comparison chronological")
+	require.Equal(t, len("2006-01-02T15:04:05.000000000Z"), len(args[0].(string)))
+
+	for _, d := range []string{dialect.Postgres, dialect.MySQL} {
+		_, args := whereFor(t, d, testMapper(), cond)
+		require.Equal(t, []any{instant}, args, "%s has a real temporal type", d)
+	}
+}
+
+// TestBooleanConstantsAvoidKeywords pins the tautology spelling. TRUE and FALSE are not portable
+// keywords across every engine ent targets, and these constants are how a folded macro and an
+// always-true filter reach the query at all, so they cannot be dialect-specific.
+func TestBooleanConstantsAvoidKeywords(t *testing.T) {
+	t.Parallel()
+
+	// A macro over an empty literal collection folds to its identity: `exists` is false, `all` true.
+	for _, tc := range []struct{ operator, want string }{
+		{operator: "exists", want: "1 = 0"},
+		{operator: "all", want: "1 = 1"},
+	} {
+		t.Run(tc.operator, func(t *testing.T) {
+			t.Parallel()
+
+			cond := expr(tc.operator, val(t, []any{}), expr("lambda", val(t, true), variable("t")))
+			for _, d := range []string{dialect.SQLite, dialect.Postgres, dialect.MySQL} {
+				query, _ := whereFor(t, d, testMapper(), cond)
+				require.Equal(t, tc.want, query)
+			}
+		})
+	}
+}
+
+// -- mapping hazards: the caller-declared store-side predicate -------------------------------------
 
 // TestSubqueryFilterNarrowsEveryShapeBuiltOnTheRelation is the class 1 mapping-hazard contract
 // (README, "Mapping hazards"). This adapter is handed a table name and two column names, so

--- a/pgx/README.md
+++ b/pgx/README.md
@@ -207,13 +207,24 @@ and use a case-sensitive (e.g. `C` or a `_cs_` ICU) collation on columns policie
 ## Development
 
 ```bash
-go test ./...          # adversarial conformance suite (needs Docker for testcontainers)
+go test -skip TestAdversarialConformance ./...   # unit suite, no Docker
+go test ./...                                    # adds the adversarial conformance suite (Docker)
 golangci-lint run ./...
 golangci-lint fmt ./...
 ```
 
-The suite starts its own PostgreSQL and Cerbos containers, reading the pinned PDP version from
-`conformance/CERBOS_VERSION`.
+The adversarial suite starts its own PostgreSQL and Cerbos containers, reading the pinned PDP
+version from `conformance/CERBOS_VERSION`.
+
+The unit suite is everything else, and needs nothing running. It covers what the corpus structurally
+cannot: malformed and hostile plans no planner emits. CI runs it as its own step before the
+container-backed one, so "these tests need no Docker" stays a checked claim.
+
+The translator under `internal/queryplan` is vendored byte-for-byte into the
+[ent module](../ent) as well, so that a consumer of either pulls in only the one.
+`conformance/scripts/validate-corpus.sh` diffs the two trees and fails on any difference: a semantic
+fix has to land in both copies. Anything genuinely per-engine belongs in `render.go`, which is
+outside the shared tree.
 
 ## License
 

--- a/pgx/internal/queryplan/expr.go
+++ b/pgx/internal/queryplan/expr.go
@@ -3,12 +3,17 @@
 
 package queryplan
 
-// The SQL expression tree the translator produces. It carries no PostgreSQL syntax: nothing here
-// decides how an identifier is quoted, how a parameter is spelled, or how a cast is written.
-// render.go owns all of that.
+// The SQL expression tree the translator produces. It carries no dialect syntax: nothing here
+// decides how an identifier is quoted, how a parameter is spelled, or how a cast is written. Each
+// module's own render.go owns all of that.
 //
 // The separation exists so the parts that are easy to get subtly wrong — operand order, escaping,
 // three-valued logic — can be read and tested without wading through string building.
+//
+// This package is vendored byte-for-byte into both the ent and pgx modules, so that a consumer of
+// either pulls in only the one. `conformance/scripts/validate-corpus.sh` diffs the two trees and
+// fails on any difference: the same semantic fix has to land in both copies, and nothing else
+// notices when it lands in only one.
 
 // Expr is any node of the abstract expression tree. Expressions are either predicates (boolean
 // results) or values; the translator tracks which is which by construction rather than by type,
@@ -61,10 +66,14 @@ const (
 // CastType is an abstract target type for a CEL type conversion.
 type CastType string
 
+// There is deliberately no integer cast: CEL's int() fails closed rather than lowering to SQL
+// CAST (see the "double", "int" arm in translate.go), so a CastInt would be a constant no
+// translation reaches and a render path no test could reach either
+// (cerbos/query-plan-adapters#319). Re-introducing it belongs with the corpus action that drives
+// it and the caller-declared numeric ValueType it needs.
 const (
 	CastText  CastType = "text"
 	CastFloat CastType = "float"
-	CastInt   CastType = "int"
 )
 
 // Column references a mapped column, optionally qualified by a table or subquery alias.

--- a/pgx/render.go
+++ b/pgx/render.go
@@ -247,28 +247,28 @@ func (r *renderer) writeBinary(symbol string, l, right queryplan.Expr) error {
 
 // writeCast lowers a CEL type conversion.
 //
-// CEL's int() truncates toward zero, while PostgreSQL's float-to-integer cast rounds to nearest —
-// `int(1.9)` is 1 in CEL and 2 in SQL, which is an over-grant on a `== 2` threshold. Truncating
-// first makes the cast mean what the policy means.
+// Only the two casts the translator emits have a spelling; see the CastType constants for why there
+// is no integer target. A target this does not know is an error rather than a nearest guess: an
+// unspelled cast that fell through to a float would compare against a value the policy never named,
+// which is the class of quiet over-grant this adapter refuses on principle.
 func (r *renderer) writeCast(c queryplan.Cast) error {
-	if c.To == queryplan.CastInt {
-		r.sb.WriteString("CAST(trunc(")
-		if err := r.write(c.X); err != nil {
-			return err
-		}
-		r.sb.WriteString(") AS bigint)")
-		return nil
+	var target string
+	switch c.To {
+	case queryplan.CastText:
+		target = "text"
+	case queryplan.CastFloat:
+		target = "double precision"
+	default:
+		return fmt.Errorf("cannot render cast to %q", c.To)
 	}
 
 	r.sb.WriteString("CAST(")
 	if err := r.write(c.X); err != nil {
 		return err
 	}
-	if c.To == queryplan.CastText {
-		r.sb.WriteString(" AS text)")
-	} else {
-		r.sb.WriteString(" AS double precision)")
-	}
+	r.sb.WriteString(" AS ")
+	r.sb.WriteString(target)
+	r.sb.WriteString(")")
 	return nil
 }
 

--- a/pgx/render_test.go
+++ b/pgx/render_test.go
@@ -1,0 +1,62 @@
+// Copyright 2021-2026 Zenauth Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+package cerbospgx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cerbos/query-plan-adapters/pgx/internal/queryplan"
+)
+
+// The renderer's error path is the one thing translate_test.go cannot reach through the public API.
+// Every node the translator emits renders, and the nodes that do not — an Expr type the switch does
+// not know, a Call naming a function with no spelling, a Cast to a target with no spelling — are
+// unconstructible from a plan: nothing outside the internal package can add an Expr type, and every
+// FuncName and CastType the translator uses is handled. So these live here, in the package's own
+// test binary, where a node the walk never produces can be built by hand. The ent module carries the
+// same file for the same reason. No Docker required.
+
+func renderExpr(t *testing.T, e queryplan.Expr) error {
+	t.Helper()
+
+	_, _, err := render(e, 0)
+	return err
+}
+
+// TestUnrenderableFunctionIsRejected pins that a function with no spelling is refused rather than
+// emitted as something else.
+func TestUnrenderableFunctionIsRejected(t *testing.T) {
+	t.Parallel()
+
+	err := renderExpr(t, queryplan.Call{Name: queryplan.FuncName("notAFunction")})
+	require.ErrorContains(t, err, "notAFunction")
+}
+
+// TestRenderErrorsEscapeNestedNodes pins that a failure raised deep in the tree reaches the caller
+// rather than being swallowed by an enclosing node. Everything the renderer emits is parenthesised,
+// so an error more than one level down is the case that would be lost.
+func TestRenderErrorsEscapeNestedNodes(t *testing.T) {
+	t.Parallel()
+
+	nested := queryplan.Not{X: queryplan.Cmp{
+		Op: queryplan.OpEq,
+		L:  queryplan.Column{Qualifier: "resource", Name: "name"},
+		R:  queryplan.Call{Name: queryplan.FuncName("notAFunction")},
+	}}
+
+	require.ErrorContains(t, renderExpr(t, nested), "notAFunction")
+}
+
+// TestUnknownCastTargetIsRejected pins that the cast spelling table fails closed. Only the two
+// targets the translator emits have a spelling, and CastType is an exported string type, so a third
+// is buildable here. Falling through to the float spelling would compare against a value the policy
+// never named — a wrong filter where an error is the whole contract.
+func TestUnknownCastTargetIsRejected(t *testing.T) {
+	t.Parallel()
+
+	cast := queryplan.Cast{X: queryplan.Column{Name: "count"}, To: queryplan.CastType("decimal")}
+	require.ErrorContains(t, renderExpr(t, cast), `cannot render cast to "decimal"`)
+}

--- a/pgx/translate_test.go
+++ b/pgx/translate_test.go
@@ -152,6 +152,18 @@ func TestPlanKinds(t *testing.T) {
 	}
 }
 
+// TestUnrecognisedFilterKindIsRejected covers the remaining wire value: an unset kind is neither of
+// the constants above and must not be read as one of them.
+func TestUnrecognisedFilterKindIsRejected(t *testing.T) {
+	t.Parallel()
+
+	plan := &responsev1.PlanResourcesResponse{
+		Filter: &enginev1.PlanResourcesFilter{Kind: enginev1.PlanResourcesFilter_KIND_UNSPECIFIED},
+	}
+	_, err := cerbospgx.Translate(plan, "resource", testMapper())
+	require.ErrorContains(t, err, "unrecognised filter kind")
+}
+
 // -- emitted SQL ---------------------------------------------------------------------------------
 
 // TestNoPlanDataReachesSQLText is the injection guard. Every value in the plan below is chosen to
@@ -204,6 +216,44 @@ func TestSymmetricComparisonsNormaliseToColumnFirst(t *testing.T) {
 	result, err := translate(t, expr("eq", val(t, "x"), variable("request.resource.attr.name")))
 	require.NoError(t, err)
 	require.Equal(t, `("resource"."name" = $1::text)`, result.Where)
+}
+
+// TestOperatorSymbols pins the two lookup tables the renderer spells operators through.
+//
+// They are the kind of thing nothing else catches: a `+` written where `-` belongs, or `<` where
+// `<=` belongs, is valid SQL that quietly returns a different row set, and the corpus only notices
+// if some action happens to straddle the boundary the wrong symbol moves. Every arm is asserted so
+// there is no operator whose spelling is taken on trust.
+func TestOperatorSymbols(t *testing.T) {
+	t.Parallel()
+
+	t.Run("comparisons", func(t *testing.T) {
+		t.Parallel()
+
+		for operator, symbol := range map[string]string{
+			"eq": "=", "ne": "<>", "lt": "<", "le": "<=", "gt": ">", "ge": ">=",
+		} {
+			result, err := translate(t, expr(operator, variable("request.resource.attr.count"), val(t, 2)))
+			require.NoError(t, err, operator)
+			require.Equal(t, `("resource"."count" `+symbol+` $1::double precision)`, result.Where, operator)
+		}
+	})
+
+	t.Run("arithmetic", func(t *testing.T) {
+		t.Parallel()
+
+		// A column dividend keeps `div` and `mod` from folding to a constant, and the division
+		// shapes wrap the arithmetic in the guards that keep a zero divisor UNKNOWN — so these
+		// assert the operator appears rather than pinning the whole surrounding CASE.
+		for operator, symbol := range map[string]string{
+			"add": "+", "sub": "-", "mult": "*", "div": "/", "mod": "%",
+		} {
+			result, err := translate(t, expr("gt",
+				expr(operator, variable("request.resource.attr.count"), val(t, 2)), val(t, 1)))
+			require.NoError(t, err, operator)
+			require.Contains(t, result.Where, " "+symbol+" ", operator+": "+result.Where)
+		}
+	})
 }
 
 // TestReceiverSensitiveOperatorsKeepWireOrder is the reason eq/ne/in are normalised by name rather


### PR DESCRIPTION
Closes #319.

`ent` and `pgx` vendor the same translator under `internal/queryplan` so each module stays standalone
and a consumer pulls in only one. But only `pgx` pinned the hostile-plan invariants, and nothing
asserted the two copies stay in step — so a fix landing in one tree was caught only if a corpus action
happened to exercise it, and none of the hostile shapes come off a real planner wire at all.

**Affected adapters:** ent, pgx. **No change to what either adapter translates.**

## What changed

**Drift protection.** `conformance/scripts/validate-corpus.sh` now diffs the two vendored trees and
fails on any difference. Byte-identical rather than allowlisted — an allowlist is where a real
divergence hides as a comment tweak — so the two comment lines that differed are reworded to one
wording true in both modules. Both adapter workflows already run the script, and each triggers on
`conformance/**` as well as its own directory, so a one-sided edit fails whichever side it lands on.

**ent unit coverage.** `ent/translate_test.go` gains every invariant `pgx` pinned: 31 malformed-plan
non-panic cases, typed-nil oneof wrappers, the `mod` panic regression, the injection guard, LIKE
escaping, both alias-shadow guards, null-under-`not` nesting, value-first mirroring, plan kinds, cast
rejection. Plus an ent-specific dialect section, where a wrong spelling is often still *valid* SQL —
`||` is legal MySQL, where it means logical OR, and `LENGTH` is legal everywhere but counts bytes
there. New `ent/render_test.go` and `pgx/render_test.go` cover the renderer error paths no plan can
reach (an `Expr` type the switch doesn't know, a `Call` or `Cast` with no spelling), including that an
error raised deep in the tree escapes ent's `Builder.Wrap`, which drops errors added to the nested
builder it hands the callback.

`ent/render.go` goes from untested-without-Docker to **91.5%** statement coverage there, with all
three dispatch tables (`cmpSymbol`, `arithSymbol`, `castType`) at 100%.

**Dead branches deleted.** `int()`/`double()` fail closed, so `CastInt` was a constant nothing
constructed and a render path — including the MySQL `TRUNCATE` spelling — no test could reach. Both
cast-spelling tables now return an error for a target they don't know rather than falling through to
the float spelling, so removing the branch doesn't cost exhaustiveness. `ent/README.md` no longer
cites `TRUNCATE` as justification for the MySQL leg.

**Harness fix.** `ent/adversarial_test.go` discarded `selector.Err()` after `Query()`. `Query()` runs
the lazy predicate's second write pass and ent reports a failure there by collecting it on the
selector rather than returning it — and the truncated SQL still parses, so the run compared the wrong
row set against the oracle instead of failing. `render_test.go` pins that mechanism so the check can't
go vacuous.

**CI.** Both workflows run the unit suite as its own step before the container-backed one, so "these
tests need no Docker" is a checked claim rather than a comment: under `./...` a unit test that grew a
container dependency would be invisible, because the suite that follows starts Docker anyway.

## Two decisions worth a reviewer's attention

**Scope extended to pgx** in three places the issue didn't name — the symbol-table test, the no-Docker
CI step, and the README notes. The tree-sync and mirrored-suites rules cut both ways, so a pgx-only
gap would reintroduce exactly what #319 is about. Neither of the issue's out-of-scope items
(de-vendoring, changing what either adapter translates) is touched.

**ent doesn't quote hostile identifiers, and I documented rather than fixed it.** `sql.Builder.Ident`
treats a name already containing the dialect's quote character as pre-quoted and writes it through
bare, so a mapper column named ``we`ird`` is emitted unescaped. `pgx` quotes defensively and pins
that. No plan data reaches an identifier — every plan value is a bound parameter, asserted against
deliberately hostile policy strings — so this is a mapping naming constraint, not an injection
surface, and making it throw would be a consumer-visible break under a coverage ticket. It's now
pinned by a test and documented under its own `Identifier quoting` heading in `ent/README.md`, kept
out of the `Mapping hazards` section since it's about `Mapper` names rather than the rows a subquery
sees. **Happy to make it fail-closed in a follow-up if you'd prefer that.**

## Verification

| Check | Result |
| --- | --- |
| `conformance/scripts/validate-corpus.sh` | pass (146 actions, 20 seeds); confirmed it exits 1 on an introduced one-line drift and on a missing tree |
| `diff -r ent/internal/queryplan pgx/internal/queryplan` | identical |
| ent unit suite, `DOCKER_HOST` pointed at nothing | 126 tests pass — `setupSuite` is reached only from `TestAdversarialConformance` |
| pgx unit suite, same | 89 tests pass |
| ent full adversarial suite (Docker) | pass, 37.6s — SQLite, PostgreSQL and MySQL legs |
| pgx full adversarial suite (Docker) | pass, 15.2s |
| `golangci-lint run` both modules | clean |
| `golangci-lint fmt` both modules | no changes |

## Reproducing locally

```bash
# no services needed
(cd ent && go test -skip TestAdversarialConformance ./...)
(cd pgx && go test -skip TestAdversarialConformance ./...)

# adds the corpus replay — needs Docker (testcontainers starts the PDP and the databases)
(cd ent && go test ./...)   # SQLite in-memory + PostgreSQL + MySQL
(cd pgx && go test ./...)   # PostgreSQL

conformance/scripts/validate-corpus.sh
```

## Docs updated in the same commit

`CLAUDE.md`, `conformance/README.md` (new *Vendored code stays byte-identical* section), `ent/README.md`
and `pgx/README.md`.
