### PR TITLE
feat(demo): shared demo domain, example runner, and the prisma reference example

### DIFF
--- a/.github/workflows/prisma.yaml
+++ b/.github/workflows/prisma.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "prisma/**"
       - "conformance/**"
+      - "demo/**"
       - "policies/**"
       - ".github/workflows/prisma.yaml"
       - ".github/workflows/prisma-publish.yaml"
@@ -78,3 +79,44 @@ jobs:
       - name: Run adversarial differential suite (PostgreSQL)
         if: matrix.node-version == '22'
         run: npm run test:adversarial:postgres:v${{ matrix.prisma-version }}
+
+  # The example application: the published package, installed from `npm pack`'s tarball and used
+  # the way a consumer uses it, against the shared demo domain. It covers the two things the
+  # suites above structurally cannot — the packaging surface (`exports`, `types`, the `files`
+  # allowlist, the peer range), which every harness bypasses by importing from `"."`, and the
+  # usage shapes past a single flat query (pagination, and composing the adapter's filter with
+  # the application's own). See cerbos/query-plan-adapters#349 and
+  # docs/adr/0002-examples-install-the-packed-artifact.md.
+  #
+  # THIS JOB MUST STAY IN THIS WORKFLOW. `renovate.json` sets `automerge: true` for every
+  # non-major bump, and that is the path an ORM regression takes into `main` today. Because the
+  # example's lockfile is committed and Renovate manages it, a Prisma bump arrives as ONE PR
+  # touching both prisma/package.json and prisma/example/package.json — and this job, being a
+  # check on that PR, is what blocks the automerge when the new ORM breaks real usage. Moving it
+  # to a nightly run or a workflow of its own silently restores that gap.
+  #
+  # One Node leg only: the demo domain discriminates the package and the ORM, not the runtime —
+  # the same reasoning that gates the adversarial step above to Node 22.
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate conformance corpus
+        run: ../conformance/scripts/validate-corpus.sh
+
+      - name: Validate demo domain
+        run: ../demo/scripts/validate-demo.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - run: npm install
+
+      # The PDP is a container started by the runner from demo/docker-compose.yml, pinned to
+      # conformance/CERBOS_VERSION and conformance/CERBOS_IMAGE_DIGEST — no cerbos-setup-action
+      # here, because an example must reach the PDP the way a deployed application does.
+      - name: Run the example against the demo domain
+        run: ../demo/scripts/run-example.sh prisma

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,45 @@ what to do when you add a new service.
 the oracle recipe, the NULL conventions, the degeneracy guard, how to add a hostile shape, and how
 to add or onboard an adapter.
 
+## The demo domain
+
+`demo/` is the repository's second shared corpus, and it proves a different property.
+`conformance/` proves **semantics** — that a translated filter returns exactly the rows the PDP
+allows — with hostile shapes and five per-adapter classification buckets. `demo/` proves
+**plumbing** — that the adapter installs, imports, and composes with its ORM's real query methods
+— with realistic shapes and **no per-adapter exceptions at all**
+([ADR 0001](docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md)).
+
+It exists because every conformance harness imports its adapter from source (`from "."`), which
+leaves the published surface — `exports` maps, type declarations, `files` allowlists, peer ranges,
+POM scopes — executed nowhere, and because a harness only ever runs one flat filtered query.
+Each adapter's `example/` installs the packed artifact
+([ADR 0002](docs/adr/0002-examples-install-the-packed-artifact.md)) and exercises five usage
+shapes, of which the load-bearing one is the adapter's filter composed with an application-owned
+filter.
+
+```bash
+demo/scripts/run-example.sh <adapter>   # pack, install, run, diff against demo/expected.json
+demo/scripts/validate-demo.sh           # corpus integrity; runs in every adapter's example job
+```
+
+The demo domain reuses `conformance/CERBOS_VERSION` and `conformance/CERBOS_IMAGE_DIGEST` and gets
+**no PDP pin of its own** — one pin in the repository, reused, and `validate-demo.sh` asserts it.
+
+Two rules that are easy to get wrong:
+
+- **A shape needing a carve-out for one adapter is wrong for `demo/`.** There is no `actions.json`
+  equivalent here and adding one is exactly what ADR 0001 rules out; the argument belongs in
+  `conformance/`, where the classification buckets already exist.
+- **Each example's job must stay inside that adapter's own workflow.** `renovate.json` automerges
+  non-major bumps, so an ORM bump arrives as one PR touching both the adapter manifest and the
+  example's committed lockfile — the example job on that PR is what blocks the automerge when the
+  new ORM breaks real usage. A nightly or standalone workflow silently restores the gap.
+
+**Read [demo/README.md](demo/README.md) before changing the demo domain.** It covers the five
+usage shapes, the emitted JSON contract, why the expectations are hardcoded here but banned in
+`conformance/`, and what each of `validate-demo.sh`'s four checks stops.
+
 ## Code Style
 
 - TypeScript: 2-space indent, camelCase functions, PascalCase types, ESM-friendly
@@ -217,6 +256,7 @@ never recompute them in a harness.
 - Edit only `src/` — never commit `lib/` until tests pass
 - Shared policies in `/policies/` affect all adapters; edit carefully
 - `conformance/` affects all adapters too: a change there re-runs every adapter's CI, and adding an action requires classifying it for all ten
+- `demo/` likewise re-runs every adapter's example job, and adding a usage shape means implementing it in all ten examples — there is no classification bucket to opt out with
 - Adding a seed row means adding its `conformance/derived-fields.json` entry in the same commit; adding a seed *field* also means widening every harness's declared key set — both are enforced, not optional
 - Regenerate build artifacts in the same commit as source changes
 - Changing what an adapter can translate means updating its `conformance/actions.json` entry and its README contract table in the same commit

--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Current supported adapters:
 - [Prisma](https://github.com/cerbos/query-plan-adapters/tree/main/prisma)
 - [Spring Data JPA](https://github.com/cerbos/query-plan-adapters/tree/main/spring-data)
 - [SQLAlchemy](https://github.com/cerbos/query-plan-adapters/tree/main/sqlalchemy)
+
+Every adapter is proved against two shared corpora at the root of this repository:
+
+- [`conformance/`](conformance/) — deliberately hostile shapes, proving each adapter's filter
+  returns exactly the rows the PDP allows.
+- [`demo/`](demo/) — one realistic domain, proving each adapter's **published package** installs,
+  imports, and composes with its ORM's real query methods.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,162 @@
+# The demo domain
+
+The single realistic policy suite, seed rows and expected id sets that every **example
+application** shares. One resource kind, four flat scalar attributes, three actions.
+
+This is the second of the repository's three policy directories, and they have distinct jobs:
+
+| Directory       | Proves     | Shapes     | Per-adapter exceptions        |
+| --------------- | ---------- | ---------- | ----------------------------- |
+| `policies/`     | —          | assorted   | per-adapter unit-test policy  |
+| `conformance/`  | semantics  | hostile    | five classification buckets   |
+| `demo/`         | plumbing   | realistic  | **none**, by construction     |
+
+**Semantics** is whether a translated filter returns exactly the rows the PDP allows.
+**Plumbing** is whether the adapter can be installed, imported and handed to the ORM's real query
+methods at all. A filter can be semantically perfect and still unusable, which is what this
+directory is for. See [`CONTEXT.md`](../CONTEXT.md) for the full glossary.
+
+## What an example covers that a conformance harness cannot
+
+Every harness already plans against a live PDP over gRPC, translates, runs a real ORM call against
+a real store, and compares ids against per-row `check()`. That chain is covered for all ten
+adapters and nothing here adds to it. Two gaps remain, and they are gaps *because of how the
+harnesses are built*:
+
+1. **Packaging.** Every harness imports its adapter from source (`from "."`). The published
+   surface — `exports` maps, type declarations, `files` allowlists, peer ranges, POM scopes — is
+   executed nowhere. Examples install the packed artifact instead; see
+   [ADR 0002](../docs/adr/0002-examples-install-the-packed-artifact.md).
+2. **Usage shape.** A harness runs one flat filtered query. Consumers also paginate, and compose
+   the adapter's filter with predicates of their own. That second category is where a "returns a
+   filter object" API most often fails in practice.
+
+## The five usage shapes
+
+Every example exercises all five:
+
+1. Plain filtered list
+2. `KIND_ALWAYS_ALLOWED`
+3. `KIND_ALWAYS_DENIED`
+4. Pagination or a limit applied on top of the filter
+5. The adapter's filter combined with an **application-owned** filter
+
+Shape 5 is the one that earns the exercise. Count, sort and relation traversal are deliberately
+absent — they have no filtered form in ChromaDB or Convex, and anything needing a per-adapter
+carve-out does not belong here
+([ADR 0001](../docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md)).
+
+## Contents
+
+| File                     | What it is                                                          |
+| ------------------------ | ------------------------------------------------------------------- |
+| `policies/document.yaml` | One resource kind. `view` is conditional, `admin-view` unconditional, and `publish` is absent so the planner denies it. |
+| `seeds.json`             | Eight rows across three owners, the three principals, and the application's own predicate. |
+| `expected.json`          | The **one shared** expectations file. All ten examples assert against it. |
+| `cerbos-config.yaml`     | PDP configuration.                                                  |
+| `docker-compose.yml`     | The PDP itself, pinned to `conformance/CERBOS_VERSION` **and** `conformance/CERBOS_IMAGE_DIGEST`. |
+| `scripts/run-example.sh` | Runs one adapter's example and diffs it against `expected.json`.    |
+| `scripts/validate-demo.sh` | Integrity checks. Needs no PDP, database or network.              |
+
+`seeds.json` also declares `applicationFilter` — the predicate the **application** owns
+(`archived == false AND region == 'emea'`). It is never expressed in policy; ANDing it with the
+adapter's filter is shape 5. It lives in the corpus rather than in ten copies inside ten examples
+so `validate-demo.sh` can recompute it.
+
+## Running an example
+
+```bash
+demo/scripts/run-example.sh prisma
+```
+
+Needs `docker` (with compose) and `jq`. The runner starts the pinned PDP, invokes
+`<adapter>/example/run.sh`, and diffs its stdout against `expected.json`.
+
+The split between the two scripts is deliberate. Everything language-independent — PDP lifecycle,
+output capture, canonicalisation, the diff — lives in the runner. Everything language-specific
+lives in `run.sh`: ten languages means ten packaging stories, and putting all ten in the shared
+runner would make it a language switch.
+
+### What an example must do
+
+Each example is a program taking **no arguments** — not an HTTP service, which does not generalise
+past Java and Node and would add a web framework to nine examples for reasons unrelated to the
+adapter. Its `run.sh` must:
+
+- pack the adapter into a real distributable and install **that** (ADR 0002; Go uses `replace` and
+  proves usage shapes only)
+- print exactly one JSON document to stdout, with everything else on stderr
+- reach the PDP at `$CERBOS_HOST`, which the runner sets — never a hardcoded address. The demo PDP
+  is published on `13592`/`13593` rather than the default `3592`/`3593` on purpose: those are the
+  ports every adapter's `cerbos run` test sidecar binds, and a demo PDP still holding them makes
+  that sidecar fail to bind while the suite silently talks to the demo policies instead.
+
+The document is:
+
+```jsonc
+{
+  "adapter": "prisma",
+  "shapes": {
+    "filtered":      { "alice/view": { "kind": "KIND_CONDITIONAL", "ids": ["d1", …] } },
+    "alwaysAllowed": { … },
+    "alwaysDenied":  { … },
+    "paginated":     { "alice/view": { "kind": …, "pageSize": 2, "pageSizes": [2,2,1], "ids": […] } },
+    "composed":      { … }
+  }
+}
+```
+
+`shapes` is diffed against `expected.json`'s `shapes` with each shape's inline `description`
+stripped, so the expectations can carry their own prose without ten examples reproducing it.
+
+Every entry pins the plan `kind` alongside the ids. That is what stops an example returning all
+eight rows for `admin-view` without ever having reached the PDP.
+
+**Ids are always sorted, and pagination is asserted by page sizes plus the sorted union — never
+by per-page order.** Several of the ten stores have no total order to paginate by, and an
+order-dependent assertion would need exactly the per-adapter carve-out ADR 0001 rules out.
+Disjointness still falls out: overlapping pages would shrink the union below the sum of the sizes.
+
+## Why the expectations are hardcoded
+
+`conformance/` bans hand-written expectations, because there a wrong expectation hides an
+authorization bug. Here the id lists are frozen on purpose: this proves plumbing — did the package
+import, did the ORM accept the filter, did rows come back — where a frozen list is the better
+tripwire and reads as documentation.
+
+The rot risk is real, and `validate-demo.sh` is what answers it:
+
+1. **Structural.** `expected.json` declares exactly the five shapes and every entry is well-formed
+   for its shape — an `alwaysAllowed` entry carrying a conditional kind would leave that kind
+   untested while still looking covered. The runner diffs the whole document exactly, so this is
+   what makes that diff mean "all five shapes".
+2. **Non-degeneracy.** The lists still discriminate. Shape 5 is recomputed from shape 1 and
+   `seeds.json`, and must differ from *both* filters it composes: equal to the adapter's filter
+   and the example could drop the application predicate; equal to the application predicate's own
+   result and the example could drop **the adapter** — an authorization hole that reads as a green
+   build.
+3. **Pin reuse.** The demo domain has no `CERBOS_VERSION` of its own. One PDP pin in the
+   repository, reused, and every example reaches it.
+4. **Example coverage.** Every adapter has an `example/`. **Currently disabled** — it cannot pass
+   until the last child of cerbos/query-plan-adapters#349 merges, and enabling it is
+   cerbos/query-plan-adapters#360's job. Run with `DEMO_REQUIRE_ALL_EXAMPLES=1` to see where it
+   stands. The roster it reads is `adapters` in `conformance/actions.json`; there is deliberately
+   no second list.
+
+## Changing the demo domain
+
+A change here re-runs every adapter's example job, the same way `conformance/` re-runs every
+adapter's test workflow.
+
+- **Adding a seed row or attribute** means updating `expected.json` in the same commit, and every
+  example's schema. `validate-demo.sh` catches the first; the exact diff in the runner catches the
+  second.
+- **Adding a usage shape** means implementing it in all ten examples. There is no per-adapter
+  classification to opt out with, and adding one is what ADR 0001 rules out.
+- **A shape that needs a carve-out for one adapter is wrong for this directory.** The argument
+  belongs in `conformance/`, where the classification buckets exist.
+
+The domain is thin by construction — roughly the intersection of ten query languages, one of which
+is a vector store. It is a **floor, not a ceiling**: every example must implement the shared
+shapes, and each is then free to add richer adapter-local scenarios that nothing shared asserts.
+`spring-data/example/` keeps its photo/album/workspace domain on exactly that basis.

--- a/demo/cerbos-config.yaml
+++ b/demo/cerbos-config.yaml
@@ -1,0 +1,15 @@
+---
+# PDP configuration for the demo domain. One PDP serves every example application, so an example
+# never carries policy or PDP configuration of its own — see demo/README.md.
+server:
+  httpListenAddr: ":3592"
+  grpcListenAddr: ":3593"
+
+storage:
+  driver: "disk"
+  disk:
+    directory: /policies
+    watchForChanges: false
+
+telemetry:
+  disabled: true

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,39 @@
+# The single PDP every example application plans against, started and stopped by
+# demo/scripts/run-example.sh.
+#
+# There is one compose file for all ten examples rather than one per example: the demo domain is
+# a single policy suite by construction (ADR 0001), so ten identical compose files would be ten
+# copies of the same PDP pin waiting to drift apart.
+services:
+  cerbos:
+    # Pinned to conformance/CERBOS_VERSION and conformance/CERBOS_IMAGE_DIGEST. The demo domain
+    # gets no version file of its own — one PDP pin in the repository, reused — and
+    # conformance/scripts/validate-corpus.sh asserts that BOTH halves of this reference agree with
+    # it. The tag alone would leave the digest free to name some other build entirely.
+    image: ghcr.io/cerbos/cerbos:0.54.0@sha256:211c261f6031675522a35c6055b13fd719c4aff13747307e4bcb6907326537ef
+    # No `container_name`: the runner gives each adapter its own compose project, and a fixed
+    # container name is global, so a container left behind by one adapter's interrupted run could
+    # not be cleaned up by the next adapter's `compose down`.
+    command:
+      - "server"
+      - "--config=/config/cerbos-config.yaml"
+    environment:
+      CERBOS_NO_TELEMETRY: "1"
+    # Deliberately NOT the default 3592/3593 on the host. Every adapter's test suite starts a
+    # `cerbos run` sidecar on those ports, and a demo PDP still holding them makes that sidecar
+    # fail to bind while the suite happily talks to THIS PDP instead — which serves demo policies,
+    # so the corpus tests fail for a reason nothing in their output names. Different host ports
+    # make that collision impossible; the runner passes the address through $CERBOS_HOST, so no
+    # example hardcodes either number.
+    ports:
+      - "13592:3592"
+      - "13593:3593"
+    volumes:
+      - ./cerbos-config.yaml:/config/cerbos-config.yaml:ro
+      - ./policies:/policies:ro
+    healthcheck:
+      test: ["CMD", "/cerbos", "healthcheck"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 3s

--- a/demo/expected.json
+++ b/demo/expected.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The ONE shared expectations file. All ten example applications emit this exact `shapes` object and demo/scripts/run-example.sh diffs against it. Per-adapter expectation files would be ten files meant to stay identical, and the first divergence would read as an adapter quirk rather than the bug it is. Hardcoded id lists are a deliberate departure from conformance/'s no-hand-written-expectations rule: the corpus proves semantics, where a wrong expectation hides an authorization bug, whereas this proves plumbing, where a frozen list is the better tripwire. demo/scripts/validate-demo.sh is what stops the list rotting.",
+
+  "shapes": {
+    "filtered": {
+      "description": "Usage shape 1 — a plain filtered list. The adapter's filter is the whole query.",
+      "results": {
+        "alice/view": {
+          "kind": "KIND_CONDITIONAL",
+          "ids": ["d1", "d2", "d3", "d4", "d7"]
+        },
+        "bob/view": {
+          "kind": "KIND_CONDITIONAL",
+          "ids": ["d1", "d3", "d4", "d5", "d6", "d7"]
+        }
+      }
+    },
+
+    "alwaysAllowed": {
+      "description": "Usage shape 2 — KIND_ALWAYS_ALLOWED. There is no filter to apply, and the example must return every row rather than none. Pinning `kind` is what stops an example returning all eight rows without ever reaching the PDP.",
+      "results": {
+        "admin/admin-view": {
+          "kind": "KIND_ALWAYS_ALLOWED",
+          "ids": ["d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8"]
+        }
+      }
+    },
+
+    "alwaysDenied": {
+      "description": "Usage shape 3 — KIND_ALWAYS_DENIED. The example must return no rows without querying for a filter that does not exist.",
+      "results": {
+        "alice/publish": {
+          "kind": "KIND_ALWAYS_DENIED",
+          "ids": []
+        }
+      }
+    },
+
+    "paginated": {
+      "description": "Usage shape 4 — pagination or a limit applied on top of the filter. Pages are asserted by their SIZES and by the sorted union of their ids, never by per-page order: several of the ten stores have no total order to paginate by, and an order-dependent assertion would need a per-adapter carve-out (ADR 0001). Disjointness still falls out — overlapping pages would shrink the union below the sum of the page sizes.",
+      "results": {
+        "alice/view": {
+          "kind": "KIND_CONDITIONAL",
+          "pageSize": 2,
+          "pageSizes": [2, 2, 1],
+          "ids": ["d1", "d2", "d3", "d4", "d7"]
+        },
+        "admin/admin-view": {
+          "kind": "KIND_ALWAYS_ALLOWED",
+          "pageSize": 3,
+          "pageSizes": [3, 3, 2],
+          "ids": ["d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8"]
+        }
+      }
+    },
+
+    "composed": {
+      "description": "Usage shape 5 — the adapter's filter ANDed with the APPLICATION's own predicate (`applicationFilter` in seeds.json: archived == false AND region == 'emea'). This is the shape that earns the exercise: it is where a 'returns a filter object' API most often fails in practice, and no conformance harness checks it. All three plan kinds appear here on purpose — composing against KIND_ALWAYS_ALLOWED (no filter to AND with) and KIND_ALWAYS_DENIED (the application predicate must not resurrect denied rows) are the two cases that break first.",
+      "results": {
+        "alice/view": {
+          "kind": "KIND_CONDITIONAL",
+          "ids": ["d1", "d2", "d4"]
+        },
+        "bob/view": {
+          "kind": "KIND_CONDITIONAL",
+          "ids": ["d1", "d4", "d6"]
+        },
+        "admin/admin-view": {
+          "kind": "KIND_ALWAYS_ALLOWED",
+          "ids": ["d1", "d2", "d4", "d6"]
+        },
+        "alice/publish": {
+          "kind": "KIND_ALWAYS_DENIED",
+          "ids": []
+        }
+      }
+    }
+  }
+}

--- a/demo/policies/document.yaml
+++ b/demo/policies/document.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+#
+# The demo domain's only resource policy. Realistic shapes, not hostile ones — the hostile ones
+# live in ../../conformance/policies/adversarial.yaml and are what proves SEMANTICS. This file
+# proves PLUMBING, so every shape in it must be expressible by all ten adapters and there is
+# deliberately no per-adapter classification. See docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md.
+#
+# Flat scalar attributes only: ownerId, public, region, archived. No relations, no NULLs, no LIKE
+# metacharacters, no arithmetic — each of those splits the adapters, and each is the conformance
+# corpus's job.
+#
+# `archived` and `region` are never referenced here. They are the APPLICATION's own columns, and
+# composing them with the adapter's filter is usage shape 5.
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: document
+  rules:
+    # Usage shapes 1, 4 and 5: a conditional plan (KIND_CONDITIONAL) over two flat attributes.
+    - actions:
+        - "view"
+      effect: EFFECT_ALLOW
+      roles:
+        - user
+      condition:
+        match:
+          expr: request.resource.attr.public || request.resource.attr.ownerId == request.principal.id
+
+    # Usage shape 2: unconditional for the admin role, so the planner returns KIND_ALWAYS_ALLOWED.
+    - actions:
+        - "admin-view"
+      effect: EFFECT_ALLOW
+      roles:
+        - admin
+
+    # Usage shape 3 is `publish`, which is deliberately ABSENT from this file. No matching rule
+    # means the planner returns KIND_ALWAYS_DENIED. Adding a `publish` rule here — even a DENY one
+    # — would change what shape 3 exercises.

--- a/demo/scripts/run-example.sh
+++ b/demo/scripts/run-example.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Run one adapter's example application against the shared demo domain.
+#
+#   demo/scripts/run-example.sh prisma
+#
+# The split between this script and the example is deliberate. Everything language-independent
+# lives here — PDP lifecycle, output capture, canonicalisation, the diff against
+# demo/expected.json. Everything language-specific lives in `<adapter>/example/run.sh`, which
+# packs the adapter into a real distributable, installs THAT (never the source directory — see
+# docs/adr/0002-examples-install-the-packed-artifact.md), runs the example, and prints one JSON
+# document to stdout. Ten languages means ten packaging stories; growing a language switch in here
+# instead would put all ten in one file.
+#
+# The example's contract:
+#   - takes no arguments, reads no environment except CERBOS_HOST (set below)
+#   - prints exactly one JSON document to stdout: {"adapter": "<name>", "shapes": {...}}
+#   - anything it wants to say to a human goes to stderr
+#
+# Pre-reqs: docker (with compose), jq.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${DEMO_DIR}/.." && pwd)"
+
+RED="\033[0;31m"; GREEN="\033[0;32m"; NC="\033[0m"
+fail() { printf "${RED}FAIL${NC} %s\n" "$*" >&2; exit 1; }
+ok()   { printf "${GREEN}OK${NC}   %s\n" "$*" >&2; }
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <adapter>" >&2
+  exit 2
+fi
+ADAPTER="$1"
+
+# The adapter roster is `adapters` in conformance/actions.json. Deliberately not a second list:
+# an adapter added to one roster but not the other looks consistent from either side.
+if ! jq -e --arg a "${ADAPTER}" '.adapters | index($a)' \
+  "${REPO_ROOT}/conformance/actions.json" >/dev/null; then
+  fail "'${ADAPTER}' is not in conformance/actions.json .adapters"
+fi
+
+EXAMPLE_DIR="${REPO_ROOT}/${ADAPTER}/example"
+RUNNER="${EXAMPLE_DIR}/run.sh"
+[[ -d "${EXAMPLE_DIR}" ]] || fail "${ADAPTER}/example/ does not exist"
+[[ -x "${RUNNER}" ]] || fail "${ADAPTER}/example/run.sh does not exist or is not executable"
+
+WORK_DIR="$(mktemp -d)"
+COMPOSE=(docker compose -f "${DEMO_DIR}/docker-compose.yml" -p "cerbos-demo-${ADAPTER}")
+
+cleanup() {
+  local status=$?
+  if (( status != 0 )); then
+    # Dump diagnostics BEFORE `compose down` discards the container — this is what CI, and anyone
+    # running headless, gets to debug with.
+    echo "==> demo example failed (exit ${status}): Cerbos container logs" >&2
+    "${COMPOSE[@]}" logs --no-color cerbos >&2 2>/dev/null || true
+    if [[ -s "${WORK_DIR}/stdout.json" ]]; then
+      echo "==> example stdout was:" >&2
+      cat "${WORK_DIR}/stdout.json" >&2
+    fi
+  fi
+  "${COMPOSE[@]}" down --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> starting the demo PDP" >&2
+"${COMPOSE[@]}" up -d --wait >&2
+
+echo "==> ${ADAPTER}/example/run.sh" >&2
+# stdout is the JSON document and nothing else; the example's own chatter goes to stderr, so it
+# stays visible while the document stays machine-readable.
+if ! CERBOS_HOST="localhost:13593" "${RUNNER}" >"${WORK_DIR}/stdout.json"; then
+  fail "${ADAPTER}/example/run.sh exited non-zero"
+fi
+
+if ! jq -e . "${WORK_DIR}/stdout.json" >/dev/null 2>&1; then
+  fail "${ADAPTER}/example/run.sh did not print a single JSON document to stdout"
+fi
+
+# The example names itself, so a runner that silently ran some other example — a stale build
+# directory, a copied run.sh — fails here rather than passing on the shared expectations.
+declared="$(jq -r '.adapter // ""' "${WORK_DIR}/stdout.json")"
+[[ "${declared}" == "${ADAPTER}" ]] || \
+  fail "example declared adapter '${declared}', expected '${ADAPTER}'"
+
+# expected.json carries its documentation inline, under a `description` sibling of each shape's
+# `results`. Examples emit the results alone, so the comparison strips the prose from the
+# expectation rather than asking ten examples to reproduce it.
+jq -S '.shapes | with_entries(.value |= .results)' "${DEMO_DIR}/expected.json" \
+  >"${WORK_DIR}/expected.json"
+jq -S '.shapes' "${WORK_DIR}/stdout.json" >"${WORK_DIR}/actual.json"
+
+if ! diff -u "${WORK_DIR}/expected.json" "${WORK_DIR}/actual.json" >"${WORK_DIR}/diff" 2>&1; then
+  echo "==> ${ADAPTER} diverged from demo/expected.json (- expected, + actual)" >&2
+  cat "${WORK_DIR}/diff" >&2
+  fail "${ADAPTER} example output does not match demo/expected.json"
+fi
+
+shape_count="$(jq -r '.shapes | length' "${WORK_DIR}/stdout.json")"
+ok "${ADAPTER} example matched demo/expected.json across ${shape_count} usage shapes"

--- a/demo/scripts/validate-demo.sh
+++ b/demo/scripts/validate-demo.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# Integrity checks for the demo domain. Runs in every adapter's example job, needs no PDP, no
+# database and no network.
+#
+# The demo domain's expectations are hardcoded id lists, unlike conformance/'s, which are computed
+# from a live oracle. That is the right trade for proving plumbing — a frozen list reads as
+# documentation and is the better tripwire — but it means the lists can rot to something that
+# passes vacuously. These checks are what stops that.
+#
+#   1. Structural: expected.json declares exactly the five usage shapes, and every entry in each
+#      is well-formed for that shape. run-example.sh diffs the WHOLE shapes object exactly, so an
+#      example that skips a shape or an entry fails there; this check is what makes that diff
+#      mean "all five shapes" rather than "whatever expected.json happened to contain".
+#   2. Non-degeneracy: the expectations still discriminate — a proper subset somewhere, and
+#      shape 5 differing from both of the two filters it composes.
+#   3. Pin reuse: the demo domain has no PDP version of its own and every example reaches the one
+#      in conformance/.
+#   4. Every adapter has an example/ directory. Landed DISABLED — it cannot pass until the last
+#      child of cerbos/query-plan-adapters#349 merges, and turning it on is #360's job.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${DEMO_DIR}/.." && pwd)"
+
+SEEDS="${DEMO_DIR}/seeds.json"
+EXPECTED="${DEMO_DIR}/expected.json"
+ACTIONS="${REPO_ROOT}/conformance/actions.json"
+
+# Turning this on is cerbos/query-plan-adapters#360, once every adapter has an example.
+REQUIRE_ALL_EXAMPLES="${DEMO_REQUIRE_ALL_EXAMPLES:-0}"
+
+# The five usage shapes from cerbos/query-plan-adapters#349, in emission order.
+SHAPES=(filtered alwaysAllowed alwaysDenied paginated composed)
+
+failures=0
+fail() { echo "  ✗ $*" >&2; failures=$((failures + 1)); }
+
+for f in "${SEEDS}" "${EXPECTED}" "${ACTIONS}"; do
+  [[ -f "${f}" ]] || { echo "missing ${f}" >&2; exit 1; }
+  jq -e . "${f}" >/dev/null || { echo "${f} is not valid JSON" >&2; exit 1; }
+done
+
+# Shared jq preamble: the seed id list, and the id set the APPLICATION's own predicate selects on
+# its own. Both are derived from seeds.json so neither can drift from the rows the examples load.
+read -r -d '' JQ_LIB <<'JQ' || true
+def seed_ids: [.documents[].id];
+def app_ids:
+  (.applicationFilter | to_entries | map(select(.key != "description"))) as $pred
+  | [ .documents[] | select(. as $d | all($pred[]; $d[.key] == .value)) | .id ];
+JQ
+
+SEED_IDS="$(jq -c "${JQ_LIB} seed_ids | sort" "${SEEDS}")"
+APP_IDS="$(jq -c "${JQ_LIB} app_ids | sort" "${SEEDS}")"
+SEED_COUNT="$(jq -r 'length' <<<"${SEED_IDS}")"
+
+echo "==> demo domain: ${SEED_COUNT} seed rows, application filter selects $(jq -r 'length' <<<"${APP_IDS}")"
+
+# ---------------------------------------------------------------------------------------------
+# 1. Structural
+# ---------------------------------------------------------------------------------------------
+echo "==> [1/4] structural: five usage shapes, well-formed entries"
+
+declared="$(jq -r '.shapes | keys_unsorted | join(",")' "${EXPECTED}")"
+expected_shapes="$(IFS=,; echo "${SHAPES[*]}")"
+if [[ "${declared}" != "${expected_shapes}" ]]; then
+  fail "expected.json declares shapes [${declared}], expected [${expected_shapes}]"
+fi
+
+for shape in "${SHAPES[@]}"; do
+  if ! jq -e --arg s "${shape}" '.shapes[$s].description | type == "string" and length > 0' \
+    "${EXPECTED}" >/dev/null; then
+    fail "shape '${shape}' has no description"
+  fi
+  if ! jq -e --arg s "${shape}" '.shapes[$s].results | type == "object" and length > 0' \
+    "${EXPECTED}" >/dev/null; then
+    fail "shape '${shape}' has no results"
+  fi
+done
+
+# Every entry, in every shape: a "<principal>/<action>" key, a real plan kind, and an id list that
+# is sorted, duplicate-free and drawn from the seed rows. Sorted ids are what makes run-example.sh
+# able to diff textually without a per-store ordering carve-out.
+while IFS= read -r problem; do
+  fail "${problem}"
+done < <(jq -r --argjson seedIds "${SEED_IDS}" '
+  ["KIND_CONDITIONAL", "KIND_ALWAYS_ALLOWED", "KIND_ALWAYS_DENIED"] as $kinds
+  | .shapes
+  | to_entries[]
+  | .key as $shape
+  | .value.results
+  | to_entries[]
+  | .key as $k | .value as $v
+  | [
+      (select($k | test("^[a-z0-9-]+/[a-z0-9-]+$") | not)
+        | "\($shape)/\($k): key must be \"<principal>/<action>\""),
+      (select($kinds | index($v.kind) | not)
+        | "\($shape)/\($k): unknown plan kind \"\($v.kind // "")\""),
+      (select($v.ids | type != "array")
+        | "\($shape)/\($k): ids must be an array"),
+      (select(($v.ids | type == "array") and ($v.ids != ($v.ids | sort)))
+        | "\($shape)/\($k): ids must be sorted"),
+      (select(($v.ids | type == "array") and (($v.ids | length) != ($v.ids | unique | length)))
+        | "\($shape)/\($k): ids must be duplicate-free"),
+      (select(($v.ids | type == "array") and (($v.ids - $seedIds) | length > 0))
+        | "\($shape)/\($k): ids not in seeds.json: \(($v.ids - $seedIds) | join(","))")
+    ][]
+' "${EXPECTED}")
+
+# Per-shape structure. alwaysAllowed/alwaysDenied exist to pin a plan KIND, so an entry carrying
+# the wrong one would leave that kind untested while still looking covered.
+while IFS= read -r problem; do
+  fail "${problem}"
+done < <(jq -r --argjson seedIds "${SEED_IDS}" '
+  [
+    (.shapes.filtered.results | to_entries[] | select(.value.kind != "KIND_CONDITIONAL")
+      | "filtered/\(.key): must be KIND_CONDITIONAL, got \(.value.kind)"),
+
+    (.shapes.alwaysAllowed.results | to_entries[] | select(.value.kind != "KIND_ALWAYS_ALLOWED")
+      | "alwaysAllowed/\(.key): must be KIND_ALWAYS_ALLOWED, got \(.value.kind)"),
+    (.shapes.alwaysAllowed.results | to_entries[] | select(.value.ids != ($seedIds | sort))
+      | "alwaysAllowed/\(.key): an unconditional plan must return every seed row"),
+
+    (.shapes.alwaysDenied.results | to_entries[] | select(.value.kind != "KIND_ALWAYS_DENIED")
+      | "alwaysDenied/\(.key): must be KIND_ALWAYS_DENIED, got \(.value.kind)"),
+    (.shapes.alwaysDenied.results | to_entries[] | select(.value.ids != [])
+      | "alwaysDenied/\(.key): an unconditional denial must return no rows"),
+
+    (.shapes.paginated.results | to_entries[]
+      | .key as $k | .value as $v
+      | [
+          (select((($v.pageSize | type) != "number") or $v.pageSize < 1)
+            | "paginated/\($k): pageSize must be a positive number"),
+          (select(($v.pageSizes | type) != "array" or ($v.pageSizes | length) < 2)
+            | "paginated/\($k): pageSizes must span more than one page"),
+          (select(($v.pageSizes | type) == "array" and ($v.pageSizes | any(. < 1)))
+            | "paginated/\($k): an empty page is not a page"),
+          (select(($v.pageSizes | type) == "array"
+                  and ($v.pageSizes | add // 0) != ($v.ids | length))
+            | "paginated/\($k): page sizes sum to \($v.pageSizes | add // 0), ids has \($v.ids | length)"),
+          (select(($v.pageSizes | type) == "array"
+                  and ($v.pageSizes[:-1] | any(. != $v.pageSize)))
+            | "paginated/\($k): every page but the last must be full (\($v.pageSize))"),
+          (select(($v.pageSizes | type) == "array" and ($v.pageSizes[-1:] | any(. > $v.pageSize)))
+            | "paginated/\($k): the last page cannot exceed pageSize")
+        ][])
+  ][]
+' "${EXPECTED}")
+
+# ---------------------------------------------------------------------------------------------
+# 2. Non-degeneracy
+# ---------------------------------------------------------------------------------------------
+echo "==> [2/4] non-degeneracy: the expectations still discriminate"
+
+# The analogue of the conformance degeneracy guard. Without it these lists can rot to all-empty,
+# or to every-seed-row, and still pass every diff.
+proper_subsets="$(jq -r --argjson seedIds "${SEED_IDS}" '
+  [ .shapes.filtered.results, .shapes.composed.results
+    | to_entries[]
+    | select((.value.ids | length) > 0 and (.value.ids | length) < ($seedIds | length))
+  ] | length
+' "${EXPECTED}")"
+if (( proper_subsets < 2 )); then
+  fail "filtered and composed must each contain at least one proper, non-empty subset of the seed rows"
+fi
+
+# Shape 5 is only worth running if it differs from BOTH filters it composes. If it equals the
+# adapter's filter, the example could drop the application predicate and still pass; if it equals
+# the application predicate's own result, the example could drop the ADAPTER and still pass — and
+# that second one is an authorization hole that reads as a green build.
+while IFS= read -r problem; do
+  fail "${problem}"
+done < <(jq -r --argjson appIds "${APP_IDS}" --argjson seedIds "${SEED_IDS}" '
+  .shapes.filtered.results as $filtered
+  | .shapes.alwaysAllowed.results as $allowed
+  | .shapes.composed.results
+  | to_entries[]
+  | .key as $k | .value as $v
+  | (if $v.kind == "KIND_ALWAYS_ALLOWED" then ($seedIds | sort)
+     elif $v.kind == "KIND_ALWAYS_DENIED" then []
+     else ($filtered[$k].ids // null) end) as $unfiltered
+  | [
+      (select($unfiltered == null)
+        | "composed/\($k): KIND_CONDITIONAL needs the same key under `filtered` to compose from"),
+
+      # The composed answer must BE the intersection. This recomputes shape 5 from shape 1 and
+      # seeds.json, so the two hardcoded lists cannot rot independently of each other.
+      (select($unfiltered != null and ($v.ids != ($unfiltered - ($unfiltered - $appIds) | sort)))
+        | "composed/\($k): expected \(($unfiltered - ($unfiltered - $appIds) | sort) | join(",")), got \($v.ids | join(","))"),
+
+      (select($v.kind == "KIND_CONDITIONAL" and $v.ids == $unfiltered)
+        | "composed/\($k): equals the adapter filter alone — the application predicate is a no-op here"),
+      (select($v.kind == "KIND_CONDITIONAL" and $v.ids == ($appIds | sort))
+        | "composed/\($k): equals the application predicate alone — an example that never called the adapter would pass")
+    ][]
+' "${EXPECTED}")
+
+# A paginated entry pages over an answer another shape already pins, so the two must agree.
+while IFS= read -r problem; do
+  fail "${problem}"
+done < <(jq -r '
+  (.shapes.filtered.results + .shapes.alwaysAllowed.results + .shapes.alwaysDenied.results) as $unpaged
+  | .shapes.paginated.results
+  | to_entries[]
+  | .key as $k | .value as $v
+  | [
+      (select($unpaged[$k] == null)
+        | "paginated/\($k): no unpaginated shape pins this principal/action"),
+      (select($unpaged[$k] != null and $unpaged[$k].ids != $v.ids)
+        | "paginated/\($k): pages union to \($v.ids | join(",")), unpaginated is \($unpaged[$k].ids | join(","))"),
+      (select($unpaged[$k] != null and $unpaged[$k].kind != $v.kind)
+        | "paginated/\($k): plan kind \($v.kind) disagrees with \($unpaged[$k].kind)")
+    ][]
+' "${EXPECTED}")
+
+# Every principal and action named in expected.json has to exist. A typo in an action name makes
+# the PDP return ALWAYS_DENIED, and the example would then assert an empty list forever without
+# anything looking wrong.
+#
+# The action names come out of the `actions:` blocks specifically, not out of every quoted list
+# item in the file — `roles:` is also a list of bare lowercase names, and a scan loose enough to
+# pick those up would accept `admin` as a valid action.
+policy_actions="$(awk '
+  /^[[:space:]]*-?[[:space:]]*actions:[[:space:]]*$/ { inactions = 1; next }
+  inactions && /^[[:space:]]*-[[:space:]]*"?[a-z0-9-]+"?[[:space:]]*$/ {
+    gsub(/^[[:space:]]*-[[:space:]]*"?|"?[[:space:]]*$/, ""); print; next
+  }
+  { inactions = 0 }
+' "${DEMO_DIR}/policies/document.yaml" | sort -u)"
+if [[ -z "${policy_actions}" ]]; then
+  fail "no actions parsed from demo/policies/document.yaml — the extraction above is broken"
+fi
+
+# An action with NO rule is how KIND_ALWAYS_DENIED is produced, so `alwaysDenied` must name one
+# that the policy does not grant, and every other shape must name one that it does. Deriving both
+# from the policy keeps the action name out of this script: renaming `publish` in the policy
+# cannot leave a stale literal here.
+while IFS= read -r shape_ref; do
+  shape="${shape_ref%% *}"
+  ref="${shape_ref#* }"
+  principal="${ref%%/*}"
+  action="${ref##*/}"
+
+  if ! jq -e --arg p "${principal}" 'any(.principals[]; .id == $p)' "${SEEDS}" >/dev/null; then
+    fail "expected.json refers to principal '${principal}', which is not in seeds.json"
+  fi
+
+  granted=0
+  grep -qx "${action}" <<<"${policy_actions}" && granted=1
+
+  if [[ "${shape}" == "alwaysDenied" ]]; then
+    (( granted == 0 )) || \
+      fail "alwaysDenied/${ref}: '${action}' IS granted by demo/policies/document.yaml, so the planner will not return KIND_ALWAYS_DENIED"
+  elif jq -e --arg s "${shape}" --arg k "${ref}" \
+    '.shapes[$s].results[$k].kind != "KIND_ALWAYS_DENIED"' "${EXPECTED}" >/dev/null; then
+    (( granted == 1 )) || \
+      fail "${shape}/${ref}: no rule in demo/policies/document.yaml grants '${action}'"
+  fi
+done < <(jq -r '.shapes | to_entries[] | .key as $s | .value.results | keys[] | "\($s) \(.)"' \
+  "${EXPECTED}")
+
+# ---------------------------------------------------------------------------------------------
+# 3. PDP pin reuse
+# ---------------------------------------------------------------------------------------------
+echo "==> [3/4] PDP pin: one pin in the repository, reused"
+
+pinned_version="$(tr -d '[:space:]' <"${REPO_ROOT}/conformance/CERBOS_VERSION")"
+pinned_digest="$(tr -d '[:space:]' <"${REPO_ROOT}/conformance/CERBOS_IMAGE_DIGEST")"
+pinned_image="ghcr.io/cerbos/cerbos:${pinned_version}@${pinned_digest}"
+
+# The demo domain gets no version file of its own. Two pins would eventually name two builds, and
+# the one an example actually ran against would be whichever it happened to read.
+for stray in CERBOS_VERSION CERBOS_IMAGE_DIGEST; do
+  [[ -e "${DEMO_DIR}/${stray}" ]] && \
+    fail "demo/${stray} must not exist — the pin lives in conformance/ and is reused"
+done
+
+if ! grep -qF "${pinned_image}" "${DEMO_DIR}/docker-compose.yml"; then
+  fail "demo/docker-compose.yml must pin ${pinned_image}"
+fi
+
+# Every adapter that HAS an example must reach that PDP: either through the shared compose file
+# above, or through a compose file of its own that names the same tag AND digest.
+# (conformance/scripts/validate-corpus.sh scans the whole repository for the same agreement; this
+# is restated here because the example job runs validate-demo.sh on its own.)
+#
+# Same file set as validate-corpus.sh, deliberately: things that RUN, never prose, and never
+# installed or built output. An example's node_modules holds a copy of the adapter's own README,
+# and two scans disagreeing about whether that counts would make one of them wrong.
+SOURCE_INCLUDES=(
+  --include='*.yml' --include='*.yaml' --include='*.sh' --include='*.py' --include='*.go'
+  --include='*.java' --include='*.kts' --include='*.ts' --include='*.js' --include='*.json'
+  --include='Dockerfile' --include='*_IMAGE'
+)
+SOURCE_EXCLUDES=(
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=lib --exclude-dir=build
+  --exclude-dir=.venv --exclude-dir=.gradle --exclude-dir=bin --exclude-dir=dist
+  --exclude-dir=generated --exclude-dir=__pypackages__
+)
+for adapter in $(jq -r '.adapters[]' "${ACTIONS}"); do
+  example_dir="${REPO_ROOT}/${adapter}/example"
+  [[ -d "${example_dir}" ]] || continue
+  while IFS= read -r ref; do
+    # An interpolation (`cerbos:${CERBOS_VERSION}`) reads the pinned files at runtime and cannot
+    # drift, so it is already correct by construction.
+    case "${ref}" in *'ghcr.io/cerbos/cerbos:$'*|*'ghcr.io/cerbos/cerbos:{'*) continue ;; esac
+    [[ "${ref}" == "${pinned_image}" ]] || \
+      fail "${adapter}/example pins Cerbos as '${ref}', expected '${pinned_image}'"
+  done < <(grep -rhoE 'ghcr\.io/cerbos/cerbos:[^@"'"'"' )]*(@sha256:[0-9a-f]{64})?' \
+    "${SOURCE_INCLUDES[@]}" "${SOURCE_EXCLUDES[@]}" "${example_dir}" 2>/dev/null || true)
+done
+
+# ---------------------------------------------------------------------------------------------
+# 4. Every adapter has an example (DISABLED — see the header)
+# ---------------------------------------------------------------------------------------------
+missing=()
+have=()
+for adapter in $(jq -r '.adapters[]' "${ACTIONS}"); do
+  if [[ -x "${REPO_ROOT}/${adapter}/example/run.sh" ]]; then
+    have+=("${adapter}")
+  else
+    missing+=("${adapter}")
+  fi
+done
+
+if [[ "${REQUIRE_ALL_EXAMPLES}" == "1" ]]; then
+  echo "==> [4/4] example coverage: enforced"
+  if (( ${#missing[@]} > 0 )); then
+    fail "no runnable example/run.sh for: ${missing[*]}"
+  fi
+else
+  echo "==> [4/4] example coverage: ${#have[@]}/$(( ${#have[@]} + ${#missing[@]} )) adapters" \
+    "(check disabled until cerbos/query-plan-adapters#360; still missing: ${missing[*]:-none})"
+fi
+
+if (( failures > 0 )); then
+  echo >&2
+  echo "demo domain validation failed with ${failures} problem(s)" >&2
+  exit 1
+fi
+
+echo "==> demo domain OK"

--- a/demo/seeds.json
+++ b/demo/seeds.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Seed rows and principals for the demo domain. Every example application persists exactly these rows into its own store and plans for exactly these principals. Realistic shapes only — the hostile ones live in ../conformance/seeds.json.",
+  "principals": [
+    { "id": "alice", "roles": ["user"] },
+    { "id": "bob", "roles": ["user"] },
+    { "id": "admin", "roles": ["admin"] }
+  ],
+  "applicationFilter": {
+    "description": "The application's OWN predicate, never expressed in policy. Usage shape 5 ANDs it with the adapter-produced filter. Kept here rather than hardcoded in ten examples so validate-demo.sh can recompute it and prove shape 5 discriminates: applying this predicate alone, or the adapter's filter alone, must both give the wrong answer.",
+    "archived": false,
+    "region": "emea"
+  },
+  "documents": [
+    { "id": "d1", "ownerId": "alice", "public": true, "region": "emea", "archived": false },
+    { "id": "d2", "ownerId": "alice", "public": false, "region": "emea", "archived": false },
+    { "id": "d3", "ownerId": "alice", "public": true, "region": "apac", "archived": true },
+    { "id": "d4", "ownerId": "bob", "public": true, "region": "emea", "archived": false },
+    { "id": "d5", "ownerId": "bob", "public": false, "region": "emea", "archived": true },
+    { "id": "d6", "ownerId": "bob", "public": false, "region": "emea", "archived": false },
+    { "id": "d7", "ownerId": "carol", "public": true, "region": "apac", "archived": false },
+    { "id": "d8", "ownerId": "carol", "public": false, "region": "emea", "archived": true }
+  ]
+}

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -652,6 +652,19 @@ type Mapper = { [key: string]: MapperConfig } | ((key: string) => MapperConfig);
 
 A complete example application using this adapter can be found at [https://github.com/cerbos/express-prisma-cerbos](https://github.com/cerbos/express-prisma-cerbos)
 
+This repository also carries a runnable [`example/`](example/), which installs the adapter from the
+artifact `npm publish` would upload and exercises it against a live PDP over the shared
+[demo domain](../demo/README.md):
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh prisma
+```
+
+Unlike the test suites, it resolves the adapter through its **published** surface — the `exports`
+map, `types`, the `files` allowlist, and the peer range — and covers usage shapes past a single
+flat query: pagination, and the adapter's filter composed with an application-owned filter.
+
 ## Resources
 
 ### Documentation

--- a/prisma/example/.gitignore
+++ b/prisma/example/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+lib
+src/generated
+tsconfig.tsbuildinfo
+prisma/demo.db
+prisma/demo.db-journal
+# The adapter tarball `run.sh` builds and installs. Regenerated on every run; never committed.
+cerbos-orm-prisma-*.tgz

--- a/prisma/example/README.md
+++ b/prisma/example/README.md
@@ -1,0 +1,93 @@
+# `@cerbos/orm-prisma` example application
+
+A runnable program that installs the adapter **as a published package** and uses it the way a
+consumer would, against the shared [demo domain](../../demo/README.md).
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh prisma
+```
+
+Needs `docker` (with compose), `jq` and Node 22+. The runner starts the pinned Cerbos PDP; this
+directory's `run.sh` packs the adapter, installs the tarball, builds, and runs.
+
+This is the reference implementation every other adapter's example copies.
+
+## What it proves
+
+Not what the adapter translates — [`../src/adversarial.test.ts`](../src/adversarial.test.ts)
+proves that against a hostile corpus with a live PDP as the oracle. This proves the two things
+that harness structurally cannot:
+
+**Packaging.** `run.sh` builds the artifact `npm publish` would upload and installs *that*, so the
+import in [`src/main.ts`](src/main.ts) resolves through the published surface — the `exports` map,
+`types`, the `files` allowlist, and the peer range against this example's own `@prisma/client`.
+The harness imports from `"."` and touches none of it. See
+[ADR 0002](../../docs/adr/0002-examples-install-the-packed-artifact.md).
+
+Both halves are load-bearing and both have been checked by breaking them:
+
+| Break                                     | Example        | `npm test`  | `npm run test:adversarial` |
+| ----------------------------------------- | -------------- | ----------- | -------------------------- |
+| `exports["."]` points at a missing file    | fails (TS2307) | 223 passing | 162 passing                |
+| `lib/**/*.js` dropped from `files`         | fails (MODULE_NOT_FOUND) | 223 passing | 162 passing      |
+
+`tsconfig.json` sets `moduleResolution: "nodenext"` for the first row specifically: the legacy
+`node10` resolver ignores `exports` entirely and falls back to `main`/`types`, so a broken
+`exports` map would compile clean here and only fail for a consumer.
+
+**Usage shape.** A harness runs one flat filtered query. This runs all
+[five shapes](../../demo/README.md#the-five-usage-shapes), including pagination and — the one that
+earns the exercise — the adapter's filter ANDed with the application's own predicate, across all
+three plan kinds.
+
+## Layout
+
+| Path                   | What it is                                                          |
+| ---------------------- | -------------------------------------------------------------------- |
+| `run.sh`               | pack → install → generate → compile → run. Prints the JSON document on stdout. |
+| `src/main.ts`          | The example itself: one function per usage shape.                    |
+| `prisma/schema.prisma` | The demo domain's one model, as a consumer would write it: flat scalar columns, no relations. |
+| `package.json`         | The ORM and SDK pins Renovate manages.                               |
+| `package-lock.json`    | Committed. See below.                                                |
+
+## Two things that look odd and are not
+
+**`@cerbos/orm-prisma` is not in `package.json`.** `npm pack`'s tarball gets a fresh integrity
+hash on every build, so a committed lockfile naming it would break `npm ci` the moment the adapter
+changed. `run.sh` runs `npm ci` for the pinned tree and then installs the tarball on top with
+`--no-save --no-package-lock`, which leaves both manifests exactly as committed while still
+resolving the adapter and its peers the way a consumer's install does.
+
+**The lockfile is committed anyway,** because it is what makes the CI job load-bearing.
+`renovate.json` automerges every non-major bump, so a Prisma bump arrives as one PR touching both
+`prisma/package.json` and this file — and the `example` job on that PR is what blocks the
+automerge when the new ORM breaks real usage. That only works while the job stays in
+`.github/workflows/prisma.yaml`; there is a comment on the job saying so.
+
+## The mapper
+
+Cerbos attribute names are not column names, so a consumer always writes one of these:
+
+```ts
+const MAPPER: Mapper = {
+  "request.resource.attr.ownerId": { field: "ownerId" },
+  "request.resource.attr.public": { field: "public" },
+};
+```
+
+Without it the adapter emits `request.resource.attr.ownerId` as a literal Prisma field and the
+query fails — which is itself worth seeing in an example.
+
+`archived` and `region` are deliberately absent: they are the application's columns, never
+referenced by policy, and composing them with the adapter's filter is shape 5.
+
+## Scope
+
+This example is a JSON-printing CLI, not an onboarding artifact — that is
+[`spring-data/example/`](../../spring-data/example/), and the floor/ceiling rule in
+[ADR 0001](../../docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md) is why both exist.
+
+It also does **not** prove the declared peer range. `@cerbos/orm-prisma` claims
+`^5 || ^6 || ^7`; this example runs one of those. Widening the harness matrix is the fix for that,
+and it is out of scope here.

--- a/prisma/example/package-lock.json
+++ b/prisma/example/package-lock.json
@@ -1,0 +1,2524 @@
+{
+  "name": "cerbos-orm-prisma-example",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cerbos-orm-prisma-example",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/grpc": "^0.28.0",
+        "@prisma/adapter-better-sqlite3": "^7.5.0",
+        "@prisma/client": "^7.5.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "prisma": "^7.5.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cerbos/api": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.10.0.tgz",
+      "integrity": "sha512-j+SCITUBsb4MFAml5okmXPAOOR1BVTSNLrsdS/h2v4lEYzNiO27t/zPx+779Fe9SzHOFwPT5bhEUgYdRnHa3UA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@cerbos/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-ZXL4qCDb+NwJmFJlWimQuegHOEIYKan6mZdYy2Jla126p+Esh5H9RNfHBnMQPbPEE35c5ShyS1ENa/wCCFtFMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/api": "^0.10.0",
+        "uuid": "^14.0.1"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.12.1"
+      }
+    },
+    "node_modules/@cerbos/grpc": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.28.0.tgz",
+      "integrity": "sha512-xfSmizAIYK9wmrCF6xVn94f0cEAGaKafJc+C8sPEfxKAO8suyI7fRK0ETYQ0QRihAUhq8+/i7E7oNJtddSOneg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/core": "^0.32.0",
+        "@grpc/grpc-js": "^1.14.4"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.12.1",
+        "@cerbos/api": "^0.10.0"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
+      "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-socket": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.3.tgz",
+      "integrity": "sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "pglite-server": "dist/scripts/server.js"
+      },
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.4.3"
+      }
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.3.tgz",
+      "integrity": "sha512-AlzLJTRJ8+UFgK8CmxIpyIpJ0+YaFw02IiOSdYrqxwPXdSyeIShz8aa9Tq+tYFXdPwcaMp/Fc80mQZ1dkOQ/wg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.4.3"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@prisma/adapter-better-sqlite3": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-better-sqlite3/-/adapter-better-sqlite3-7.9.1.tgz",
+      "integrity": "sha512-EoAk+crcwbqjdhwjVehj1TaMx7X/zsR49cxjeukFs/g5frdJYYM3k8Q3xNQp032nvWb1L+RMBytn/4b/EYrNoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.9.1",
+        "better-sqlite3": "^12.6.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.9.1.tgz",
+      "integrity": "sha512-+xgrh2EhJVF79wC0yX5G4PI1Rdcm7Qn/nekNQ+t/O153wtNggruHal+fXHSa0QE+Tp/Cw5wvxeCEhZZ59xGm8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/client-runtime-utils": "7.9.1"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.9.1.tgz",
+      "integrity": "sha512-mVIBGYdO5CFmK0HvjxrtfIyQQcPdb88pSCeVQriVQPVZyDovIWblpHfOgcS8QO187j3QF0ePArH8qPhp0AU2vg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/config": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.1.tgz",
+      "integrity": "sha512-4znKhxTmXmuPye9Z6pbIyYb5VZlkZ05qG1L6Dr4g+7oTwc6V50Bs9XirFBDdjWt+H/AabMn9aUnxBcvj8z05aA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.3.4",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.20.0",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
+      "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dev": {
+      "version": "0.24.17",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.17.tgz",
+      "integrity": "sha512-UvdZzmpFwknnfreh6Jije84ekkYGPYEJhXG1tFzCsCfQyzJifrOo38eZc0qajzvaC6OLUOrN9ML5XfCnEZL9DA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "@electric-sql/pglite": "0.4.3",
+        "@electric-sql/pglite-socket": "0.1.3",
+        "@electric-sql/pglite-tools": "0.3.3",
+        "@prisma/get-platform": "7.2.0",
+        "@prisma/query-plan-executor": "7.2.0",
+        "@prisma/streams-local": "0.1.11",
+        "find-my-way": "9.7.0",
+        "foreground-child": "3.3.1",
+        "get-port-please": "3.2.0",
+        "pathe": "2.0.3",
+        "proper-lockfile": "4.1.2",
+        "remeda": "2.33.4",
+        "std-env": "3.10.0",
+        "valibot": "1.4.2",
+        "zeptomatch": "2.1.0"
+      }
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.9.1.tgz",
+      "integrity": "sha512-vmHehG7nn/heW32DXXpp13DxxAxVVe6n250oEt3dOL2E/4bt3olktKZN0mzSuxMMronyMSkbeW2uCOn3F4g8RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.9.1"
+      }
+    },
+    "node_modules/@prisma/engines": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.1.tgz",
+      "integrity": "sha512-UprXSMNXx2NF5ow4pqaQtE8OuBz6K78B0wc0tn2L28G5r933iWp1DR9Do2qWrsNvvFIP3x6mpEWnQtckMO0Uhg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.9.1",
+        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+        "@prisma/fetch-engine": "7.9.1",
+        "@prisma/get-platform": "7.9.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
+      "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
+      "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.9.1"
+      }
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.1.tgz",
+      "integrity": "sha512-9DwxrNTeT25Orbu9CWh0CZvVlyY1lmscpbaeLZcOnuR7zcuFrt91YSmmOfIm7zJ08YOZ6mVzURKwLoMwEBcK8w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.9.1",
+        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+        "@prisma/get-platform": "7.9.1"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
+      "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.9.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
+      "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.2.0"
+      }
+    },
+    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
+      "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/query-plan-executor": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
+      "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/streams-local": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.11.tgz",
+      "integrity": "sha512-0TcebL559MByKqTJ+SsrFIEg228iw8UCVRFckzgfRSiJqczhs+MuAgWOF9lnOIV/IVqvu+KMnFTH0eDeTQMpUg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "better-result": "^2.7.0",
+        "env-paths": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
+      },
+      "engines": {
+        "bun": ">=1.2.0",
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@prisma/studio-core": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.33.0.tgz",
+      "integrity": "sha512-V2fX/nKEymNTrHXwfP26PGjoLStO35Ogu+ex7CFJbLrMYEcZxxZpiSNOs7px23Hk5mzLWvM5RsqG6Ka+rha+wg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@radix-ui/react-toggle": "1.1.10",
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/event": "4.0.1-alpha.0",
+        "@visx/grid": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/responsive": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/shape": "4.0.1-alpha.0",
+        "d3-array": "3.2.4",
+        "d3-shape": "3.2.0",
+        "elkjs": "0.11.1"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0",
+        "pnpm": "8"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
+      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+      "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@visx/curve": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@visx/vendor": "4.0.0-alpha.0"
+      }
+    },
+    "node_modules/@visx/event": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/event/-/event-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/point": "4.0.1-alpha.0"
+      }
+    },
+    "node_modules/@visx/grid": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/point": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/shape": "4.0.1-alpha.0",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/group": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/group/-/group-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/point": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/point/-/point-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@visx/responsive": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/responsive/-/responsive-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.17.13",
+        "@types/react": "*",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/scale": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@visx/vendor": "4.0.0-alpha.0"
+      }
+    },
+    "node_modules/@visx/shape": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.17.13",
+        "@types/react": "*",
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/vendor": "4.0.0-alpha.0",
+        "classnames": "^2.3.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/vendor": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==",
+      "devOptional": true,
+      "license": "MIT and ISC",
+      "dependencies": {
+        "@types/d3-array": "3.0.3",
+        "@types/d3-color": "3.1.0",
+        "@types/d3-delaunay": "6.0.1",
+        "@types/d3-format": "3.0.1",
+        "@types/d3-geo": "3.1.0",
+        "@types/d3-interpolate": "3.0.1",
+        "@types/d3-path": "3.1.1",
+        "@types/d3-scale": "4.0.2",
+        "@types/d3-shape": "3.1.7",
+        "@types/d3-time": "3.0.0",
+        "@types/d3-time-format": "2.1.0",
+        "d3-array": "3.2.1",
+        "d3-color": "3.1.0",
+        "d3-delaunay": "6.0.2",
+        "d3-format": "3.1.0",
+        "d3-geo": "3.1.0",
+        "d3-interpolate": "3.0.1",
+        "d3-path": "3.1.0",
+        "d3-scale": "4.0.2",
+        "d3-shape": "3.2.0",
+        "d3-time": "3.1.0",
+        "d3-time-format": "4.1.0",
+        "internmap": "2.0.3"
+      }
+    },
+    "node_modules/@visx/vendor/node_modules/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-result": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.10.0.tgz",
+      "integrity": "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
+      },
+      "peerDependencies": {
+        "magicast": "*"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
+      "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "devOptional": true,
+      "license": "EPL-2.0"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/find-my-way": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/giget": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/grammex": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.13.tgz",
+      "integrity": "sha512-LnPnhOBLEJEVKS8WFDVaA397L9Kq55Q9oSITJiVLHVdhAclfUkWzQv74KhvZHKL2Q09Pb1XdsrOsZ4LfTFFTEg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/graphmatch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
+      "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
+      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "devOptional": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.1.tgz",
+      "integrity": "sha512-aPqePoZIqwlAchbgbFDO/wHqGB+7H1nj9gaM+OsL9h77S5S3TnLd9BgD3LnoeDikULo7cl2HSUrEyQ55Z7DYbg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "7.9.1",
+        "@prisma/dev": "0.24.17",
+        "@prisma/engines": "7.9.1",
+        "@prisma/studio-core": "0.33.0",
+        "mysql2": "3.15.3",
+        "postgres": "3.4.7"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "better-sqlite3": ">=9.0.0",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc9": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/remeda": {
+      "version": "2.33.4",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
+      "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "devOptional": true,
+      "license": "Unlicense"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
+      "devOptional": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zeptomatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
+      "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "grammex": "^3.1.11",
+        "graphmatch": "^1.1.0"
+      }
+    }
+  }
+}

--- a/prisma/example/package.json
+++ b/prisma/example/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cerbos-orm-prisma-example",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example application for @cerbos/orm-prisma, run against the shared demo domain",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsc --build",
+    "start": "node lib/main.js"
+  },
+  "//": "@cerbos/orm-prisma is deliberately ABSENT from these dependencies. run.sh installs it from `npm pack`'s tarball, whose integrity hash changes on every build and would make a committed lockfile unusable with `npm ci`. The ORM and the SDK ARE pinned here, which is the half Renovate manages: an ORM bump lands as one PR touching both prisma/package.json and this file, and the example job on that PR is what blocks automerge if the new ORM broke real usage.",
+  "dependencies": {
+    "@cerbos/grpc": "^0.28.0",
+    "@prisma/adapter-better-sqlite3": "^7.5.0",
+    "@prisma/client": "^7.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "prisma": "^7.5.0",
+    "typescript": "^6.0.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/prisma/example/prisma.config.ts
+++ b/prisma/example/prisma.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  datasource: {
+    url: "file:./prisma/demo.db",
+  },
+});

--- a/prisma/example/prisma/schema.prisma
+++ b/prisma/example/prisma/schema.prisma
@@ -1,0 +1,22 @@
+// The demo domain's single resource kind, as a consumer would model it: flat scalar columns and
+// no relations. The richer schemas the adapter is PROVED against live in ../../prisma/.
+generator client {
+  provider     = "prisma-client"
+  output       = "../src/generated/prisma"
+  engineType   = "client"
+  moduleFormat = "cjs"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+model Document {
+  id      String  @id
+  ownerId String
+  public  Boolean
+  region  String
+  // Never referenced by policy. `archived` and `region` are the application's own columns, and
+  // ANDing them with the adapter's filter is usage shape 5.
+  archived Boolean
+}

--- a/prisma/example/run.sh
+++ b/prisma/example/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# The prisma half of `demo/scripts/run-example.sh prisma`: pack the adapter, install THAT, build
+# the example against it, run it. The PDP is already up and reachable at $CERBOS_HOST — the
+# shared runner owns it.
+#
+# Everything this script prints for a human goes to stderr. stdout carries exactly one JSON
+# document, which the shared runner diffs against demo/expected.json.
+
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_DIR="$(cd "${EXAMPLE_DIR}/.." && pwd)"
+
+cd "${EXAMPLE_DIR}"
+rm -f cerbos-orm-prisma-*.tgz
+
+# 1. Build and pack the adapter into the artifact npm would publish.
+echo "==> packing @cerbos/orm-prisma" >&2
+(cd "${ADAPTER_DIR}" && npm run build) >&2
+TARBALL="$(cd "${ADAPTER_DIR}" && npm pack --silent --pack-destination "${EXAMPLE_DIR}")"
+echo "==> packed ${TARBALL}" >&2
+
+# 2. Install the example's own pinned tree from the committed lockfile, then the tarball on top.
+#
+# The tarball is NOT a package.json dependency and NOT in the lockfile: its integrity hash changes
+# on every build, which would make `npm ci` fail on a lockfile that was correct when committed.
+# `--no-save --no-package-lock` keeps both files exactly as committed while still resolving the
+# adapter — and its peer range against this example's @prisma/client — the way a consumer's
+# install would.
+echo "==> npm ci" >&2
+npm ci >&2
+echo "==> installing the packed adapter" >&2
+npm install --no-save --no-package-lock "./${TARBALL}" >&2
+
+# 3. Generate the Prisma client and create the SQLite file the example seeds into.
+#
+# The database file is scratch state this example owns and .gitignore excludes, so each run starts
+# from nothing by deleting it. That is deliberately not `db push --force-reset`: a reset is a
+# destructive operation against whatever database the config happens to name, and this needs no
+# such power — the file is ours and it is one `rm` away from clean.
+echo "==> prisma generate && db push" >&2
+rm -f prisma/demo.db prisma/demo.db-journal
+npx prisma generate >&2
+npx prisma db push >&2
+
+# 4. Compile. This is half of the packaging proof: `moduleResolution: nodenext` reads the
+#    adapter's `exports` map, so a broken one fails HERE rather than shipping to a consumer.
+echo "==> tsc" >&2
+npm run build >&2
+
+# 5. Run. stdout is the JSON document and nothing else.
+echo "==> node lib/main.js" >&2
+node lib/main.js

--- a/prisma/example/src/main.ts
+++ b/prisma/example/src/main.ts
@@ -1,0 +1,252 @@
+/**
+ * Example application for `@cerbos/orm-prisma`, run against the shared demo domain.
+ *
+ * This is NOT a test of what the adapter translates — `../src/adversarial.test.ts` proves that
+ * against a hostile corpus and a live PDP oracle. This proves the two things that harness
+ * structurally cannot:
+ *
+ *   1. Packaging. The import below resolves through the PUBLISHED package — `exports`, `types`,
+ *      the `files` allowlist, the peer range — because run.sh installs `npm pack`'s tarball
+ *      rather than linking the source directory. The harness imports from `"."` and touches
+ *      none of it. See docs/adr/0002-examples-install-the-packed-artifact.md.
+ *   2. Usage shape. A harness runs one flat filtered query. Consumers also paginate, and compose
+ *      the adapter's filter with predicates of their own. Shape 5 below is the one that earns
+ *      the exercise.
+ *
+ * Prints one JSON document to stdout; everything a human might want to read goes to stderr.
+ * demo/scripts/run-example.sh diffs that document against demo/expected.json.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { GRPC as Cerbos } from "@cerbos/grpc";
+import type { PlanResourcesResponse } from "@cerbos/core";
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import {
+  PlanKind,
+  queryPlanToPrisma,
+  type Mapper,
+  type QueryPlanToPrismaResult,
+} from "@cerbos/orm-prisma";
+
+import { PrismaClient, type Prisma } from "./generated/prisma/client";
+
+const DEMO_DIR = resolve(__dirname, "../../../demo");
+const RESOURCE_KIND = "document";
+
+interface Seeds {
+  principals: { id: string; roles: string[] }[];
+  applicationFilter: { description: string; archived: boolean; region: string };
+  documents: {
+    id: string;
+    ownerId: string;
+    public: boolean;
+    region: string;
+    archived: boolean;
+  }[];
+}
+
+// demo/seeds.json is a repository-controlled corpus file, checked structurally by
+// demo/scripts/validate-demo.sh before this ever runs — not untrusted input.
+const seeds = JSON.parse(
+  readFileSync(resolve(DEMO_DIR, "seeds.json"), "utf8")
+) as Seeds;
+
+/**
+ * Cerbos attribute names are not column names, so a consumer always writes one of these. Without
+ * it the adapter emits `request.resource.attr.ownerId` as a literal Prisma field and the query
+ * fails — which is itself worth seeing in an example.
+ */
+const MAPPER: Mapper = {
+  "request.resource.attr.ownerId": { field: "ownerId" },
+  "request.resource.attr.public": { field: "public" },
+};
+
+/** The application's OWN predicate. Never expressed in policy; declared in demo/seeds.json. */
+const APPLICATION_FILTER = {
+  archived: seeds.applicationFilter.archived,
+  region: seeds.applicationFilter.region,
+} satisfies Prisma.DocumentWhereInput;
+
+const prisma = new PrismaClient({
+  adapter: new PrismaBetterSqlite3({ url: "file:./prisma/demo.db" }),
+});
+const cerbos = new Cerbos(process.env["CERBOS_HOST"] ?? "localhost:3593", {
+  tls: false,
+});
+
+function principal(id: string): { id: string; roles: string[] } {
+  const found = seeds.principals.find((p) => p.id === id);
+  if (!found) throw new Error(`demo/seeds.json declares no principal '${id}'`);
+  return found;
+}
+
+async function plan(
+  principalId: string,
+  action: string
+): Promise<PlanResourcesResponse> {
+  return cerbos.planResources({
+    principal: principal(principalId),
+    resource: { kind: RESOURCE_KIND },
+    action,
+  });
+}
+
+/**
+ * What a consumer actually writes at the call site. `ALWAYS_DENIED` short-circuits rather than
+ * building an impossible `where`, and `ALWAYS_ALLOWED` contributes no predicate at all — which
+ * is exactly why composing it with an application filter (shape 5) is the case that breaks
+ * first.
+ */
+type Where = Prisma.DocumentWhereInput | "denied";
+
+function toWhere(result: QueryPlanToPrismaResult): Where {
+  switch (result.kind) {
+    case PlanKind.ALWAYS_DENIED:
+      return "denied";
+    case PlanKind.ALWAYS_ALLOWED:
+      return {};
+    case PlanKind.CONDITIONAL:
+      return result.filters;
+  }
+}
+
+async function findIds(where: Where): Promise<string[]> {
+  if (where === "denied") return [];
+  const rows = await prisma.document.findMany({
+    where,
+    select: { id: true },
+  });
+  return rows.map((r) => r.id).sort();
+}
+
+interface ShapeResult {
+  kind: PlanKind;
+  ids: string[];
+}
+
+interface PaginatedShapeResult extends ShapeResult {
+  pageSize: number;
+  pageSizes: number[];
+}
+
+// ---------------------------------------------------------------------------------------------
+// The five usage shapes
+// ---------------------------------------------------------------------------------------------
+
+/** Shape 1: a plain filtered list. The adapter's filter is the whole query. */
+async function filtered(
+  principalId: string,
+  action: string
+): Promise<ShapeResult> {
+  const queryPlan = await plan(principalId, action);
+  const result = queryPlanToPrisma({ queryPlan, mapper: MAPPER });
+  return { kind: result.kind, ids: await findIds(toWhere(result)) };
+}
+
+/**
+ * Shape 4: pagination applied on top of the filter. Reported as page SIZES plus the sorted union
+ * of the ids, never as per-page order — demo/expected.json is shared by ten stores and several
+ * of them have no total order to paginate by.
+ */
+async function paginated(
+  principalId: string,
+  action: string,
+  pageSize: number
+): Promise<PaginatedShapeResult> {
+  const queryPlan = await plan(principalId, action);
+  const result = queryPlanToPrisma({ queryPlan, mapper: MAPPER });
+  const where = toWhere(result);
+
+  const pageSizes: number[] = [];
+  const ids: string[] = [];
+  if (where !== "denied") {
+    for (let skip = 0; ; skip += pageSize) {
+      const page = await prisma.document.findMany({
+        where,
+        select: { id: true },
+        // Required for the paging itself to be correct, not for the assertion: without a total
+        // order, `skip`/`take` may repeat or omit rows between pages. The assertion below stays
+        // order-independent regardless — those are separate concerns.
+        orderBy: { id: "asc" },
+        skip,
+        take: pageSize,
+      });
+      if (page.length === 0) break;
+      pageSizes.push(page.length);
+      ids.push(...page.map((r) => r.id));
+      if (page.length < pageSize) break;
+    }
+  }
+
+  return { kind: result.kind, pageSize, pageSizes, ids: ids.sort() };
+}
+
+/**
+ * Shape 5: the adapter's filter ANDed with the application's own predicate. All three plan kinds
+ * go through here on purpose — an `ALWAYS_ALLOWED` plan has no filter to AND with, and an
+ * `ALWAYS_DENIED` one must not have its denial undone by the application's predicate.
+ */
+async function composed(
+  principalId: string,
+  action: string
+): Promise<ShapeResult> {
+  const queryPlan = await plan(principalId, action);
+  const result = queryPlanToPrisma({ queryPlan, mapper: MAPPER });
+  const where = toWhere(result);
+  if (where === "denied") {
+    return { kind: result.kind, ids: [] };
+  }
+  return {
+    kind: result.kind,
+    ids: await findIds({ AND: [where, APPLICATION_FILTER] }),
+  };
+}
+
+async function seed(): Promise<void> {
+  await prisma.document.deleteMany({});
+  await prisma.document.createMany({ data: seeds.documents });
+}
+
+async function main(): Promise<void> {
+  await seed();
+  console.error(`seeded ${seeds.documents.length} documents`);
+
+  const shapes = {
+    filtered: {
+      "alice/view": await filtered("alice", "view"),
+      "bob/view": await filtered("bob", "view"),
+    },
+    alwaysAllowed: {
+      "admin/admin-view": await filtered("admin", "admin-view"),
+    },
+    alwaysDenied: {
+      "alice/publish": await filtered("alice", "publish"),
+    },
+    paginated: {
+      "alice/view": await paginated("alice", "view", 2),
+      "admin/admin-view": await paginated("admin", "admin-view", 3),
+    },
+    composed: {
+      "alice/view": await composed("alice", "view"),
+      "bob/view": await composed("bob", "view"),
+      "admin/admin-view": await composed("admin", "admin-view"),
+      "alice/publish": await composed("alice", "publish"),
+    },
+  };
+
+  process.stdout.write(
+    `${JSON.stringify({ adapter: "prisma", shapes }, null, 2)}\n`
+  );
+}
+
+void (async () => {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+})();

--- a/prisma/example/tsconfig.json
+++ b/prisma/example/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  // `nodenext` resolution is load-bearing, not a style choice: it is what makes TypeScript read
+  // the adapter's `exports` map. The legacy `node10` resolver ignores `exports` entirely and
+  // falls back to `main`/`types`, so a broken `exports` map would compile clean here and only
+  // fail for a consumer.
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Part of #349. Closes #350.

Foundation PR for the example-application epic. Establishes the demo domain, the shared runner, the validator, and one reference example; every other child of #349 copies the pattern this lands.

## Why

Every conformance harness imports its adapter from source (`from "."`), so the published surface — `exports` maps, type declarations, `files` allowlists, peer ranges, POM scopes — is executed nowhere. And a harness only ever runs one flat filtered query, while consumers also paginate and compose the adapter's filter with predicates of their own.

Neither gap is closable from inside a harness, because both are properties of how the harness is built. `demo/` is the second shared corpus that closes them: it proves **plumbing** where `conformance/` proves **semantics** — realistic shapes, and no per-adapter classification at all ([ADR 0001](https://github.com/cerbos/query-plan-adapters/blob/main/docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md)).

## What changed

**`demo/`** — one resource kind (`document`), four flat scalar attributes, eight rows across three owners. `view` is conditional, `admin-view` unconditional, and `publish` is absent from the policy so the planner denies it. One shared `expected.json` for all ten examples: per-adapter expectation files would be ten files meant to stay identical, and the first divergence gets read as an adapter quirk instead of a bug.

**`demo/scripts/run-example.sh <adapter>`** — starts the pinned PDP, invokes `<adapter>/example/run.sh`, diffs its stdout. Everything language-independent lives in the runner; the pack→install→run half lives in each example, so the shared runner never becomes a ten-way language switch.

**`demo/scripts/validate-demo.sh`** — the answer to hardcoded expectations rotting. Four checks: structural five-shape, non-degeneracy, PDP-pin reuse, and every-adapter-has-an-example (landed **disabled**; enabling it is #360's job, and it reads the `adapters` roster already in `conformance/actions.json` rather than adding a second list).

The interesting one is shape 5. It recomputes the composed answer from shape 1 plus the seeds, and rejects it if it equals *either* filter alone:

- equal to the adapter's filter → the example could drop the application predicate and still pass
- equal to the application predicate's own result → the example could drop **the adapter** and still pass, which is an authorization hole that reads as a green build

**`prisma/example/`** — the reference implementation, installing the packed artifact per [ADR 0002](https://github.com/cerbos/query-plan-adapters/blob/main/docs/adr/0002-examples-install-the-packed-artifact.md).

**CI** — one `example` job added to `.github/workflows/prisma.yaml`, one Node leg, path-gated on `prisma/**` plus `demo/**`.

## The acceptance criterion, checked

#350 asked for the packaging claim to be falsified rather than assumed. Both halves of the published surface were broken deliberately:

| Break | Example | `npm test` | `npm run test:adversarial` |
| --- | --- | --- | --- |
| `exports["."]` points at a missing file | fails (TS2307) | 223 passing | 162 passing |
| `lib/**/*.js` dropped from `files` | fails (MODULE_NOT_FOUND) | 223 passing | 162 passing |

That gap between the columns is the entire reason the example exists. `tsconfig.json` sets `moduleResolution: "nodenext"` specifically for the first row — the legacy `node10` resolver ignores `exports` and falls back to `main`/`types`, so a broken map would compile clean and only fail for a consumer.

Also confirmed, rather than assumed:

- `example/` stays out of the published tarball (`npm pack --dry-run`: 79 files, none matching `example`) — #350 asked for this to be confirmed rather than taken on trust from the `files` allowlist.
- The adapter builds with **no** generated Prisma client, which the `example` job depends on since it never runs `prisma:generate`.

## Two judgment calls a reviewer should weigh

**Pagination is asserted by page sizes plus the sorted union, never per-page order.** Several of the ten stores have no total order to paginate by, and an order-dependent assertion would need exactly the per-adapter carve-out ADR 0001 rules out. Disjointness still falls out: overlapping pages would shrink the union below the sum of the sizes. The example still issues a real `orderBy` — that is required for the paging itself to be correct, which is a separate concern from the assertion.

**The demo PDP publishes on 13592/13593, not the Cerbos defaults.** Those are the ports every adapter's `cerbos run` test sidecar binds, and a lingering demo container makes that sidecar fail to bind while the suite silently talks to demo policies instead. I hit one unreproducible adversarial-suite failure mid-session that this would explain; it did not recur across five subsequent runs, so I can't attribute it with confidence, but the collision is real either way.

## Why the CI placement is load-bearing

`renovate.json` sets `automerge: true` for every non-major bump, and that is the path an ORM regression takes into `main` today. The example's lockfile is committed and Renovate manages it, so a Prisma bump arrives as one PR touching both `prisma/package.json` and `prisma/example/package.json` — and the `example` job, being a check on that PR, is what blocks the automerge when the new ORM breaks real usage. Moving it to a nightly or a separate workflow silently restores the gap. There is a comment on the job saying so.

Related: `@cerbos/orm-prisma` is deliberately **not** in the example's `package.json`. `npm pack`'s tarball gets a fresh integrity hash on every build, so a committed lockfile naming it would break `npm ci`. `run.sh` runs `npm ci` for the pinned tree, then installs the tarball on top with `--no-save --no-package-lock`.

## Verification

- `demo/scripts/run-example.sh prisma` — passes; matched `expected.json` across all five shapes
- `demo/scripts/validate-demo.sh` — passes; 15 deliberate mutations of `expected.json` and the policy each caught by the intended check
- `conformance/scripts/validate-corpus.sh` — `Corpus valid: 152 actions, 20 seeds` (it scans the whole repo, so it also holds the new compose file to the pin)
- `npm run typecheck` (v6 + v7), `npm test` (223), `npm run test:adversarial` (162) — all green, unmodified

Reviewers reproducing locally need `docker` (with compose) and `jq`; the PDP comes from `demo/docker-compose.yml`, pinned to `conformance/CERBOS_VERSION` and `CERBOS_IMAGE_DIGEST` with no pin of its own.

## Not in scope

Per #349's explicit non-goals: this does not prove the declared `^5 || ^6 || ^7` peer range (it runs one of the three; widening the harness matrix is the fix), and it does not make the example an onboarding artifact — `spring-data/example/` keeps that role under the floor/ceiling rule.

`demo/**` is wired only into the prisma workflow, since prisma is the only adapter with an example; each child issue adds its own. The `.github/workflows/spring-data.yaml` comment that overstates its `example` job is corrected by #359, not here.
