### PR TITLE
refactor(spring-data): collapse Scope's three partial resolvers into one total resolve()

### DIFF
--- a/spring-data/CONTEXT.md
+++ b/spring-data/CONTEXT.md
@@ -25,6 +25,19 @@ Terms used by this adapter's code, tests, and reviews. Architecture vocabulary
   directional operators (`lt`↔`gt`). Receiver-sensitive operators
   (`contains`/`startsWith`/`endsWith`) are exempt — the receiver's position is
   meaning, not noise. Overrides observe the mirrored operator name.
+- **Scope / Resolution** — the single variable-resolution seam. `resolve(var)` is
+  total: every plan variable lands in `ResolvedScalar` (the mapping it was
+  resolved through, plus a column when this scope's `From` holds one — a Field
+  behind a relation prefix is scalar with no column here) or `ResolvedRelation`
+  (the join chain plus its **owner**), or throws naming why. Chain walking,
+  lambda delegation and owner anchoring live only here; `path(var)` is a
+  narrowing over it, not a second resolver.
+- **Owner anchoring** — a `ResolvedRelation` carries the scope that HOLDS its
+  first hop, not the scope that resolved it. `R.attr.tags` referenced inside a
+  `categories.exists(c, …)` body is owned by the root, so its subquery
+  correlates the root's `From`. Getting this wrong is silent rather than loud:
+  the element entity can carry a collection of the same name, so the query
+  still builds and returns the wrong rows.
 - **ChainSubquery** — the one correlated-subquery skeleton. It anchors
   correlation at the scope that owns the relation and joins through every hop
   of a multi-hop chain; all collection operators compose over it.

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/HierarchyTranslator.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/HierarchyTranslator.java
@@ -180,7 +180,7 @@ final class HierarchyTranslator {
                 return new Hierarchy.Constant(splitLiteral(raw, delimiter), delimiter);
             }
             if (strOp.getNodeCase() == Operand.NodeCase.VARIABLE) {
-                return new Hierarchy.FieldRef(scope.resolvePath(strOp.getVariable()), delimiter);
+                return new Hierarchy.FieldRef(scope.path(strOp.getVariable()), delimiter);
             }
             throw new IllegalArgumentException("hierarchy(string, delimiter) requires a value or field operand");
         }
@@ -189,7 +189,7 @@ final class HierarchyTranslator {
             return switch (inner.getNodeCase()) {
                 case VALUE -> new Hierarchy.Constant(
                         splitLiteral(String.valueOf(PlanValues.protoValueToJava(inner.getValue())), "."), ".");
-                case VARIABLE -> new Hierarchy.FieldRef(scope.resolvePath(inner.getVariable()), ".");
+                case VARIABLE -> new Hierarchy.FieldRef(scope.path(inner.getVariable()), ".");
                 case EXPRESSION -> {
                     if (!"list".equals(inner.getExpression().getOperator())) {
                         throw new IllegalArgumentException("hierarchy requires a value, field, or list operand");
@@ -199,7 +199,7 @@ final class HierarchyTranslator {
                         switch (seg.getNodeCase()) {
                             case VALUE -> segs.add(new Seg.Const(
                                     String.valueOf(PlanValues.protoValueToJava(seg.getValue()))));
-                            case VARIABLE -> segs.add(new Seg.FieldSeg(scope.resolvePath(seg.getVariable())));
+                            case VARIABLE -> segs.add(new Seg.FieldSeg(scope.path(seg.getVariable())));
                             default -> throw new IllegalArgumentException(
                                     "hierarchy list segment must be a value or field, got " + seg.getNodeCase());
                         }

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/Scope.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/Scope.java
@@ -11,31 +11,79 @@ import java.util.Map;
 
 /**
  * Resolution context for Cerbos plan variables: maps a variable such as
- * {@code request.resource.attr.foo} (or a lambda-scoped {@code t.name}) to a JPA {@link Path}
- * or an {@link AttributeMapping}, relative to the {@code From} the current (sub)query is built
- * against.
+ * {@code request.resource.attr.foo} (or a lambda-scoped {@code t.name}) to what it denotes —
+ * a scalar JPA {@link Path} or a relation to join through — relative to the {@code From} the
+ * current (sub)query is built against.
  */
 sealed interface Scope permits Scope.RootScope, Scope.LambdaScope {
 
-    Path<?> resolvePath(String cerbosVar);
-
-    AttributeMapping resolveMapping(String cerbosVar);
+    /**
+     * Classify a Cerbos plan variable and resolve it against this scope.
+     *
+     * <p>TOTAL: every variable either lands in one of {@link Resolution}'s two arms or throws
+     * {@link IllegalArgumentException} naming why — there is no null return and no second
+     * classifier to consult afterwards. Callers that need a column narrow with {@link #path};
+     * callers that need a collection pattern-match {@link ResolvedRelation}, and get the
+     * unmapped-variable rejection from this throw rather than from a second call made purely
+     * for it.
+     *
+     * <p>The three resolution rules live here and only here:
+     * <ul>
+     *   <li><b>chain walking</b> — a dotted variable is matched against the longest registered
+     *       Relation prefix and its suffix walked through nested {@code fields()} maps, so
+     *       {@code ...attr.categories.subCategories} resolves to the two-hop join chain;</li>
+     *   <li><b>lambda delegation</b> — a {@link LambdaScope} resolves variables prefixed with
+     *       its lambda variable against the joined element and delegates everything else
+     *       outward;</li>
+     *   <li><b>owner anchoring</b> — a {@link ResolvedRelation} carries the scope that OWNS
+     *       its first hop, which is where a subquery over it must correlate.</li>
+     * </ul>
+     */
+    Resolution resolve(String cerbosVar);
 
     /**
-     * Resolve a relation-valued variable to the JOIN CHAIN reaching its elements together with
-     * the scope that OWNS the first hop, or {@code null} when the variable is not
-     * relation-valued. The owner is the resolution site — the root scope for
-     * {@code request.resource.attr.*} references (even when resolved from inside a lambda,
-     * whose scope merely delegates outward), or the lambda scope itself when the chain hangs
-     * off the lambda element. A subquery over the relation must correlate the OWNER's
-     * {@code from()}: joining the chain off any other {@code From} either fails at query-build
-     * time or silently queries a same-named collection on the wrong entity.
+     * Narrow {@link #resolve} to the scalar arm: the JPA path to compare {@code cerbosVar} as.
+     *
+     * <p>Relation-valued variables and Fields with no column on this scope's {@code From} are
+     * rejected here rather than resolved to a guessed path — the adapter fails closed rather
+     * than comparing the wrong column.
      */
-    ResolvedRelation resolveRelation(String cerbosVar);
+    default Path<?> path(String cerbosVar) {
+        if (resolve(cerbosVar) instanceof ResolvedScalar scalar) {
+            if (scalar.path() == null) {
+                throw new IllegalArgumentException("Unknown attribute: " + cerbosVar);
+            }
+            return scalar.path();
+        }
+        throw new IllegalArgumentException(
+                "Attribute " + cerbosVar + " is a Relation; cannot resolve as a scalar path");
+    }
 
     From<?, ?> from();
 
     AbstractQuery<?> parentQuery();
+
+    /** What a Cerbos plan variable denotes in a scope: a scalar value, or a relation. */
+    sealed interface Resolution permits ResolvedScalar, ResolvedRelation {}
+
+    /**
+     * A variable denoting a single value: {@code path} is the JPA path to compare it as and
+     * {@code mapping} is the {@link AttributeMapping} it was resolved through.
+     *
+     * <p>{@code mapping} is never null, but it is a {@link AttributeMapping.Relation} for the
+     * bare lambda variable — {@code t} inside {@code tags.exists(t, ...)} denotes the ELEMENT,
+     * whose {@code path} is the relation's {@code defaultMemberField} (or the joined element
+     * itself), and whose only mapping is the relation it came from. Callers that need a
+     * genuine scalar attribute test {@code mapping instanceof AttributeMapping.Field}.
+     *
+     * <p>{@code path} is null exactly when the Field is reachable only THROUGH a relation
+     * chain ({@code ...attr.categories.name} against a root scope): mapped, and scalar per
+     * ELEMENT, but with no column on the entity this scope is rooted at. It resolves to this
+     * arm rather than throwing so the collection operators can say the variable is a scalar
+     * one instead of calling it unknown; {@link #path} reports it as the "Unknown attribute"
+     * it has always been.
+     */
+    record ResolvedScalar(Path<?> path, AttributeMapping mapping) implements Resolution {}
 
     /**
      * A relation-valued variable resolved to the Relations to join through — in hop order,
@@ -43,8 +91,16 @@ sealed interface Scope permits Scope.RootScope, Scope.LambdaScope {
      * elements the enclosing operator ranges over. Multi-hop chains
      * ({@code categories.subCategories}) denote the FLATTENED union of tail elements across
      * the intermediate hops, which is exactly what a correlated join chain expresses.
+     *
+     * <p>The owner is the resolution site — the root scope for
+     * {@code request.resource.attr.*} references (even when resolved from inside a lambda,
+     * whose scope merely delegates outward), or the lambda scope itself when the chain hangs
+     * off the lambda element. A subquery over the relation must correlate the OWNER's
+     * {@code from()}: joining the chain off any other {@code From} either fails at query-build
+     * time or silently queries a same-named collection on the wrong entity.
      */
-    record ResolvedRelation(Scope owner, List<AttributeMapping.Relation> chain) {
+    record ResolvedRelation(Scope owner, List<AttributeMapping.Relation> chain)
+            implements Resolution {
         public ResolvedRelation {
             chain = List.copyOf(chain);
         }
@@ -70,8 +126,8 @@ sealed interface Scope permits Scope.RootScope, Scope.LambdaScope {
      * between {@code scope} and the target keep their Froms — paths through them stay legal as
      * implicit correlation references, the same reliance the base case already places on
      * untouched {@code outer} links — but adopt {@code sub} as the query any deeper subqueries
-     * are built against. Identity comparison is deliberate: the target is always a scope object
-     * returned by {@link #resolveRelation} on this same chain.
+     * are built against. Identity comparison is deliberate: the target is always the
+     * {@link ResolvedRelation#owner()} {@link #resolve} returned on this same chain.
      */
     static Scope rebaseAt(Scope scope, Scope target, From<?, ?> correlated, AbstractQuery<?> sub) {
         if (scope == target) {
@@ -92,43 +148,26 @@ sealed interface Scope permits Scope.RootScope, Scope.LambdaScope {
     record RootScope(From<?, ?> from, AbstractQuery<?> parentQuery, Map<String, AttributeMapping> mapper)
             implements Scope {
         @Override
-        public Path<?> resolvePath(String cerbosVar) {
-            AttributeMapping m = mapper.get(cerbosVar);
-            if (m == null) {
+        public Resolution resolve(String cerbosVar) {
+            // A directly registered Field is a column on this From — the common case, and the
+            // only one where the variable names a scalar the entity actually holds.
+            if (mapper.get(cerbosVar) instanceof AttributeMapping.Field f) {
+                return new ResolvedScalar(traversePath(from, f.jpaPath()), f);
+            }
+            // Otherwise the variable is either a registered Relation, or a dotted suffix off
+            // one. Example: mapper has "request.resource.attr.categories" →
+            // Relation("categories", fields={"subCategories": Relation(...)}) and we are asked
+            // for "request.resource.attr.categories.subCategories" — walk the chain.
+            RelationChain chain = resolveRelationChain(mapper, cerbosVar);
+            if (chain == null) {
                 throw new IllegalArgumentException("Unknown attribute: " + cerbosVar);
             }
-            if (m instanceof AttributeMapping.Field f) {
-                return traversePath(from, f.jpaPath());
-            }
-            throw new IllegalArgumentException(
-                    "Attribute " + cerbosVar + " is a Relation; cannot resolve as a scalar path");
-        }
-
-        @Override
-        public AttributeMapping resolveMapping(String cerbosVar) {
-            AttributeMapping m = mapper.get(cerbosVar);
-            if (m != null) {
-                return m;
-            }
-            // Try resolving as a dotted suffix off a registered Relation prefix.
-            // Example: mapper has "request.resource.attr.categories" → Relation("categories", fields={"subCategories": Relation(...)})
-            // and we're asked for "request.resource.attr.categories.subCategories" — walk the chain.
-            RelationChain chain = resolveRelationChain(mapper, cerbosVar);
-            if (chain != null) {
-                return chain.tail() != null
-                        ? chain.tail()
-                        : chain.relations().get(chain.relations().size() - 1);
-            }
-            throw new IllegalArgumentException("Unknown attribute: " + cerbosVar);
-        }
-
-        @Override
-        public ResolvedRelation resolveRelation(String cerbosVar) {
-            RelationChain chain = resolveRelationChain(mapper, cerbosVar);
-            if (chain != null && chain.tail() == null) {
+            if (chain.tail() == null) {
                 return new ResolvedRelation(this, chain.relations());
             }
-            return null;
+            // A Field reached THROUGH the chain: scalar per element, no column here — see
+            // ResolvedScalar on why this is an arm rather than a throw.
+            return new ResolvedScalar(null, chain.tail());
         }
     }
 
@@ -148,58 +187,51 @@ sealed interface Scope permits Scope.RootScope, Scope.LambdaScope {
         }
 
         @Override
-        public Path<?> resolvePath(String cerbosVar) {
+        public Resolution resolve(String cerbosVar) {
             if (!isLambdaRef(cerbosVar)) {
+                // An outer reference: it resolves — and, when relation-valued, is OWNED —
+                // further out. request.resource.attr.tags inside a categories lambda belongs
+                // to the root, so a subquery over it correlates the root's From, not this
+                // lambda's element join.
                 if (outer != null) {
-                    return outer.resolvePath(cerbosVar);
-                }
-                throw new IllegalArgumentException(
-                        "Variable '" + cerbosVar + "' does not start with lambda variable '" + lambdaVar + "'");
-            }
-            return memberPath(from, relation, extractLambdaSuffix(cerbosVar, lambdaVar));
-        }
-
-        @Override
-        public AttributeMapping resolveMapping(String cerbosVar) {
-            if (!isLambdaRef(cerbosVar)) {
-                if (outer != null) {
-                    return outer.resolveMapping(cerbosVar);
+                    return outer.resolve(cerbosVar);
                 }
                 throw new IllegalArgumentException(
                         "Variable '" + cerbosVar + "' does not start with lambda variable '" + lambdaVar + "'");
             }
             String suffix = extractLambdaSuffix(cerbosVar, lambdaVar);
             if (suffix.isEmpty()) {
-                return relation;
+                // The bare lambda variable is the element itself, not a relation: its value is
+                // the relation's scalar projection, its mapping the relation it came from.
+                return new ResolvedScalar(memberPath(from, relation, suffix), relation);
             }
+            List<AttributeMapping.Relation> chain = relationChain(suffix);
+            if (chain != null) {
+                return new ResolvedRelation(this, chain);
+            }
+            // Not a chain off the element, so a member scalar: the mapping registered under
+            // the whole suffix if there is one, else the suffix read as a raw JPA path.
             AttributeMapping nested = relation.fields().get(suffix);
-            if (nested != null) {
-                return nested;
-            }
-            return AttributeMapping.field(suffix);
+            return new ResolvedScalar(memberPath(from, relation, suffix),
+                    nested != null ? nested : AttributeMapping.field(suffix));
         }
 
-        @Override
-        public ResolvedRelation resolveRelation(String cerbosVar) {
-            if (!isLambdaRef(cerbosVar)) {
-                // An outer reference: the OWNING scope is found further out — e.g.
-                // request.resource.attr.tags inside a categories lambda is owned by the root.
-                return outer != null ? outer.resolveRelation(cerbosVar) : null;
-            }
-            String suffix = extractLambdaSuffix(cerbosVar, lambdaVar);
-            if (suffix.isEmpty()) {
-                return null; // the bare lambda var is the element itself, not a relation
-            }
+        /**
+         * Walk {@code suffix}'s dotted parts through the element's nested {@code fields()}
+         * maps, or {@code null} as soon as a hop is scalar or unmapped: {@code c.subCategories}
+         * is a relation chain hanging off the element, {@code c.name} is not.
+         */
+        private List<AttributeMapping.Relation> relationChain(String suffix) {
             List<AttributeMapping.Relation> chain = new ArrayList<>();
             AttributeMapping.Relation current = relation;
             for (String part : suffix.split("\\.")) {
                 if (!(current.fields().get(part) instanceof AttributeMapping.Relation next)) {
-                    return null; // scalar (or unmapped) hop — not relation-valued
+                    return null;
                 }
                 chain.add(next);
                 current = next;
             }
-            return new ResolvedRelation(this, chain);
+            return chain;
         }
     }
 

--- a/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
+++ b/spring-data/src/main/java/dev/cerbos/queryplan/springdata/SpringDataQueryPlanAdapter.java
@@ -525,7 +525,7 @@ public final class SpringDataQueryPlanAdapter {
         }
 
         private Predicate handleBareVariable(String variable, Scope scope) {
-            Path<?> path = scope.resolvePath(variable);
+            Path<?> path = scope.path(variable);
             return applyLeaf("eq", path, true);
         }
 
@@ -690,7 +690,8 @@ public final class SpringDataQueryPlanAdapter {
          * discriminate them.
          */
         private boolean isExplicitNull(String cerbosVar, Scope scope) {
-            return scope.resolveMapping(cerbosVar) instanceof AttributeMapping.Field f
+            return scope.resolve(cerbosVar) instanceof Scope.ResolvedScalar scalar
+                    && scalar.mapping() instanceof AttributeMapping.Field f
                     && f.nullAttributeRepresentation() == NullAttributeRepresentation.EXPLICIT;
         }
 
@@ -1184,7 +1185,7 @@ public final class SpringDataQueryPlanAdapter {
                             throw new IllegalArgumentException(
                                     op + " requires a string receiver, got " + typeName(receiver));
                         }
-                        Path<?> needle = scope.resolvePath(needleField.variable());
+                        Path<?> needle = scope.path(needleField.variable());
                         // The needle is a column, so it is escaped dynamically; a NULL needle is
                         // a missing attribute → CEL error → deny (fieldToFieldLike guards it).
                         return switch (op) {
@@ -1224,7 +1225,7 @@ public final class SpringDataQueryPlanAdapter {
                     // plan constant (normalization guarantees the field arrives first). Strings
                     // concatenate here, matching CEL — this shape never enters double space.
                     if (left instanceof Resolved.Field f && right instanceof Resolved.ConstantAdd ca) {
-                        return applyLeaf(op, scope.resolvePath(f.variable()), ca.fold());
+                        return applyLeaf(op, scope.path(f.variable()), ca.fold());
                     }
                     // Solve: `add(field, const) eq/ne constant` — for the ALGEBRAICALLY EXACT
                     // shapes only (string concatenation, in-range long/long integers).
@@ -1296,7 +1297,7 @@ public final class SpringDataQueryPlanAdapter {
                                     + " in/hasIntersection, or compare elements individually.");
                 }
 
-                Path<?> path = scope.resolvePath(field.variable());
+                Path<?> path = scope.path(field.variable());
 
                 if (value == null) {
                     // A registered override owns the operator's full translation, including a null RHS.
@@ -1352,7 +1353,7 @@ public final class SpringDataQueryPlanAdapter {
             private Predicate timestampLeaf(String op, Resolved.TimestampField field,
                                             Resolved.TimestampConstant constant, Scope scope) {
                 Instant instant = constant.instant();
-                Path<?> path = scope.resolvePath(field.variable());
+                Path<?> path = scope.path(field.variable());
                 return withOverride(op, path, instant, () -> {
                     Class<?> javaType = path.getJavaType();
                     Object bound;
@@ -1431,9 +1432,9 @@ public final class SpringDataQueryPlanAdapter {
                     if ("eq".equals(op)) {
                         return cb.disjunction();
                     }
-                    return cb.isNotNull(scope.resolvePath(fpc.fieldVariable()));
+                    return cb.isNotNull(scope.path(fpc.fieldVariable()));
                 }
-                return applyLeaf(op, scope.resolvePath(fpc.fieldVariable()), solved);
+                return applyLeaf(op, scope.path(fpc.fieldVariable()), solved);
             }
 
             /**
@@ -1477,7 +1478,7 @@ public final class SpringDataQueryPlanAdapter {
                         throw new IllegalArgumentException(
                                 "add(const, const) compared to a non-field operand is not supported");
                     }
-                    return applyLeaf(op, scope.resolvePath(otherOperand.getVariable()), folded);
+                    return applyLeaf(op, scope.path(otherOperand.getVariable()), folded);
                 }
                 throw new IllegalArgumentException(
                         "add comparison with a field reference only supports eq/ne (got " + op + ")");
@@ -1590,8 +1591,8 @@ public final class SpringDataQueryPlanAdapter {
              */
             private Predicate fieldToFieldComparison(String op, String leftVar, String rightVar,
                                                      Scope scope) {
-                jakarta.persistence.criteria.Expression<?> left = scope.resolvePath(leftVar);
-                jakarta.persistence.criteria.Expression<?> right = scope.resolvePath(rightVar);
+                jakarta.persistence.criteria.Expression<?> left = scope.path(leftVar);
+                jakarta.persistence.criteria.Expression<?> right = scope.path(rightVar);
                 boolean leftExplicit = isExplicitNull(leftVar, scope);
                 boolean rightExplicit = isExplicitNull(rightVar, scope);
                 // Mixing the two conventions across one comparison has no faithful rendering.
@@ -2035,7 +2036,7 @@ public final class SpringDataQueryPlanAdapter {
                         @SuppressWarnings("unchecked")
                         jakarta.persistence.criteria.Expression<? extends Number> path =
                                 (jakarta.persistence.criteria.Expression<? extends Number>)
-                                        scope.resolvePath(operand.getVariable());
+                                        scope.path(operand.getVariable());
                         return new NumericOperand.Sql(toIeeeDouble(path));
                     }
                     case VALUE -> {
@@ -2267,10 +2268,13 @@ public final class SpringDataQueryPlanAdapter {
                             "Unsupported size() expression: size() argument must be a collection "
                                     + "attribute or filter(...), got " + describeOperand(sizeArg));
                 }
-                Scope.ResolvedRelation ref = scope.resolveRelation(var);
-                if (ref == null) {
-                    AttributeMapping mapping = scope.resolveMapping(var);
-                    if (!(mapping instanceof AttributeMapping.Field)) {
+                Scope.Resolution resolved = scope.resolve(var);
+                if (!(resolved instanceof Scope.ResolvedRelation ref)) {
+                    // Only a genuine scalar ATTRIBUTE has a string length to take. The bare
+                    // lambda element lands in the scalar arm too, but its mapping is the
+                    // Relation it came from — size() of a relation element is not a length.
+                    Scope.ResolvedScalar scalar = (Scope.ResolvedScalar) resolved;
+                    if (!(scalar.mapping() instanceof AttributeMapping.Field)) {
                         throw new IllegalArgumentException(
                                 "size() requires a collection (Relation) mapping for " + var);
                     }
@@ -2279,7 +2283,7 @@ public final class SpringDataQueryPlanAdapter {
                         throw new IllegalArgumentException(
                                 "size(filter(...)) requires a collection (Relation) mapping for " + var);
                     }
-                    Path<?> path = scope.resolvePath(var);
+                    Path<?> path = scope.path(var);
                     if (fractionalCollapse != null) {
                         // ne f is vacuously true only for a PRESENT string: a NULL column is a
                         // missing attribute → CEL error → deny, so it must stay excluded —
@@ -2458,12 +2462,11 @@ public final class SpringDataQueryPlanAdapter {
             String var = fieldOp.getVariable();
             Object val = PlanValues.protoValueToJava(valueOp.getValue());
 
-            Scope.ResolvedRelation relRef = scope.resolveRelation(var);
-            if (relRef != null) {
+            if (scope.resolve(var) instanceof Scope.ResolvedRelation relRef) {
                 return collectionContainsAny(scope, relRef, asList(val));
             }
 
-            Path<?> path = scope.resolvePath(var);
+            Path<?> path = scope.path(var);
             return withOverride("in", path, val, () -> {
                 if (val instanceof List<?> list) {
                     if (list.isEmpty()) {
@@ -2526,22 +2529,24 @@ public final class SpringDataQueryPlanAdapter {
          */
         private Predicate handleInVariableVariable(String memberVar, String collectionVar,
                                                    Scope scope) {
-            Scope.ResolvedRelation ref = scope.resolveRelation(collectionVar);
-            if (ref == null) {
-                scope.resolveMapping(collectionVar); // throws "Unknown attribute" when unmapped
+            // resolve() is total, so an unmapped collectionVar throws "Unknown attribute" here
+            // rather than needing a separate call made purely for its throw.
+            if (!(scope.resolve(collectionVar) instanceof Scope.ResolvedRelation ref)) {
                 throw new IllegalArgumentException(
                         "in(" + memberVar + ", " + collectionVar + ") requires the second "
                                 + "attribute to be mapped as a Relation (collection membership), "
                                 + "but " + collectionVar + " resolves to a scalar Field mapping");
             }
-            // Resolve the member OUTSIDE the subquery first so an unknown/Relation-valued
-            // member reports its own resolution error rather than a subquery-build failure.
-            scope.resolvePath(memberVar);
+            // Check the member eagerly: resolved only inside the subquery body, an unknown or
+            // Relation-valued member would be masked by chainSubquery's own failure (the
+            // bulk-delete guard). The path itself has to be rebuilt against the REBASED scope
+            // below to be a legal correlation reference, so this call is a check, not a value.
+            scope.path(memberVar);
             return chainContains(scope, ref, (sub, tailJoin, rebased) -> {
                 Path<?> element = Scope.memberPath(tailJoin, ref.tail(), null);
                 // The outer scalar resolves through the REBASED scope so the produced path is
                 // a legal correlation reference inside the subquery.
-                Path<?> outer = rebased.resolvePath(memberVar);
+                Path<?> outer = rebased.path(memberVar);
                 return cb.or(
                         cb.equal(element, outer),
                         cb.and(cb.isNull(element), cb.isNull(outer)));
@@ -2590,11 +2595,10 @@ public final class SpringDataQueryPlanAdapter {
                 Object val = PlanValues.protoValueToJava(second.getValue());
                 List<?> values = asList(val);
 
-                Scope.ResolvedRelation relRef = scope.resolveRelation(var);
-                if (relRef != null) {
+                if (scope.resolve(var) instanceof Scope.ResolvedRelation relRef) {
                     return collectionContainsAny(scope, relRef, values);
                 }
-                Path<?> path = scope.resolvePath(var);
+                Path<?> path = scope.path(var);
                 // hasIntersection(field, []) is always false; avoid a dialect-dependent empty `IN ()`.
                 if (values.isEmpty()) {
                     return cb.disjunction();
@@ -2679,9 +2683,7 @@ public final class SpringDataQueryPlanAdapter {
             // dotted chains ("request.resource.attr.categories.subCategories") share one path:
             // the subquery correlates the OWNING From and joins through every hop, so the
             // projection ranges over the flattened tail elements.
-            Scope.ResolvedRelation ref = scope.resolveRelation(collectionVar);
-            if (ref == null) {
-                scope.resolveMapping(collectionVar); // throws "Unknown attribute" when unmapped
+            if (!(scope.resolve(collectionVar) instanceof Scope.ResolvedRelation ref)) {
                 throw new IllegalArgumentException(
                         "map can only be applied to a collection mapped as Relation: " + collectionVar);
             }
@@ -2805,9 +2807,7 @@ public final class SpringDataQueryPlanAdapter {
             String collectionVar = listOperand.getVariable();
             // Owner-anchored chain resolution: multi-hop chains join through every hop, and a
             // relation referenced from inside a lambda anchors to the scope that owns it.
-            Scope.ResolvedRelation ref = scope.resolveRelation(collectionVar);
-            if (ref == null) {
-                scope.resolveMapping(collectionVar); // throws "Unknown attribute" when unmapped
+            if (!(scope.resolve(collectionVar) instanceof Scope.ResolvedRelation ref)) {
                 throw new IllegalArgumentException(
                         op + " requires a Relation mapping for " + collectionVar);
             }

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/ScopeTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/ScopeTest.java
@@ -1,0 +1,334 @@
+package dev.cerbos.queryplan.springdata;
+
+import dev.cerbos.queryplan.springdata.testmodel.ResourceEntity;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the variable-resolution seam itself, rather than through a translated query.
+ *
+ * <p>{@link Scope#resolve} is the adapter's one classifier: it decides whether a plan variable
+ * denotes a column or a collection, and — for a collection — which scope OWNS it. That
+ * ownership is what {@link Scope#rebaseAt} and {@code chainSubquery} anchor a correlated
+ * subquery to, and getting it wrong is silent: the element entity of an enclosing lambda can
+ * carry a collection of the same name ({@link dev.cerbos.queryplan.springdata.testmodel.SubCategoryEntity}
+ * has its own {@code categories}), so a subquery anchored to the lambda join still builds and
+ * still returns rows — the wrong ones. Proving it here rather than only through multi-hop
+ * collection queries means the invariant is stated where it lives.
+ */
+class ScopeTest {
+
+    private static final String TAGS = "request.resource.attr.tags";
+    private static final String CATEGORIES = "request.resource.attr.categories";
+
+    private static final AttributeMapping.Relation SUB_CATEGORIES =
+            AttributeMapping.relation("subCategories", "name",
+                    Map.of("name", AttributeMapping.field("name")));
+
+    private static final Map<String, AttributeMapping> MAPPER = Map.of(
+            "request.resource.attr.aString", AttributeMapping.field("aString"),
+            "request.resource.attr.aOptionalString",
+            AttributeMapping.field("aOptionalString", NullAttributeRepresentation.EXPLICIT),
+            TAGS, AttributeMapping.relation("tags", Map.of(
+                    "name", AttributeMapping.field("name"))),
+            CATEGORIES, AttributeMapping.relation("categories", Map.of(
+                    "name", AttributeMapping.field("name"),
+                    "subCategories", SUB_CATEGORIES)));
+
+    private static EntityManagerFactory emf;
+
+    private EntityManager em;
+    private CriteriaBuilder cb;
+    private CriteriaQuery<ResourceEntity> query;
+    private Root<ResourceEntity> root;
+    private Scope rootScope;
+
+    @BeforeAll
+    static void setUp() {
+        emf = Persistence.createEntityManagerFactory("test-pu");
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (emf != null) emf.close();
+    }
+
+    @BeforeEach
+    void newQuery() {
+        em = emf.createEntityManager();
+        cb = em.getCriteriaBuilder();
+        query = cb.createQuery(ResourceEntity.class);
+        root = query.from(ResourceEntity.class);
+        rootScope = Scope.root(root, query, MAPPER);
+    }
+
+    @AfterEach
+    void closeEm() {
+        em.close();
+    }
+
+    /** A lambda scope over {@code categories}, as {@code categories.exists(c, ...)} builds. */
+    private Scope categoriesLambda(Scope outer, From<?, ?> from) {
+        return Scope.lambda(from, query,
+                (AttributeMapping.Relation) MAPPER.get(CATEGORIES), "c", outer);
+    }
+
+    @Nested
+    class RootResolution {
+
+        @Test
+        void fieldResolvesToItsColumnAndItsMapping() {
+            Scope.ResolvedScalar scalar = assertInstanceOf(Scope.ResolvedScalar.class,
+                    rootScope.resolve("request.resource.attr.aString"));
+            assertSame(root, scalar.path().getParentPath());
+            assertEquals(AttributeMapping.field("aString"), scalar.mapping());
+        }
+
+        /**
+         * The declared NULL convention travels on the resolution, which is what
+         * {@code isExplicitNull} reads — the JPA path cannot discriminate two attributes
+         * mapped to the same column under different conventions.
+         */
+        @Test
+        void fieldCarriesItsDeclaredNullConvention() {
+            Scope.ResolvedScalar scalar = assertInstanceOf(Scope.ResolvedScalar.class,
+                    rootScope.resolve("request.resource.attr.aOptionalString"));
+            assertEquals(NullAttributeRepresentation.EXPLICIT,
+                    ((AttributeMapping.Field) scalar.mapping()).nullAttributeRepresentation());
+        }
+
+        @Test
+        void relationResolvesToASingleHopChainOwnedByThisScope() {
+            Scope.ResolvedRelation rel = assertInstanceOf(Scope.ResolvedRelation.class,
+                    rootScope.resolve(TAGS));
+            assertSame(rootScope, rel.owner());
+            assertEquals(List.of("tags"),
+                    rel.chain().stream().map(AttributeMapping.Relation::joinAttribute).toList());
+        }
+
+        @Test
+        void dottedChainWalksEveryHop() {
+            Scope.ResolvedRelation rel = assertInstanceOf(Scope.ResolvedRelation.class,
+                    rootScope.resolve(CATEGORIES + ".subCategories"));
+            assertSame(rootScope, rel.owner());
+            assertEquals(List.of("categories", "subCategories"),
+                    rel.chain().stream().map(AttributeMapping.Relation::joinAttribute).toList());
+            assertEquals(SUB_CATEGORIES, rel.tail());
+        }
+
+        /**
+         * A Field reached THROUGH a relation ({@code categories.name}) is a scalar per
+         * ELEMENT: mapped — so the collection operators can say "that is a scalar" rather than
+         * "unknown attribute" — but with no column on the root entity, so asking for its path
+         * is the "Unknown attribute" it has always been.
+         */
+        @Test
+        void fieldBehindARelationIsScalarButHasNoColumnHere() {
+            Scope.ResolvedScalar scalar = assertInstanceOf(Scope.ResolvedScalar.class,
+                    rootScope.resolve(CATEGORIES + ".name"));
+            assertNull(scalar.path());
+            assertEquals(AttributeMapping.field("name"), scalar.mapping());
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> rootScope.path(CATEGORIES + ".name"));
+            assertTrue(ex.getMessage().contains("Unknown attribute"), ex.getMessage());
+        }
+
+        @Test
+        void unmappedVariableThrows() {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> rootScope.resolve("request.resource.attr.nonexistent"));
+            assertTrue(ex.getMessage().contains("Unknown attribute"), ex.getMessage());
+        }
+
+        @Test
+        void relationIsRejectedWhereAColumnIsRequired() {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> rootScope.path(TAGS));
+            assertTrue(ex.getMessage().contains("is a Relation"), ex.getMessage());
+        }
+    }
+
+    @Nested
+    class LambdaResolution {
+
+        private Join<?, ?> categoryJoin;
+        private Scope lambdaScope;
+
+        @BeforeEach
+        void enterLambda() {
+            categoryJoin = root.join("categories");
+            lambdaScope = categoriesLambda(rootScope, categoryJoin);
+        }
+
+        @Test
+        void memberReferenceResolvesAgainstTheJoinedElement() {
+            Scope.ResolvedScalar scalar = assertInstanceOf(Scope.ResolvedScalar.class,
+                    lambdaScope.resolve("c.name"));
+            assertSame(categoryJoin, scalar.path().getParentPath());
+        }
+
+        /**
+         * The bare lambda variable denotes the ELEMENT, not a relation — it has a path (the
+         * relation's scalar projection, or the join itself) but no Field mapping of its own,
+         * which is how {@code size(t)} stays rejected while {@code size(aString)} does not.
+         */
+        @Test
+        void bareLambdaVariableIsTheElementWithTheRelationAsItsMapping() {
+            Join<?, ?> subCategoryJoin = categoryJoin.join("subCategories");
+            Scope subLambda = Scope.lambda(subCategoryJoin, query, SUB_CATEGORIES, "s", lambdaScope);
+
+            Scope.ResolvedScalar scalar = assertInstanceOf(Scope.ResolvedScalar.class,
+                    subLambda.resolve("s"));
+            // The relation's defaultMemberField stands in for the bare element.
+            assertSame(subCategoryJoin, scalar.path().getParentPath());
+            assertSame(SUB_CATEGORIES, scalar.mapping());
+        }
+
+        @Test
+        void memberRelationIsOwnedByTheLambdaScope() {
+            Scope.ResolvedRelation rel = assertInstanceOf(Scope.ResolvedRelation.class,
+                    lambdaScope.resolve("c.subCategories"));
+            assertSame(lambdaScope, rel.owner());
+            assertEquals(List.of("subCategories"),
+                    rel.chain().stream().map(AttributeMapping.Relation::joinAttribute).toList());
+        }
+
+        /**
+         * OWNER ANCHORING. {@code request.resource.attr.tags} referenced inside a
+         * {@code categories.exists(c, ...)} body resolves outward, and the owner it comes back
+         * with must be the scope that HOLDS the attribute — the root — not the scope that
+         * happened to resolve it. {@code chainSubquery} correlates {@code owner().from()}, so
+         * an owner of {@code lambdaScope} would join {@code tags} off the category join.
+         */
+        @Test
+        void outerRelationIsOwnedByTheScopeThatHoldsIt() {
+            Scope.ResolvedRelation rel = assertInstanceOf(Scope.ResolvedRelation.class,
+                    lambdaScope.resolve(TAGS));
+            assertSame(rootScope, rel.owner());
+            assertSame(root, rel.owner().from());
+        }
+
+        /**
+         * The same anchoring where getting it wrong is SILENT rather than a build error: a
+         * sub-category element carries its own {@code categories} collection, so anchoring
+         * {@code request.resource.attr.categories} to the innermost lambda would still build
+         * and still return rows — a different entity's same-named collection.
+         */
+        @Test
+        void outerRelationIsNotCapturedByASameNamedCollectionOnTheElement() {
+            Join<?, ?> subCategoryJoin = categoryJoin.join("subCategories");
+            Scope subLambda = Scope.lambda(subCategoryJoin, query, SUB_CATEGORIES, "s", lambdaScope);
+
+            Scope.ResolvedRelation rel = assertInstanceOf(Scope.ResolvedRelation.class,
+                    subLambda.resolve(CATEGORIES));
+            assertSame(rootScope, rel.owner());
+            assertSame(root, rel.owner().from());
+        }
+
+        @Test
+        void unprefixedVariableWithNoOuterScopeThrows() {
+            Scope orphan = categoriesLambda(null, categoryJoin);
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> orphan.resolve(TAGS));
+            assertTrue(ex.getMessage().contains("does not start with lambda variable"),
+                    ex.getMessage());
+        }
+    }
+
+    /**
+     * {@link Scope#rebaseAt} re-roots exactly the level that owns the relation, so paths
+     * resolved through it become correlation references of the new subquery while every other
+     * level keeps its own {@code From}.
+     */
+    @Nested
+    class Rebasing {
+
+        private Join<?, ?> categoryJoin;
+        private Scope lambdaScope;
+        private Subquery<Integer> sub;
+        private From<?, ?> correlated;
+
+        @BeforeEach
+        void enterLambda() {
+            categoryJoin = root.join("categories");
+            lambdaScope = categoriesLambda(rootScope, categoryJoin);
+            sub = query.subquery(Integer.class);
+            correlated = sub.correlate(root);
+        }
+
+        @Test
+        void rebasingTheRootScopeItselfReRootsItAtTheCorrelatedFrom() {
+            Scope rebased = Scope.rebaseAt(rootScope, rootScope, correlated, sub);
+            assertSame(correlated, rebased.from());
+            assertSame(sub, rebased.parentQuery());
+            assertSame(correlated,
+                    rebased.path("request.resource.attr.aString").getParentPath());
+        }
+
+        /**
+         * Rebasing an outer-owned relation from inside a lambda touches ONLY the root level:
+         * the lambda keeps its element join (its member references stay legal), but adopts the
+         * subquery as the query any deeper subqueries are built against.
+         */
+        @Test
+        void rebasingAnOuterOwnerKeepsTheInterveningLambdaFrom() {
+            Scope rebased = Scope.rebaseAt(lambdaScope, rootScope, correlated, sub);
+
+            assertSame(categoryJoin, rebased.from());
+            assertSame(sub, rebased.parentQuery());
+
+            Path<?> outerPath = rebased.path("request.resource.attr.aString");
+            assertSame(correlated, outerPath.getParentPath());
+
+            Path<?> memberPath = rebased.path("c.name");
+            assertSame(categoryJoin, memberPath.getParentPath());
+        }
+
+        @Test
+        void rebasingTheLambdaLevelReRootsThatLevelOnly() {
+            From<?, ?> correlatedJoin = sub.correlate(categoryJoin);
+            Scope rebased = Scope.rebaseAt(lambdaScope, lambdaScope, correlatedJoin, sub);
+
+            assertSame(correlatedJoin, rebased.from());
+            assertSame(correlatedJoin, rebased.path("c.name").getParentPath());
+            // The outer level is untouched — it stays a legal implicit correlation reference.
+            assertSame(root, rebased.path("request.resource.attr.aString").getParentPath());
+        }
+
+        @Test
+        void rebasingAtAScopeOffTheChainThrows() {
+            Scope unrelated = Scope.root(query.from(ResourceEntity.class), query, MAPPER);
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Scope.rebaseAt(lambdaScope, unrelated, correlated, sub));
+            assertTrue(ex.getMessage().contains("not on the current resolution chain"),
+                    ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Closes #265. **Affected adapter: spring-data only.** No corpus files touched, so no other adapter's CI is implicated.

## Summary

Variable resolution in the spring-data adapter was split across three partial functions with overlapping domains — `resolvePath`, `resolveMapping`, `resolveRelation` — each re-deriving the same rules and each disagreeing with the others about which variables it accepts. Two of `resolveMapping`'s three call sites invoked it purely for its "Unknown attribute" throw and discarded the result.

`Scope` now exposes one total `resolve(var)` returning a two-arm sum:

```java
ResolvedScalar(path, mapping)     // the value, and the mapping it was resolved through
ResolvedRelation(owner, chain)    // the join chain, and the scope that OWNS its first hop
```

Chain walking, lambda delegation and owner anchoring live in that one walk. `path(var)` is a `default` narrowing over it, not a second resolver, and an unmapped variable is rejected by `resolve()`'s own throw — so the call-it-to-throw sites are gone. 27 call sites converted across `SpringDataQueryPlanAdapter` and `HierarchyTranslator`.

Everything involved is package-private; the published surface is unchanged.

## Owner anchoring now has a test at its own seam

This was previously provable only transitively, through multi-hop collection queries at the `toSpecification` seam — even though getting it wrong is *silent* rather than loud. `SubCategoryEntity` declares its own `categories`, so a subquery anchored to the lambda join instead of the owning root still builds and still returns rows: a different entity's same-named collection.

The new `ScopeTest` (17 tests) pins the owner directly. I verified it isn't decorative by mutating the source twice and confirming the tests catch each:

| Mutation | Result |
|---|---|
| `LambdaScope.resolve` claims ownership of outer references (`new ResolvedRelation(this, …)`) | `outerRelationIsOwnedByTheScopeThatHoldsIt` and `outerRelationIsNotCapturedByASameNamedCollectionOnTheElement` FAILED |
| `rebaseAt` re-roots every level, not just the target | `rebasingAnOuterOwnerKeepsTheInterveningLambdaFrom` FAILED |

## Behaviour changes — two error messages, no translation changes

**Nothing that used to return a filter now throws, and nothing that used to throw now returns a filter**, so this is not a consumer-visible break. Two *error-path messages* change, both where the old code failed to recognise a Relation for what it was:

- `R.attr.categories.subCategories` in scalar position said `Unknown attribute` — though it *is* mapped. It now reports that it is a Relation.
- `c.subCategories` inside a lambda built a plural JPA path that failed later inside Hibernate with a raw coercion error. It now throws the adapter's named `is a Relation` error.

Neither shape is reachable from a policy — CEL rejects comparing a collection to a scalar — and no `conformance/actions.json` entry pins either string (grepped). Restoring the old wording would mean re-deriving resolution inside the narrowing helper to reinstate a message that was wrong, so they are documented rather than reverted.

## Reviewer notes

- **One discarded-result call survives**, on the member operand of `in(variable, variable)`. It is deliberate error ordering, not the idiom this PR removes: resolved only inside the subquery body, an unknown or Relation-valued member gets masked by `chainSubquery`'s bulk-delete guard. Its comment now says so. It is pre-existing and not one of the three sites the issue names; removing it would be an unrequested behaviour change.
- **`ResolvedScalar.path` is nullable**, so totality holds at the classifier rather than inside the arm. This is deliberate and documented on the record: the null case is a Field reachable only *through* a relation chain (`…attr.categories.name`), which is scalar per element but has no column on the entity the scope is rooted at. `Scope.path()` is its only reader and converts it to the same "Unknown attribute" the old resolver threw. A third arm would force every collection operator's guard to handle a case none of them care about.
- `spring-data/CONTEXT.md` gains **Scope / Resolution** and **Owner anchoring** glossary entries.

## Verification

Run from the repository root (the Java harnesses read the shared corpus at `../conformance/`). Requires Docker — testcontainers starts the pinned Cerbos PDP:

```bash
docker run --rm -v "$(pwd)":/repo -v /var/run/docker.sock:/var/run/docker.sock -e TESTCONTAINERS_RYUK_DISABLED=true --network host -w /repo/spring-data gradle:8.12-jdk17 gradle build --no-daemon
```

`BUILD SUCCESSFUL` — **576 tests, 0 failures, 0 errors, 0 skipped** across 51 classes, including:

- `AdversarialConformanceTest` — 159 tests, the differential oracle that guards this refactor, against `ghcr.io/cerbos/cerbos:0.54.0@sha256:211c261f6031675522a35c6055b13fd719c4aff13747307e4bcb6907326537ef`
- `SpringDataIntegrationTest` — 45 tests plus nested classes
- `SpringDataQueryPlanAdapterTest`, `TriPredicateTest`, `MacroNestingBenchmarkTest`
- `ScopeTest` — 17 new tests

```bash
conformance/scripts/validate-corpus.sh
# Corpus valid: 152 actions, 20 seeds
```
