### PR TITLE
fix(convex): make the integration suite execute the adapter, and pin what push-down actually covers

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -124,8 +124,13 @@ What that second assertion looks like depends on where the adapter's NULL lives:
   harness asserts the aligned empty result *and* that `owner` (same column, no `nullable`) still
   returns its five explicit-null documents, so the empty set is the flag talking.
 - **convex** — a document store, so the seeded shape mirrors the convention directly: the harness
-  omits the field entirely and `q.eq(field, null)` does not match an absent field. Same paired
-  assertion as mongoose. Alignment here comes from the storage layout, not from the plan.
+  omits the field entirely, and because `aOptionalString` is `nullable: true` in the mapper the
+  adapter refuses the push-down and evaluates the predicate in its own JavaScript post-filter,
+  where the absent path raises the same CEL missing-attribute error that made `check()` deny. Same
+  paired assertion as mongoose — `owner` is the same seed field stored as an explicit null and
+  returns its five documents through that same evaluator. Alignment here comes from the storage
+  layout, not from the plan, and *not* from a Convex `q.eq(field, null)`: that code path never runs
+  for either action (cerbos/query-plan-adapters#327).
 - **langchain-chromadb, elasticsearch-java** — need no option at all: neither store can represent
   an explicit null distinguishably from a missing key, so every null-selecting direction already
   fails closed under both conventions. Their harnesses assert the rejection happens regardless,
@@ -389,7 +394,11 @@ guard; run it before trusting it.
    `expect(MANIFEST_ACTIONS.size).toBe(146)` and `expect(THROWING_ACTIONS).toHaveLength(50)` in
    `prisma/src/adversarial.test.ts`; the oracle counts too in the convex, langchain-chromadb and
    elasticsearch-java harnesses). Bump them deliberately — those assertions exist so a new action
-   cannot slip past an adapter unnoticed.
+   cannot slip past an adapter unnoticed. The convex harness additionally pins WHICH actions its
+   filter engine decides on its own, under each of its two mappers, because its README quotes those
+   counts as the coverage the differential actually buys
+   ([#327](https://github.com/cerbos/query-plan-adapters/issues/327)) — a new action lands in one
+   of those buckets and has to be named.
 7. Add the action to each harness's degeneracy-guard list so it cannot pass vacuously — to that
    harness's *compared* list where the adapter translates the shape, and to its liveness-only list
    where it does not, per "The degeneracy guard" above. Adding it to the compared list of an
@@ -662,7 +671,13 @@ the policy suite and classify it like anything else.
     MySQL and literal on SQLite, so one needle meant two things. Not expressible without an
     `ESCAPE` clause Prisma does not emit, so it is now `adapterUnsupported` and throws.
 
-  Each adapter's README names the stores its contract is actually proved on.
+  The same caution applies to a *hosted* store the harness substitutes a local build for: `convex`
+  runs against a pinned self-hosted `convex-backend` container, never Convex Cloud, and most of its
+  corpus is decided by the adapter's own JavaScript post-filter rather than by any filter engine at
+  all ([#327](https://github.com/cerbos/query-plan-adapters/issues/327)).
+
+  Each adapter's README names the stores its contract is actually proved on, and how much of the
+  corpus each one actually executes.
 
 ## Regenerating wire fixtures after a Cerbos version bump
 

--- a/convex/README.md
+++ b/convex/README.md
@@ -94,9 +94,11 @@ instead of returning documents the PDP denies.
 queryPlanToConvex({ queryPlan, mapper, nullAttributeRepresentation: "omitted" });
 ```
 
-Storing the field as absent rather than as an explicit `null` also aligns the two, since
-`q.eq(field, null)` does not match an absent field — but that is a property of your document
-shape, not of the plan, so the option remains the reliable guard.
+Storing the field as absent rather than as an explicit `null` also aligns the two, but not through
+the filter: a field that can be absent must be `nullable: true` in the mapper, and that makes the
+adapter refuse the push-down and evaluate the predicate in the `postFilter`, where an absent path
+is a CEL missing-attribute error and denies — the same three-valued logic `check()` applied. That
+is a property of your document shape, not of the plan, so the option remains the reliable guard.
 
 The rejection is deliberately wider than the shapes that actually over-grant — `x != null` and
 `!(x == null)` are aligned under both conventions — because negation is applied around the built
@@ -106,19 +108,54 @@ under any nesting. See [#302](https://github.com/cerbos/query-plan-adapters/issu
 
 ## Conformance contract
 
-The adapter is differentially tested with 20 hostile seed documents against Cerbos PDP 0.54.0 `checkResource` decisions: each query plan is executed by Convex, and the returned document IDs must equal the PDP's per-document decisions. The Spring Data adapter defines the reference semantics for this compatibility snapshot.
+The adapter is differentially tested with 20 hostile seed documents against Cerbos PDP 0.54.0 `checkResource` decisions: each query plan is translated by the adapter and executed inside a Convex query function, and the returned document IDs must equal the PDP's per-document decisions. The Spring Data adapter defines the reference semantics for this compatibility snapshot. How much of that execution is Convex's filter engine and how much is the adapter's `postFilter` is set out below.
 
 | Classification | Coverage |
 | --- | --- |
 | Oracle-tested | 134 of the 136 reference conformance actions, plus `matches()`, list indexing/`get-field`, `timestamp()`, and `int()`/`double()` cast plans that the Spring Data reference adapter rejects — the post-filter reimplements CEL cast semantics exactly (whole-string parse, truncation toward zero), so the SQL divergences do not apply (140 actions total) |
 | Fail-closed | `filter()`/`map()` used as a condition (they return a list, not a boolean) and a constant zero divisor whose sign the JSON hop into a Convex function discards (4 actions). All four throw during translation, before any filter exists; unknown operators and invalid expression structures still throw |
 | Explicit opt-in | Any plan that cannot be represented entirely as a Convex database filter requires `allowPostFilter: true` |
-| Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`. Under the default it already returns the empty set the PDP demands *when the document omits the field for a NULL value*, which is what the conformance harness seeds; a deployment that stores explicit nulls while omitting the attribute would over-grant |
+| Representation-dependent | `null-eq-missing` — rejected under `nullAttributeRepresentation: "omitted"`. Under the default it already returns the empty set the PDP demands *when the document omits the field for a NULL value*, which is what the conformance harness seeds. The alignment is the `postFilter`'s doing, not a Convex filter's: the field is `nullable: true`, so the predicate is evaluated in JavaScript and the absent path raises the same CEL missing-attribute error that made `check()` deny. A deployment that stores explicit nulls while omitting the attribute would over-grant |
 | Known planner divergence | `has()` on a missing attribute is currently folded by the Cerbos planner to `ALWAYS_ALLOWED`; `checkResource` still denies documents where the attribute is missing. Until the planner is fixed, use `R.attr.x != null` for database-backed attributes instead of `has(R.attr.x)` |
 
 This support statement includes value-first comparisons, field-to-field expressions, null and missing-attribute behavior, nested lambdas, collection macros, string and arithmetic expressions, timestamps, hierarchy operations, and chained nested fields. Fields that may be absent must be marked `nullable: true` in the mapper so the adapter evaluates their predicates with CEL-compatible missing-value semantics instead of pushing them to a Convex filter.
 
 Every fail-closed shape's error message is pinned in the shared corpus (`conformance/actions.json`) and asserted by this adapter's conformance run, so a classification proves the throw names its declared mechanism rather than merely that something threw.
+
+### What the differential proves, and what it does not
+
+Convex's filter API has no string, collection, arithmetic or cast operators, so most of the corpus
+is decided by the adapter's in-memory `postFilter` after an unfiltered `.collect()`. That is the
+adapter's design rather than a gap in the harness, but it changes what the numbers above mean, so
+the split is pinned by the conformance run instead of being left to inference:
+
+| Decided by | Default mapper | Pushdown mapper |
+| --- | --- | --- |
+| Convex's filter engine, alone | 13 | 21 |
+| the adapter's `postFilter` | 126 | 118 |
+| folded to `ALWAYS_DENIED` before any filter exists (`in-empty`) | 1 | 1 |
+
+For the 126 post-filtered actions the differential compares the adapter's CEL evaluator against the
+PDP's CEL evaluator; Convex's own comparison and ordering semantics only get a say on the 13.
+The **pushdown mapper** is a second leg that clears `nullable` on `owner` — the one nullable field
+the seeded documents always carry, since the table declares it `v.union(v.string(), v.null())`
+rather than `v.optional(...)`. That moves the null-comparison family (`null-eq`, `null-ne`,
+`null-not-eq`, `vf-null-ne` and the four `in-null-elem-*` shapes) into the engine, where
+`q.eq(field, null)` against a stored explicit null is proved against the same oracle. Both legs
+run in CI; the leg re-executes only those eight, because `nullable` is read in exactly one place in
+the adapter and an action whose execution path both mappers agree on is translated identically by
+both — a claim the harness pins rather than assumes.
+
+It cannot go further without lying about the documents: the other `nullable` fields
+(`aOptionalString`, `aDouble`, `createdAt`, `scope`, `mainCategory` and its two chained paths) are
+genuinely **absent** from some seeds, and a comparison against an absent path has CEL
+missing-attribute semantics that a Convex filter cannot reproduce — which is exactly what
+`nullable: true` exists to prevent.
+
+The harness runs against a self-hosted `convex-backend` container, pinned by tag and digest in
+`docker-compose.yml`. Convex Cloud is not exercised, so any divergence between the two — the
+filter engine, value ordering, or the `undefined`/`null` distinction — is outside what this
+contract proves.
 
 ## Mapping hazards
 

--- a/convex/convex/adversarial.ts
+++ b/convex/convex/adversarial.ts
@@ -1,14 +1,11 @@
-import type {
-  PlanExpressionOperand,
-  PlanResourcesResponse,
-} from "@cerbos/core";
 import type { Expression, FilterBuilder } from "convex/server";
 import { v } from "convex/values";
 
 import { PlanKind, queryPlanToConvex } from "../src/index";
-import type { Mapper } from "../src/index";
+import type { Mapper, MapperConfig } from "../src/index";
 import { mutation, query } from "./_generated/server";
 import type { DataModel } from "./_generated/dataModel";
+import { executionPathOf, isPlanResourcesResponse } from "./planExecution";
 
 const tag = v.object({ id: v.string(), name: v.optional(v.string()) });
 const label = v.object({ name: v.optional(v.string()) });
@@ -46,7 +43,10 @@ const document = {
 
 // Exported so the adversarial throw suite can invoke translation with the exact mapper the
 // backend uses — a duplicated copy would be a projection that can drift.
-export const MAPPER: Mapper = {
+//
+// Typed as the record arm of `Mapper` rather than as `Mapper` itself, so `PUSHDOWN_MAPPER` below
+// can derive from it without asserting away the function arm.
+export const MAPPER: Record<string, MapperConfig> = {
   "request.resource.attr.aBool": { field: "aBool" },
   "request.resource.attr.aString": { field: "aString" },
   "request.resource.attr.aNumber": { field: "aNumber" },
@@ -77,28 +77,45 @@ export const MAPPER: Mapper = {
   },
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+/**
+ * Fields `MAPPER` declares `nullable` that the seeded documents nonetheless ALWAYS carry.
+ *
+ * `nullable: true` means "this path may be absent from the document", and `canPushToDb` refuses to
+ * push any comparison touching such a field: an absent path has CEL missing-attribute semantics
+ * that a Convex comparison cannot reproduce. `owner` is the one nullable field whose value can be
+ * NULL while the key is still present — the table declares it `v.union(v.string(), v.null())`, not
+ * `v.optional(...)` — so the flag is buying nothing there and costs the whole null-comparison
+ * family its push-down.
+ *
+ * Demoting it is a statement about the DOCUMENT SHAPE, not about the plan, so the harness asserts
+ * the key is present on every seeded document before trusting this list
+ * (cerbos/query-plan-adapters#327).
+ */
+export const PUSHDOWN_DEMOTED_FIELDS = ["owner"] as const;
 
-const isPlanOperand = (value: unknown): value is PlanExpressionOperand => {
-  if (!isRecord(value)) return false;
-  if (typeof value["operator"] === "string") {
-    const operands = value["operands"];
-    return Array.isArray(operands) && operands.every(isPlanOperand);
-  }
-  if (typeof value["name"] === "string") return true;
-  return Object.prototype.hasOwnProperty.call(value, "value");
-};
+/**
+ * The same mapper with `nullable` cleared on {@link PUSHDOWN_DEMOTED_FIELDS}, so the comparison
+ * shapes over those fields are decided by Convex's filter engine instead of the adapter's
+ * in-memory post-filter. That moves the null-comparison family across the boundary, which is
+ * where Convex's own `q.eq(field, null)` semantics live.
+ *
+ * How much of the corpus each mapper actually hands to the engine is pinned by the harness and
+ * quoted in the adapter README; it is deliberately not restated here.
+ */
+export const PUSHDOWN_MAPPER: Record<string, MapperConfig> = Object.fromEntries(
+  Object.entries(MAPPER).map(([path, config]) =>
+    PUSHDOWN_DEMOTED_FIELDS.some((field) => field === config.field)
+      ? [path, { ...config, nullable: false }]
+      : [path, config],
+  ),
+);
 
-const isPlanResourcesResponse = (
-  value: unknown,
-): value is PlanResourcesResponse => {
-  if (!isRecord(value)) return false;
-  const kind = value["kind"];
-  if (kind === PlanKind.ALWAYS_ALLOWED || kind === PlanKind.ALWAYS_DENIED) {
-    return true;
-  }
-  return kind === PlanKind.CONDITIONAL && isPlanOperand(value["condition"]);
+/** Which mapper `executePlan` should translate with. */
+export type MapperVariant = "default" | "pushdown";
+
+const MAPPERS: Record<MapperVariant, Mapper> = {
+  default: MAPPER,
+  pushdown: PUSHDOWN_MAPPER,
 };
 
 export const insert = mutation({
@@ -124,6 +141,9 @@ export const executePlan = query({
     nullAttributeRepresentation: v.optional(
       v.union(v.literal("explicit"), v.literal("omitted")),
     ),
+    // #327: the pushdown leg replays the whole corpus with `nullable` demoted where the document
+    // shape allows it, so the mapper choice has to cross the Convex boundary too.
+    mapper: v.optional(v.union(v.literal("default"), v.literal("pushdown"))),
   },
   handler: async (ctx, args) => {
     const queryPlan: unknown = args.queryPlan;
@@ -136,23 +156,27 @@ export const executePlan = query({
       Expression<boolean>
     >({
       queryPlan,
-      mapper: MAPPER,
+      mapper: MAPPERS[args.mapper ?? "default"],
       allowPostFilter: true,
       nullAttributeRepresentation: args.nullAttributeRepresentation ?? "explicit",
     });
 
-    if (translated.kind === PlanKind.ALWAYS_DENIED) return [];
+    // Reported alongside the ids so the harness can assert WHICH half answered: a pushdown leg
+    // that quietly fell back to the post-filter would return the same ids (#327).
+    const execution = executionPathOf(translated);
+    if (translated.kind === PlanKind.ALWAYS_DENIED) return { ids: [], execution };
 
     let queryBuilder = ctx.db.query("adversarial");
     if (translated.kind === PlanKind.CONDITIONAL && translated.filter) {
       queryBuilder = queryBuilder.filter(translated.filter);
     }
     const docs = await queryBuilder.collect();
-    return docs
+    const ids = docs
       .filter((doc) =>
         translated.postFilter ? translated.postFilter({ ...doc }) : true,
       )
       .map((doc) => doc.id)
       .sort();
+    return { ids, execution };
   },
 });

--- a/convex/convex/planExecution.ts
+++ b/convex/convex/planExecution.ts
@@ -1,0 +1,58 @@
+import type {
+  PlanExpressionOperand,
+  PlanResourcesResponse,
+} from "@cerbos/core";
+
+import { PlanKind } from "../src/index";
+import type { QueryPlanToConvexResult } from "../src/index";
+
+// Shared by the two test backends. Both re-establish a plan's shape after it crosses the Convex
+// boundary as `v.any()`, and both report which half of the adapter's output actually answered the
+// query. One copy each: the guard is what stands between an arbitrary JSON payload and
+// `queryPlanToConvex`, and the path is a claim a harness asserts, so two drifting copies would
+// mean the two backends disagreed about what they had proved.
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isPlanOperand = (value: unknown): value is PlanExpressionOperand => {
+  if (!isRecord(value)) return false;
+  if (typeof value["operator"] === "string") {
+    const operands = value["operands"];
+    return Array.isArray(operands) && operands.every(isPlanOperand);
+  }
+  if (typeof value["name"] === "string") return true;
+  return Object.prototype.hasOwnProperty.call(value, "value");
+};
+
+export const isPlanResourcesResponse = (
+  value: unknown,
+): value is PlanResourcesResponse => {
+  if (!isRecord(value)) return false;
+  const kind = value["kind"];
+  if (kind === PlanKind.ALWAYS_ALLOWED || kind === PlanKind.ALWAYS_DENIED) {
+    return true;
+  }
+  return kind === PlanKind.CONDITIONAL && isPlanOperand(value["condition"]);
+};
+
+/**
+ * Which half of the adapter's output decided the query.
+ *
+ * A harness cannot tell `db` from `post` by looking at the ids: both are supposed to return the
+ * documents `check()` allows, so a leg that meant to exercise Convex's filter engine and silently
+ * fell back to the in-memory evaluator passes its oracle comparison unchanged. Reporting the path
+ * FROM THE BACKEND is what makes that assertable — deriving it in the harness instead would only
+ * re-run the same translation the harness already trusts, not observe the one that ran.
+ */
+export type ExecutionPath = "db" | "split" | "post" | "unconditional";
+
+// Generic over the filter's own types: `ConvexFilter` is a function type, so it is contravariant
+// in `Q` and a result built for a concrete `FilterBuilder` is not assignable to an `unknown` one.
+export const executionPathOf = <Q, R>(
+  translated: QueryPlanToConvexResult<Q, R>,
+): ExecutionPath => {
+  if (translated.kind !== PlanKind.CONDITIONAL) return "unconditional";
+  if (translated.filter && translated.postFilter) return "split";
+  return translated.filter ? "db" : "post";
+};

--- a/convex/convex/resources.ts
+++ b/convex/convex/resources.ts
@@ -1,5 +1,11 @@
-import { mutation, query } from "./_generated/server";
+import type { Expression, FilterBuilder } from "convex/server";
 import { v } from "convex/values";
+
+import { PlanKind, queryPlanToConvex } from "../src/index";
+import type { Mapper } from "../src/index";
+import { mutation, query } from "./_generated/server";
+import type { DataModel } from "./_generated/dataModel";
+import { executionPathOf, isPlanResourcesResponse } from "./planExecution";
 
 export const insert = mutation({
   args: {
@@ -29,164 +35,57 @@ export const deleteAll = mutation({
   },
 });
 
-const filterValue = v.union(v.string(), v.number(), v.boolean());
-const resourceField = v.union(
-  v.literal("key"),
-  v.literal("aBool"),
-  v.literal("aNumber"),
-  v.literal("aString"),
-  v.literal("aOptionalString"),
-  v.literal("nested.aBool"),
-  v.literal("nested.aNumber"),
-  v.literal("nested.aString"),
-);
-
-const requireArgument = <T>(value: T | undefined, name: string): T => {
-  if (value === undefined) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
+// Exported so the integration suite translates with the exact mapper this backend executes —
+// a duplicated copy in the test would be a projection that can drift.
+export const MAPPER: Mapper = {
+  "request.resource.attr.aBool": { field: "aBool" },
+  "request.resource.attr.aNumber": { field: "aNumber" },
+  "request.resource.attr.aString": { field: "aString" },
+  "request.resource.attr.aOptionalString": {
+    field: "aOptionalString",
+    nullable: true,
+  },
+  "request.resource.attr.nested.aBool": { field: "nested.aBool" },
+  "request.resource.attr.nested.aNumber": { field: "nested.aNumber" },
+  "request.resource.attr.nested.aString": { field: "nested.aString" },
 };
 
-export const filteredQuery = query({
-  args: {
-    filterType: v.string(),
-    filterField: v.optional(resourceField),
-    filterValue: v.optional(filterValue),
-    filterValues: v.optional(v.array(filterValue)),
-    filterField2: v.optional(resourceField),
-    filterValue2: v.optional(filterValue),
-  },
+/**
+ * Runs a Cerbos query plan against the `resources` table THROUGH THE ADAPTER.
+ *
+ * This used to be a `filterType`/`filterField`/`filterValue` switch that rebuilt each filter by
+ * hand, which meant the integration suite proved Convex's filter API worked and never executed a
+ * single translated filter (cerbos/query-plan-adapters#327). The plan goes in, the adapter's
+ * `filter`/`postFilter` pair comes out, and the keys it selects are what the suite compares
+ * against `check()`.
+ */
+export const executePlan = query({
+  args: { queryPlan: v.any() },
   handler: async (ctx, args) => {
-    const { filterType, filterField, filterValue, filterValues, filterField2, filterValue2 } = args;
-
-    let q = ctx.db.query("resources");
-
-    switch (filterType) {
-      case "eq":
-        return await q
-          .filter((f) =>
-            f.eq(
-              f.field(requireArgument(filterField, "filterField")),
-              requireArgument(filterValue, "filterValue"),
-            ),
-          )
-          .collect();
-      case "neq":
-        return await q
-          .filter((f) =>
-            f.neq(
-              f.field(requireArgument(filterField, "filterField")),
-              requireArgument(filterValue, "filterValue"),
-            ),
-          )
-          .collect();
-      case "gt":
-        return await q
-          .filter((f) =>
-            f.gt(
-              f.field(requireArgument(filterField, "filterField")),
-              requireArgument(filterValue, "filterValue"),
-            ),
-          )
-          .collect();
-      case "gte":
-        return await q
-          .filter((f) =>
-            f.gte(
-              f.field(requireArgument(filterField, "filterField")),
-              requireArgument(filterValue, "filterValue"),
-            ),
-          )
-          .collect();
-      case "lt":
-        return await q
-          .filter((f) =>
-            f.lt(
-              f.field(requireArgument(filterField, "filterField")),
-              requireArgument(filterValue, "filterValue"),
-            ),
-          )
-          .collect();
-      case "lte":
-        return await q
-          .filter((f) =>
-            f.lte(
-              f.field(requireArgument(filterField, "filterField")),
-              requireArgument(filterValue, "filterValue"),
-            ),
-          )
-          .collect();
-      case "not":
-        return await q
-          .filter((f) =>
-            f.not(
-              f.eq(
-                f.field(requireArgument(filterField, "filterField")),
-                requireArgument(filterValue, "filterValue"),
-              ),
-            ),
-          )
-          .collect();
-      case "and":
-        return await q
-          .filter((f) =>
-            f.and(
-              f.eq(
-                f.field(requireArgument(filterField, "filterField")),
-                requireArgument(filterValue, "filterValue"),
-              ),
-              f.neq(
-                f.field(requireArgument(filterField2, "filterField2")),
-                requireArgument(filterValue2, "filterValue2"),
-              ),
-            ),
-          )
-          .collect();
-      case "or":
-        return await q
-          .filter((f) =>
-            f.or(
-              f.eq(
-                f.field(requireArgument(filterField, "filterField")),
-                requireArgument(filterValue, "filterValue"),
-              ),
-              f.neq(
-                f.field(requireArgument(filterField2, "filterField2")),
-                requireArgument(filterValue2, "filterValue2"),
-              ),
-            ),
-          )
-          .collect();
-      case "in":
-        if (!filterValues || filterValues.length === 0) {
-          return [];
-        }
-        return await q
-          .filter((f) =>
-            f.or(
-              ...filterValues.map((value) =>
-                f.eq(
-                  f.field(requireArgument(filterField, "filterField")),
-                  value,
-                ),
-              ),
-            ),
-          )
-          .collect();
-      // Named for the SQL-ish shape, not a Cerbos operator: the planner has no existence
-      // operator, it emits ne(field, null) (cerbos/query-plan-adapters#261).
-      case "notNull":
-        return await q
-          .filter((f) =>
-            f.neq(
-              f.field(requireArgument(filterField, "filterField")),
-              undefined,
-            ),
-          )
-          .collect();
-      default:
-        return await q.collect();
+    const queryPlan: unknown = args.queryPlan;
+    if (!isPlanResourcesResponse(queryPlan)) {
+      throw new Error("Invalid Cerbos query plan");
     }
+
+    const translated = queryPlanToConvex<
+      FilterBuilder<DataModel["resources"]>,
+      Expression<boolean>
+    >({ queryPlan, mapper: MAPPER, allowPostFilter: true });
+
+    const execution = executionPathOf(translated);
+    if (translated.kind === PlanKind.ALWAYS_DENIED) return { keys: [], execution };
+
+    let queryBuilder = ctx.db.query("resources");
+    if (translated.kind === PlanKind.CONDITIONAL && translated.filter) {
+      queryBuilder = queryBuilder.filter(translated.filter);
+    }
+    const docs = await queryBuilder.collect();
+    const keys = docs
+      .filter((doc) =>
+        translated.postFilter ? translated.postFilter({ ...doc }) : true,
+      )
+      .map((doc) => doc.key)
+      .sort();
+    return { keys, execution };
   },
 });

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -7,7 +7,14 @@ import { GRPC as Cerbos } from "@cerbos/grpc";
 import { ConvexHttpClient } from "convex/browser";
 
 import { api } from "../convex/_generated/api.js";
-import { MAPPER } from "../convex/adversarial";
+import {
+  MAPPER,
+  PUSHDOWN_DEMOTED_FIELDS,
+  PUSHDOWN_MAPPER,
+  type MapperVariant,
+} from "../convex/adversarial";
+import type { ExecutionPath } from "../convex/planExecution";
+import type { Mapper } from ".";
 import { PlanKind, queryPlanToConvex } from ".";
 
 const CONVEX_URL = process.env["CONVEX_URL"] ?? "http://127.0.0.1:3210";
@@ -457,6 +464,94 @@ const DEGENERACY_LIVENESS_PROBES = [
   "cr-div-neg-zero",
 ] as const;
 
+// -- pushdown coverage (cerbos/query-plan-adapters#327) ------------------------------------------
+//
+// Convex has no string, collection, arithmetic or cast operators in its filter API, so most of the
+// corpus is decided by the adapter's in-memory post-filter after an unfiltered `.collect()` — the
+// differential is then adapter-CEL against PDP-CEL, and Convex's own comparison and ordering
+// semantics only get a say on the shapes that reach the engine. That split is the adapter's
+// documented design, but the SIZE of it is a fact about coverage, so it is pinned here and quoted
+// in the README rather than left to be re-derived by whoever next wonders.
+//
+// The lists below name the actions Convex's filter engine decides ON ITS OWN — a filter with no
+// post-filter beside it. An action gaining or losing push-down fails this pin, which is the point:
+// the README's numbers are only trustworthy while a test enforces them.
+
+const DB_DECIDED_DEFAULT = [
+  "cs-eq",
+  "double-negation",
+  "double-threshold",
+  "empty-string-eq",
+  "in-single",
+  "nary-and",
+  "neg-number",
+  "p-struct",
+  "triple-negation",
+  "unicode-eq",
+  "vf-ge",
+  "vf-le",
+  "vf-ne",
+];
+
+/**
+ * The actions `PUSHDOWN_MAPPER` moves into Convex's filter engine — the null-comparison family,
+ * un-blocked by clearing `nullable` on `owner`, a field the seeded documents always carry.
+ *
+ * These are the ONLY actions the pushdown leg re-executes. `nullable` is read in exactly one place
+ * in the adapter — `canPushToDb` — so an action whose execution path the two mappers agree on is
+ * translated identically by both, and replaying it would be a second identical query. The
+ * classification pin below is what makes that argument checkable rather than assumed: it asserts
+ * the full split under both mappers, so an action silently changing path fails there.
+ */
+const PUSHDOWN_ONLY_ACTIONS = [
+  "in-null-elem-mixed",
+  "in-null-elem-neg",
+  "in-null-elem-only",
+  "in-null-elem-only-neg",
+  "null-eq",
+  "null-ne",
+  "null-not-eq",
+  "vf-null-ne",
+];
+
+const DB_DECIDED_PUSHDOWN = [
+  ...DB_DECIDED_DEFAULT,
+  ...PUSHDOWN_ONLY_ACTIONS,
+].sort();
+
+/** `in-empty` folds to ALWAYS_DENIED, so no mapper can put it in either category. */
+const UNCONDITIONAL_ACTIONS = ["in-empty"];
+
+async function executionFor(
+  action: string,
+  mapper: Mapper,
+): Promise<ExecutionPath> {
+  const queryPlan = await cerbos.planResources({
+    principal: seedsFile.principal,
+    resource: { kind: seedsFile.resourceKind },
+    action,
+  });
+  if (queryPlan.kind !== PlanKind.CONDITIONAL) return "unconditional";
+  const { filter, postFilter } = queryPlanToConvex({
+    queryPlan,
+    mapper,
+    allowPostFilter: true,
+  });
+  if (filter && postFilter) return "split";
+  return filter ? "db" : "post";
+}
+
+/** Whether `path` — a mapped document field, dotted for nested ones — is present on `document`. */
+function documentCarries(document: unknown, path: string): boolean {
+  let current: unknown = document;
+  for (const part of path.split(".")) {
+    if (!isRecord(current)) return false;
+    if (!Object.prototype.hasOwnProperty.call(current, part)) return false;
+    current = current[part];
+  }
+  return true;
+}
+
 // -- deterministic derived fields (conformance/README.md, "Deterministic derived fields") --------
 //
 // Read from conformance/derived-fields.json rather than restated here. The same value feeds the
@@ -602,20 +697,38 @@ async function expectNonDegenerateOracle(action: string): Promise<void> {
   }).toEqual({ action, nonEmpty: true, nonTotal: true });
 }
 
-async function adapterFilteredIds(
+/**
+ * Executes the action's plan in Convex and reports the ids it selected AND which half of the
+ * adapter's output selected them. The path comes back from the backend rather than being
+ * re-derived here: re-deriving would only re-run the translation this harness already trusts, so a
+ * backend that used the wrong mapper would go unnoticed — both halves return the same ids.
+ */
+async function adapterRun(
   action: string,
   nullAttributeRepresentation: "explicit" | "omitted" = "explicit",
-): Promise<string[]> {
+  mapper: MapperVariant = "default",
+): Promise<{ ids: string[]; execution: string }> {
   const queryPlan = await cerbos.planResources({
     principal: seedsFile.principal,
     resource: { kind: seedsFile.resourceKind },
     action,
   });
-  if (queryPlan.kind === PlanKind.ALWAYS_DENIED) return [];
+  if (queryPlan.kind === PlanKind.ALWAYS_DENIED) {
+    return { ids: [], execution: "unconditional" };
+  }
   return convex.query(api.adversarial.executePlan, {
     queryPlan: JSON.parse(JSON.stringify(queryPlan)),
     nullAttributeRepresentation,
+    mapper,
   });
+}
+
+async function adapterFilteredIds(
+  action: string,
+  nullAttributeRepresentation: "explicit" | "omitted" = "explicit",
+  mapper: MapperVariant = "default",
+): Promise<string[]> {
+  return (await adapterRun(action, nullAttributeRepresentation, mapper)).ids;
 }
 
 beforeAll(async () => {
@@ -707,39 +820,173 @@ describe("adversarial conformance corpus", () => {
   );
 
   test.each(ORACLE_ACTIONS)("%s matches the check() oracle", async (action) => {
-    const [oracle, filtered] = await Promise.all([
+    const [oracle, run] = await Promise.all([
       oracleAllowedIds(action),
-      adapterFilteredIds(action),
+      adapterRun(action),
     ]);
-    expect(filtered).toEqual(oracle);
+    // The path the backend reports is checked against the pinned split, so the README's coverage
+    // table is a claim about what executed rather than about what this harness re-translates.
+    const expected = DB_DECIDED_DEFAULT.includes(action)
+      ? "db"
+      : UNCONDITIONAL_ACTIONS.includes(action)
+        ? "unconditional"
+        : "post";
+    expect({ ids: run.ids, execution: run.execution }).toEqual({
+      ids: oracle,
+      execution: expected,
+    });
+  });
+
+  // The pushdown leg. These eight shapes are answered above by the adapter's own CEL evaluator;
+  // here the SAME oracle is put to Convex's filter engine instead, so `q.eq(field, null)` and its
+  // negations are proved against the PDP rather than assumed to agree with the evaluator
+  // (cerbos/query-plan-adapters#327).
+  //
+  // The reported path is asserted alongside the ids, and that assertion is the whole leg: both
+  // halves return the documents check() allows, so a backend that ignored the mapper argument and
+  // post-filtered these would satisfy the id comparison and prove nothing.
+  test.each(PUSHDOWN_ONLY_ACTIONS)(
+    "%s matches the check() oracle when Convex's filter engine decides it",
+    async (action) => {
+      const [oracle, pushed] = await Promise.all([
+        oracleAllowedIds(action),
+        adapterRun(action, "explicit", "pushdown"),
+      ]);
+      expect({ ids: pushed.ids, execution: pushed.execution }).toEqual({
+        ids: oracle,
+        execution: "db",
+      });
+    },
+  );
+
+  // The pushdown mapper is a claim about the DOCUMENT SHAPE — "this field is never absent" — and
+  // nothing in the plan can check it. If a seed ever stopped carrying the key, `canPushToDb` would
+  // hand Convex a comparison whose CEL meaning is a missing-attribute error, and the engine would
+  // answer it as an ordinary comparison against `undefined`.
+  test("the pushdown mapper only demotes fields every seeded document carries", () => {
+    const absent: string[] = [];
+    for (const seed of seedsFile.seeds) {
+      const document = storedDocument(seed);
+      for (const field of PUSHDOWN_DEMOTED_FIELDS) {
+        if (!documentCarries(document, field)) {
+          absent.push(`${seed.id}.${field}`);
+        }
+      }
+    }
+    expect({ demoted: [...PUSHDOWN_DEMOTED_FIELDS], absent }).toEqual({
+      demoted: ["owner"],
+      absent: [],
+    });
+  });
+
+  // The README quotes these counts; this is what keeps them true. A shape that gains or loses
+  // push-down fails here rather than silently making the documented coverage a lie.
+  test("pins how much of the corpus each mapper hands to Convex's filter engine", async () => {
+    const classify = async (mapper: Mapper) => {
+      const byExecution: Record<ExecutionPath, string[]> = {
+        db: [],
+        split: [],
+        post: [],
+        unconditional: [],
+      };
+      for (const action of ORACLE_ACTIONS) {
+        byExecution[await executionFor(action, mapper)].push(action);
+      }
+      return byExecution;
+    };
+
+    const base = await classify(MAPPER);
+    const pushdown = await classify(PUSHDOWN_MAPPER);
+
+    expect({
+      total: ORACLE_ACTIONS.length,
+      defaultDb: base.db,
+      defaultSplit: base.split,
+      defaultUnconditional: base.unconditional,
+      defaultPostCount: base.post.length,
+      pushdownDb: pushdown.db,
+      pushdownSplit: pushdown.split,
+      pushdownPostCount: pushdown.post.length,
+      // The two mappers must differ ONLY where the pushdown leg re-executes, which is what makes
+      // skipping the other 132 actions there sound rather than a coverage hole.
+      moved: pushdown.db.filter((action) => !base.db.includes(action)),
+    }).toEqual({
+      total: 140,
+      defaultDb: DB_DECIDED_DEFAULT,
+      // No corpus action currently splits: `buildFilters` only splits a root `and`, and every
+      // hostile shape that mixes pushable and non-pushable children is rooted elsewhere.
+      defaultSplit: [],
+      defaultUnconditional: UNCONDITIONAL_ACTIONS,
+      defaultPostCount: 126,
+      pushdownDb: DB_DECIDED_PUSHDOWN,
+      pushdownSplit: [],
+      pushdownPostCount: 118,
+      moved: PUSHDOWN_ONLY_ACTIONS,
+    });
   });
 
   // #302. `null-eq-missing` probes `aOptionalString == null`, and `aOptionalString` follows the
   // corpus default: a NULL column sends NO attribute, so check() denies every document.
   //
-  // Convex is a document store, so the SEEDED SHAPE can mirror that convention directly: this
-  // harness omits `aOptionalString` entirely for a NULL column, and `q.eq(field, null)` does not
-  // match an absent field. The default translation therefore already returns the empty set the
-  // oracle demands — alignment that comes from the storage layout, not from anything the adapter
-  // knows about the plan. A deployment that stored explicit nulls while omitting the attribute at
-  // check time would over-grant exactly as a SQL adapter does, which is what the option guards.
+  // Convex is a document store, so the SEEDED SHAPE mirrors that convention directly: this harness
+  // omits `aOptionalString` entirely for a NULL column. What decides the action is the ADAPTER'S
+  // POST-FILTER, not a Convex `q.eq(field, null)` — `aOptionalString` is `nullable: true` in the
+  // mapper, so `canPushToDb` refuses the push-down and the whole predicate is evaluated in
+  // JavaScript. There `getNestedValue` finds no such key and yields a CEL missing-attribute error,
+  // which denies, so the empty set the oracle demands comes out of the same three-valued logic
+  // check() applied (cerbos/query-plan-adapters#327 corrected this rationale — the `q.eq` path it
+  // used to name never executes).
+  //
+  // The `owner` control runs through that same evaluator: it maps to the same seed field but IS
+  // stored as an explicit null, so `getNestedValue` finds the key, `null == null` holds, and its
+  // five documents come back. That is what makes the empty result above the document shape talking
+  // rather than a filter that matches nothing everywhere.
+  //
+  // A deployment that stored explicit nulls while omitting the attribute at check time would
+  // over-grant exactly as a SQL adapter does, which is what the option guards.
   test.each(NULL_REPRESENTATION_OMITTED)(
     "$action aligns via the omitted document shape and is rejected under omitted ($reason)",
     async ({ action, message }) => {
       expect(await oracleAllowedIds(action)).toEqual([]);
       expect(await adapterFilteredIds(action, "explicit")).toEqual([]);
 
-      // `owner` maps to the same seed field but IS stored as an explicit null, so the empty
-      // result above is the document shape talking, not a filter that matches nothing everywhere.
+      // The rationale above names the post-filter, so pin that it IS the post-filter — as the
+      // backend reports it, not as this harness would re-derive it. A mapper change that started
+      // pushing either action down would make the comment false while every id comparison passed.
       const explicitNullOracle = await oracleAllowedIds("null-eq");
       expect(explicitNullOracle.length).toBeGreaterThan(0);
-      expect(await adapterFilteredIds("null-eq", "explicit")).toEqual(
-        explicitNullOracle,
-      );
+      const [missingRun, controlRun] = await Promise.all([
+        adapterRun(action, "explicit"),
+        adapterRun("null-eq", "explicit"),
+      ]);
+      expect({
+        missing: missingRun.execution,
+        control: controlRun.execution,
+        controlIds: controlRun.ids,
+      }).toEqual({
+        missing: "post",
+        control: "post",
+        controlIds: explicitNullOracle,
+      });
 
+      // Under the pushdown mapper the control IS answered by Convex's filter engine, so the same
+      // five documents coming back proves `q.eq(field, null)` agrees with the evaluator on a
+      // stored explicit null — the claim the corrected rationale no longer makes about the
+      // missing-field case.
+      const pushedControl = await adapterRun("null-eq", "explicit", "pushdown");
+      expect(pushedControl).toEqual({
+        execution: "db",
+        ids: explicitNullOracle,
+      });
+
+      // The rejection is the null-operand scan over the plan, which runs before translation picks
+      // a path, so it cannot depend on the mapper.
       await expect(adapterFilteredIds(action, "omitted")).rejects.toThrow(
         message,
       );
+      await expect(
+        adapterFilteredIds(action, "omitted", "pushdown"),
+      ).rejects.toThrow(message);
     },
   );
 

--- a/convex/src/integration.test.ts
+++ b/convex/src/integration.test.ts
@@ -1,14 +1,37 @@
 import { beforeAll, afterAll, test, expect, describe } from "@jest/globals";
-import { ConvexHttpClient } from "convex/browser";
-import { api } from "../convex/_generated/api.js";
-import { queryPlanToConvex, PlanKind, Mapper } from ".";
+import type { Resource as CerbosResource, Value } from "@cerbos/core";
 import { GRPC as Cerbos } from "@cerbos/grpc";
+import { ConvexHttpClient } from "convex/browser";
+
+import { api } from "../convex/_generated/api.js";
+
+// What this suite is for, and what it deliberately leaves alone.
+//
+// `index.test.ts` proves the SHAPE of the filter the adapter builds, but it runs that filter
+// against a hand-rolled mock of Convex's `FilterBuilder`. Nothing in that suite can catch the mock
+// lying about what Convex's real filter engine does with the expression tree it is handed. That is
+// the gap this suite closes, so every case here is one the adapter PUSHES DOWN — plus the one that
+// splits, which carries a `postFilter` alongside the pushed-down half.
+//
+// It used to assert `result.kind === CONDITIONAL` and then run a hand-written query built from a
+// `filterType`/`filterField`/`filterValue` switch, so the translated filter was discarded and the
+// suite proved Convex's filter API worked (cerbos/query-plan-adapters#327).
+//
+// Post-filter-only shapes are NOT rehearsed here. `src/adversarial.test.ts` already executes 126
+// of them inside a real Convex backend against per-document `check()` decisions; adding a second,
+// weaker copy over the non-hostile `/policies` suite would buy runtime, not coverage.
+//
+// Expectations are per-document `checkResource` decisions, not hand-written key lists — the same
+// oracle recipe the shared corpus uses (conformance/README.md).
 
 const CONVEX_URL = process.env["CONVEX_URL"] || "http://127.0.0.1:3210";
 const convex = new ConvexHttpClient(CONVEX_URL);
 const cerbos = new Cerbos("127.0.0.1:3593", { tls: false });
 
-interface Resource {
+const RESOURCE_KIND = "resource";
+const PRINCIPAL = { id: "user1", roles: ["USER"] };
+
+interface Fixture {
   key: string;
   aBool: boolean;
   aNumber: number;
@@ -21,7 +44,12 @@ interface Resource {
   };
 }
 
-const fixtureResources: Resource[] = [
+/**
+ * Chosen so every action below allows some fixtures and denies others — a suite whose oracle is
+ * empty or total passes without discriminating anything, which is the failure mode the corpus
+ * calls a degenerate oracle. The `oracle is not degenerate` test enforces it.
+ */
+const fixtures: Fixture[] = [
   {
     key: "a",
     aBool: true,
@@ -42,14 +70,130 @@ const fixtureResources: Resource[] = [
     aBool: false,
     aNumber: 3,
     aString: "string3",
-    nested: { aBool: true, aNumber: 1, aString: "string" },
+    nested: { aBool: false, aNumber: 2, aString: "testing" },
+  },
+  {
+    key: "d",
+    aBool: true,
+    aNumber: 4,
+    aString: "other",
+    aOptionalString: "set",
+    nested: { aBool: true, aNumber: 3, aString: "test123" },
+  },
+  {
+    key: "e",
+    aBool: false,
+    aNumber: 0,
+    aString: "string",
+    nested: { aBool: false, aNumber: 0, aString: "none" },
   },
 ];
 
+/**
+ * The attributes `check()` sees must be the ones the stored document carries, or the two sides of
+ * the differential are answering questions about different data. A fixture with no
+ * `aOptionalString` sends no attribute, matching the document that omits the field.
+ */
+function checkResource(fixture: Fixture): CerbosResource {
+  const attr: Record<string, Value> = {
+    aBool: fixture.aBool,
+    aNumber: fixture.aNumber,
+    aString: fixture.aString,
+    nested: {
+      aBool: fixture.nested.aBool,
+      aNumber: fixture.nested.aNumber,
+      aString: fixture.nested.aString,
+    },
+  };
+  if (fixture.aOptionalString !== undefined) {
+    attr["aOptionalString"] = fixture.aOptionalString;
+  }
+  return { kind: RESOURCE_KIND, id: fixture.key, attr };
+}
+
+async function oracleAllowedKeys(action: string): Promise<string[]> {
+  const keys: string[] = [];
+  for (const fixture of fixtures) {
+    const result = await cerbos.checkResource({
+      principal: PRINCIPAL,
+      resource: checkResource(fixture),
+      actions: [action],
+    });
+    if (result.isAllowed(action)) keys.push(fixture.key);
+  }
+  return keys.sort();
+}
+
+/**
+ * Plans, translates, and executes the ADAPTER'S filter against the real Convex backend, reporting
+ * the keys it selected and which half of the adapter's output selected them. The path is the
+ * backend's own answer — re-deriving it here would re-run the translation rather than observe the
+ * one that ran, and both halves return the same keys.
+ */
+async function adapterRun(
+  action: string,
+): Promise<{ keys: string[]; execution: string }> {
+  const queryPlan = await cerbos.planResources({
+    principal: PRINCIPAL,
+    resource: { kind: RESOURCE_KIND },
+    action,
+  });
+  return convex.query(api.resources.executePlan, {
+    queryPlan: JSON.parse(JSON.stringify(queryPlan)),
+  });
+}
+
+/**
+ * The one action that splits: `and(eq(aBool, true), contains(nested.aString, "test"))`. The
+ * pushed-down half runs in Convex's filter engine and the `contains` half in the `postFilter`,
+ * both inside the same Convex query function.
+ */
+const SPLIT_ACTION = "combined-and";
+
+/**
+ * Actions the adapter pushes into Convex's filter engine, chosen so each `q.*` builder method the
+ * adapter can emit is executed at least once: `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `and`, `or`,
+ * `not`, `field`, and the `or`-of-`eq` composition `in` translates to. Every oracle is non-empty
+ * and non-total over the fixtures above, asserted below.
+ *
+ * A post-filter-only shape does not belong in this list — its per-action test would fail, since
+ * every entry here is asserted to be answered by the engine. That is deliberate: those shapes are
+ * the adversarial harness's job, and a second copy of them over the non-hostile `/policies` suite
+ * would buy runtime, not coverage.
+ */
+const DISCRIMINATING_ACTIONS = [
+  // Pushed to Convex's filter engine in full.
+  "and",
+  "bare-bool",
+  "bare-bool-negated",
+  "bare-bool-nested",
+  "bare-bool-nested-negated",
+  "equal",
+  "equal-bool-false",
+  "equal-nested",
+  "explicit-deny",
+  "gt",
+  "gte",
+  "in",
+  "in-number",
+  "lt",
+  "lte",
+  "nand",
+  "ne",
+  "nor",
+  "or",
+  "relation-eq-number",
+  "relation-gt-number",
+  SPLIT_ACTION,
+];
+
+/** Total and empty BY CONSTRUCTION, so they are excluded from the degeneracy guard. */
+const UNCONDITIONAL_ACTIONS = ["always-allow", "always-deny"];
+
 beforeAll(async () => {
   await convex.mutation(api.resources.deleteAll, {});
-  for (const resource of fixtureResources) {
-    await convex.mutation(api.resources.insert, resource);
+  for (const fixture of fixtures) {
+    await convex.mutation(api.resources.insert, fixture);
   }
 });
 
@@ -57,195 +201,53 @@ afterAll(async () => {
   await convex.mutation(api.resources.deleteAll, {});
 });
 
-const defaultMapper: Mapper = {
-  "request.resource.attr.aBool": { field: "aBool" },
-  "request.resource.attr.aNumber": { field: "aNumber" },
-  "request.resource.attr.aString": { field: "aString" },
-  "request.resource.attr.aOptionalString": { field: "aOptionalString" },
-  "request.resource.attr.nested.aBool": { field: "nested.aBool" },
-  "request.resource.attr.nested.aNumber": { field: "nested.aNumber" },
-  "request.resource.attr.nested.aString": { field: "nested.aString" },
-};
-
 describe("Integration: Convex + Cerbos", () => {
-  test("eq filter against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "equal",
-    });
+  test.each(DISCRIMINATING_ACTIONS)(
+    "%s: Convex's filter engine selects the documents check() allows",
+    async (action) => {
+      const [oracle, run] = await Promise.all([
+        oracleAllowedKeys(action),
+        adapterRun(action),
+      ]);
+      // The path is asserted with the keys: a case that stopped pushing down would still return
+      // the right keys, via the post-filter, and prove nothing about Convex.
+      expect({ keys: run.keys, pushedDown: run.execution }).toEqual({
+        keys: oracle,
+        pushedDown: action === SPLIT_ACTION ? "split" : "db",
+      });
+    },
+  );
 
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
+  test.each(UNCONDITIONAL_ACTIONS)(
+    "%s: the unconditional plan selects the documents check() allows",
+    async (action) => {
+      const [oracle, run] = await Promise.all([
+        oracleAllowedKeys(action),
+        adapterRun(action),
+      ]);
+      expect({ keys: run.keys, execution: run.execution }).toEqual({
+        keys: oracle,
+        execution: "unconditional",
+      });
+    },
+  );
 
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "eq",
-      filterField: "aBool",
-      filterValue: true,
-    });
+  test("oracle is not degenerate", async () => {
+    const degenerate: string[] = [];
+    for (const action of DISCRIMINATING_ACTIONS) {
+      const allowed = await oracleAllowedKeys(action);
+      if (allowed.length === 0 || allowed.length === fixtures.length) {
+        degenerate.push(`${action} (${allowed.length}/${fixtures.length})`);
+      }
+    }
+    expect(degenerate).toEqual([]);
 
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources.filter((r) => r.aBool).map((r) => r.key).sort(),
-    );
+    // The unconditional pair is the complement: it must stay total and empty, otherwise it has
+    // drifted into the guarded set without anyone noticing.
+    expect({
+      allow: await oracleAllowedKeys("always-allow"),
+      deny: await oracleAllowedKeys("always-deny"),
+    }).toEqual({ allow: fixtures.map((f) => f.key).sort(), deny: [] });
   });
 
-  test("ne filter against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "ne",
-    });
-
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
-
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "neq",
-      filterField: "aString",
-      filterValue: "string",
-    });
-
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources.filter((r) => r.aString !== "string").map((r) => r.key).sort(),
-    );
-  });
-
-  test("gt filter against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "gt",
-    });
-
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
-
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "gt",
-      filterField: "aNumber",
-      filterValue: 1,
-    });
-
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources.filter((r) => r.aNumber > 1).map((r) => r.key).sort(),
-    );
-  });
-
-  test("in filter (composed as OR of eq) against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "in",
-    });
-
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
-
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "in",
-      filterField: "aString",
-      filterValues: ["string", "anotherString"],
-    });
-
-    const allowed = new Set(["string", "anotherString"]);
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources.filter((r) => allowed.has(r.aString)).map((r) => r.key).sort(),
-    );
-  });
-
-  test("and filter against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "and",
-    });
-
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
-
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "and",
-      filterField: "aBool",
-      filterValue: true,
-      filterField2: "aString",
-      filterValue2: "string",
-    });
-
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources
-        .filter((r) => r.aBool && r.aString !== "string")
-        .map((r) => r.key)
-        .sort(),
-    );
-  });
-
-  test("or filter against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "or",
-    });
-
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
-
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "or",
-      filterField: "aBool",
-      filterValue: true,
-      filterField2: "aString",
-      filterValue2: "string",
-    });
-
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources
-        .filter((r) => r.aBool || r.aString !== "string")
-        .map((r) => r.key)
-        .sort(),
-    );
-  });
-
-  test("not filter against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "explicit-deny",
-    });
-
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
-
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "not",
-      filterField: "aBool",
-      filterValue: true,
-    });
-
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources.filter((r) => !r.aBool).map((r) => r.key).sort(),
-    );
-  });
-
-  test("IS NOT NULL filter against real Convex DB", async () => {
-    const queryPlan = await cerbos.planResources({
-      principal: { id: "user1", roles: ["USER"] },
-      resource: { kind: "resource" },
-      action: "is-set",
-    });
-
-    const result = queryPlanToConvex({ queryPlan, mapper: defaultMapper });
-    expect(result.kind).toBe(PlanKind.CONDITIONAL);
-
-    const docs = await convex.query(api.resources.filteredQuery, {
-      filterType: "notNull",
-      filterField: "aOptionalString",
-    });
-
-    expect(docs.map((d: Resource) => d.key).sort()).toEqual(
-      fixtureResources
-        .filter((r) => r.aOptionalString !== undefined)
-        .map((r) => r.key)
-        .sort(),
-    );
-  });
 });

--- a/convex/tsconfig.typecheck.json
+++ b/convex/tsconfig.typecheck.json
@@ -1,11 +1,13 @@
 {
   "//": "Type-checks the full source tree, including the test suites that tsconfig.json excludes from the emitting `tsc --build`. Never emits, so nothing here can reach lib/.",
+  "//rootDir": "The test backends under convex/ are not part of the published surface, so tsconfig.json roots the emitting build at src/. This config emits nothing, and widening the root is what lets a helper shared BETWEEN those backends be checked rather than duplicated into each of them.",
   "extends": "./tsconfig.json",
   "include": ["src"],
   "exclude": [],
   "compilerOptions": {
     "noEmit": true,
     "composite": false,
+    "rootDir": ".",
     "types": ["node"],
     "declaration": false,
     "declarationMap": false,


### PR DESCRIPTION
Closes #327.

Affects the **convex** adapter, plus a docs-only change to `conformance/README.md` (which re-runs every adapter's workflow — no corpus data moved, so no other adapter's classification changes).

## 1. The integration suite discarded the translated filter

`convex/src/integration.test.ts` planned against a real PDP, asserted only `result.kind === CONDITIONAL`, then ran a **hand-written** query built from a `filterType`/`filterField`/`filterValue` switch in `convex/convex/resources.ts`. The adapter's output was never executed — the suite proved Convex's filter API worked.

It now routes every case through `api.resources.executePlan`, which applies the adapter's own `filter`/`postFilter` pair. The switch is deleted. Expectations are per-document `checkResource` decisions rather than hand-written key lists — the oracle recipe `conformance/README.md` documents — and the fixture set grew to 5 so every case's oracle is non-empty and non-total, enforced by a degeneracy guard.

Post-filter-only shapes are deliberately **not** rehearsed there: `src/adversarial.test.ts` already executes 126 of them inside a real Convex backend against `check()`. So every remaining case is one Convex's engine decides, plus `combined-and`, which splits between the filter and the post-filter. A post-filter-only case added to that list fails its own assertion.

## 2. Push-down coverage is now stated and pinned

Convex's filter API has no string, collection, arithmetic or cast operators, so most of the corpus is decided by the adapter's in-memory `postFilter` after an unfiltered `.collect()` — the differential is then adapter-CEL against PDP-CEL. That is the adapter's design, not the harness cheating, but it was nowhere written down.

| Decided by | Default mapper | Pushdown mapper |
| --- | --- | --- |
| Convex's filter engine, alone | 13 | 21 |
| the adapter's `postFilter` | 126 | 118 |
| folded to `ALWAYS_DENIED` before any filter exists (`in-empty`) | 1 | 1 |

The **pushdown leg** clears `nullable` on `owner` — the one nullable mapper entry the seeded documents always carry, since the table declares it `v.union(v.string(), v.null())` rather than `v.optional(...)`. That moves the null-comparison family (`null-eq`, `null-ne`, `null-not-eq`, `vf-null-ne`, four `in-null-elem-*`) into the engine, where `q.eq(field, null)` is proved against the same oracle.

It re-executes only those eight. `nullable` is read in exactly one place in the adapter — `canPushToDb` — so an action both mappers classify alike is translated identically by both; the classification pin asserts the full split under both mappers, which makes that argument checkable rather than assumed. The other nullable fields are genuinely **absent** from some seeds and cannot be demoted without lying about the documents; the README says so.

The README also records that the contract is proved on a pinned self-hosted `convex-backend` container and never on Convex Cloud.

## 3. The `null-eq-missing` rationale named a code path that never runs

Three places justified alignment with \"\`q.eq(field, null)\` does not match an absent field\". That path never executes: `aOptionalString` is `nullable: true`, so `canPushToDb` refuses the push-down and the adapter's post-filter decides it, reading the absent path as a CEL missing-attribute error — the same three-valued logic that made `check()` deny. The explicit-null `owner` control returns its five documents through that same evaluator.

Corrected in the harness comment, `convex/README.md` and `conformance/README.md`, and pinned: the test now asserts both the probe and its control really are post-filter-decided, so a mapper change that started pushing either down fails rather than leaving the comment quietly false.

## Reviewer notes

**The first version of the pushdown leg passed vacuously.** I aliased `MAPPERS.pushdown` to the default mapper and the suite stayed green — both halves return the ids `check()` allows, so an id comparison cannot tell them apart, and the harness-side classification only re-ran a translation it already trusted. Both test backends now report which half answered (`executionPathOf` in the new `convex/convex/planExecution.ts`), and the leg asserts it. The same sabotage now fails 9 tests. The main 140-action leg checks its reported path against the pinned split too, so the README table is a claim about what executed.

`convex/tsconfig.typecheck.json` gains `rootDir: "."`. The emitting `tsconfig.json` is untouched and still roots at `src/`; the typecheck config emits nothing, and widening its root is what lets `planExecution.ts` be shared between the two test backends instead of duplicated into each. `lib/` is unchanged.

**No CI change.** The pushdown leg runs inside the existing adversarial step — no new job, no new matrix leg.

## Verification

All run locally against the pinned Cerbos PDP and a self-hosted Convex backend:

- `npm run typecheck`, `npm run build` — clean
- `npm test` — 115 passed
- `npm run test:integration` — 25 passed
- `npm run test:adversarial` — 160 passed
- `conformance/scripts/validate-corpus.sh` — corpus valid: 146 actions, 20 seeds

To reproduce, a reviewer needs Docker (the Convex backend via `npm run convex:up`, then `npx convex deploy` and `npx convex codegen` against it) and the Cerbos CLI.