### PR TITLE
feat(drizzle): example application, and two fixes to the prisma example it inherited from

### DIFF
--- a/.github/workflows/drizzle.yaml
+++ b/.github/workflows/drizzle.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "drizzle/**"
       - "conformance/**"
+      - "demo/**"
       - "policies/**"
       - ".github/workflows/drizzle.yaml"
       - ".github/workflows/drizzle-publish.yaml"
@@ -66,3 +67,46 @@ jobs:
       - name: Run adversarial differential suite (PostgreSQL)
         if: matrix.node-version == '22'
         run: npm run test:adversarial:postgres
+
+  # The example application: the published package, installed from `npm pack`'s tarball and used
+  # the way a consumer uses it, against the shared demo domain. It covers the two things the
+  # suites above structurally cannot — the packaging surface (`exports`, `types`, the `files`
+  # allowlist, the peer range), which every harness bypasses by importing from `"."`, and the
+  # usage shapes past a single flat query (pagination, and composing the adapter's filter with
+  # the application's own). See cerbos/query-plan-adapters#349 and
+  # docs/adr/0002-examples-install-the-packed-artifact.md.
+  #
+  # THIS JOB MUST STAY IN THIS WORKFLOW. `renovate.json` sets `automerge: true` for every
+  # non-major bump, and that is the path an ORM regression takes into `main` today. Because the
+  # example's lockfile is committed and Renovate manages it, a Drizzle bump arrives as ONE PR
+  # touching both drizzle/package.json and drizzle/example/package.json — and this job, being a
+  # check on that PR, is what blocks the automerge when the new ORM breaks real usage. Moving it
+  # to a nightly run or a workflow of its own silently restores that gap.
+  #
+  # One Node leg only: the demo domain discriminates the package and the ORM, not the runtime —
+  # the same reasoning that gates the adversarial steps above to Node 22. SQLite only, for the
+  # matching reason: the PostgreSQL leg exists to discriminate collation, LIKE escaping and
+  # parameter typing, which are semantics the corpus already covers, and this proves plumbing.
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate conformance corpus
+        run: ../conformance/scripts/validate-corpus.sh
+
+      - name: Validate demo domain
+        run: ../demo/scripts/validate-demo.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - run: npm install
+
+      # The PDP is a container started by the runner from demo/docker-compose.yml, pinned to
+      # conformance/CERBOS_VERSION and conformance/CERBOS_IMAGE_DIGEST — no cerbos-setup-action
+      # here, because an example must reach the PDP the way a deployed application does.
+      - name: Run the example against the demo domain
+        run: ../demo/scripts/run-example.sh drizzle

--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -324,6 +324,21 @@ Those `EXISTS` expressions read the mapped table bare. If your own reads of that
 - Scalar collections stored through a relation can opt in with `collectionValueType: "scalar"` and set the relation's `field`. This enables direct membership such as `R.attr.owner in R.attr.tagNames`, including explicit `null` elements.
 - `filter`: Cerbos uses `filter` during plan construction. The adapter discards those lambdas because the entire filter is rerun in Drizzle land.
 
+## Example application
+
+This repository carries a runnable [`example/`](example/), which installs the adapter from the
+artifact `npm publish` would upload and exercises it against a live PDP over the shared
+[demo domain](../demo/README.md):
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh drizzle
+```
+
+Unlike the test suites, it resolves the adapter through its **published** surface — the `exports`
+map, `types`, the `files` allowlist, and the peer range — and covers usage shapes past a single
+flat query: pagination, and the adapter's filter composed with an application-owned filter.
+
 ## Testing
 
 The project ships with a comprehensive test suite that exercises all supported operators using an in-memory SQLite database and the official Drizzle ORM query builder.

--- a/drizzle/example/.gitignore
+++ b/drizzle/example/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+lib
+tsconfig.tsbuildinfo
+demo.db
+demo.db-journal
+# The adapter tarball `run.sh` builds and installs. Regenerated on every run; never committed.
+cerbos-orm-drizzle-*.tgz

--- a/drizzle/example/README.md
+++ b/drizzle/example/README.md
@@ -1,0 +1,124 @@
+# `@cerbos/orm-drizzle` example application
+
+A runnable program that installs the adapter **as a published package** and uses it the way a
+consumer would, against the shared [demo domain](../../demo/README.md).
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh drizzle
+```
+
+Needs `docker` (with compose), `jq` and Node 22+. The runner starts the pinned Cerbos PDP; this
+directory's `run.sh` packs the adapter, installs the tarball, builds, and runs.
+
+It follows [`prisma/example/`](../../prisma/example/), which is the reference implementation.
+
+## What it proves
+
+Not what the adapter translates — [`../src/adversarial.test.ts`](../src/adversarial.test.ts)
+proves that against a hostile corpus with a live PDP as the oracle, on SQLite and on PostgreSQL.
+This proves the two things that harness structurally cannot:
+
+**Packaging.** `run.sh` builds the artifact `npm publish` would upload and installs *that*, so the
+import in [`src/main.ts`](src/main.ts) resolves through the published surface — the `exports` map,
+`types`, the `files` allowlist, and the peer range against this example's own `drizzle-orm`. The
+harness imports from `"."` and touches none of it. See
+[ADR 0002](../../docs/adr/0002-examples-install-the-packed-artifact.md).
+
+Both halves are load-bearing and both have been checked by breaking them:
+
+| Break                                   | Example                  | `npm test`  | `npm run test:adversarial` |
+| --------------------------------------- | ------------------------ | ----------- | -------------------------- |
+| `exports["."]` points at a missing file  | fails (TS2307)           | 135 passing | 159 passing                |
+| `lib/**/*.js` dropped from `files`       | fails (MODULE_NOT_FOUND) | 135 passing | 159 passing                |
+
+`tsconfig.json` sets `moduleResolution: "nodenext"` for the first row specifically: the legacy
+`node10` resolver ignores `exports` entirely and falls back to `main`/`types`, so a broken
+`exports` map would compile clean here and only fail for a consumer.
+
+`run.sh` deletes `lib/` and `tsconfig.tsbuildinfo` before compiling for the same row. `tsc --build`
+is incremental and keys its state on this example's own sources, which do not change when the
+adapter's packaging does — so on a warm tree that first break compiles clean and reaches the
+second row's runtime error instead. CI is always cold; the tree where someone checks the break by
+hand is not.
+
+**Usage shape.** A harness runs one flat filtered query. This runs all
+[five shapes](../../demo/README.md#the-five-usage-shapes), including pagination and — the one that
+earns the exercise — the adapter's filter ANDed with the application's own predicate, across all
+three plan kinds.
+
+## Layout
+
+| Path                | What it is                                                                     |
+| ------------------- | ------------------------------------------------------------------------------ |
+| `run.sh`            | pack → install → compile cold → run. Prints the JSON document on stdout.        |
+| `src/main.ts`       | The example itself: one function per usage shape.                              |
+| `src/schema.ts`     | The demo domain's one table, as a consumer would write it: flat scalar columns, no relations. Carries the `CREATE TABLE` beside the schema it has to agree with. |
+| `package.json`      | The ORM and SDK pins Renovate manages.                                         |
+| `package-lock.json` | Committed. See below.                                                          |
+
+There is no generation step and no `drizzle-kit`: a Drizzle schema is ordinary TypeScript, and one
+table's DDL is a string next to it. The SQLite file is scratch state `main.ts` deletes and
+recreates on every run — a dedicated file rather than `:memory:`, so a failing run leaves the
+seeded rows behind to inspect.
+
+## Two things that look odd and are not
+
+**`@cerbos/orm-drizzle` is not in `package.json`.** `npm pack`'s tarball gets a fresh integrity
+hash on every build, so a committed lockfile naming it would break `npm ci` the moment the adapter
+changed. `run.sh` runs `npm ci` for the pinned tree and then installs the tarball on top with
+`--no-save --no-package-lock`, which leaves both manifests exactly as committed while still
+resolving the adapter and its peers the way a consumer's install does.
+
+**The lockfile is committed anyway,** because it is what makes the CI job load-bearing.
+`renovate.json` automerges every non-major bump, so a Drizzle bump arrives as one PR touching both
+`drizzle/package.json` and this file — and the `example` job on that PR is what blocks the
+automerge when the new ORM breaks real usage. That only works while the job stays in
+[`.github/workflows/drizzle.yaml`](../../.github/workflows/drizzle.yaml); there is a comment on the
+job saying so.
+
+## The mapper
+
+Cerbos attribute names are not column names, so a consumer always writes one of these:
+
+```ts
+const MAPPER: Mapper = {
+  "request.resource.attr.ownerId": documents.ownerId,
+  "request.resource.attr.public": documents.public,
+};
+```
+
+Without it the adapter has nothing to resolve `request.resource.attr.ownerId` to and throws —
+which is itself worth seeing in an example. `src/schema.ts` names the columns `owner_id` and
+`public` while the TypeScript properties are `ownerId` and `public`, which is ordinary Drizzle and
+makes the point that a Cerbos attribute name is neither of those two things.
+
+`archived` and `region` are deliberately absent from the mapper: they are the application's
+columns, never referenced by policy, and composing them with the adapter's filter is shape 5.
+
+## `undefined` is Drizzle's word for "no predicate"
+
+The three plan kinds land on Drizzle unusually cleanly, which is worth naming because it is what
+makes shape 5 a one-liner here:
+
+```ts
+type Where = SQL | undefined | "denied";
+```
+
+`ALWAYS_ALLOWED` becomes `undefined`, which both `.where()` and `and()` already treat as "no
+predicate", so `and(where, APPLICATION_FILTER)` collapses to the application's predicate alone
+without a branch. That is also why `ALWAYS_DENIED` is a string sentinel rather than a second
+`undefined`: a denial that reached `and()` would come back out as the application's filter and
+return rows the PDP denied.
+
+## Scope
+
+This example is a JSON-printing CLI, not an onboarding artifact — that is
+[`spring-data/example/`](../../spring-data/example/), and the floor/ceiling rule in
+[ADR 0001](../../docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md) is why both exist.
+
+It runs SQLite only. The PostgreSQL leg in
+[`../src/adversarial.test.ts`](../src/adversarial.test.ts) exists to discriminate collation, LIKE
+escaping and parameter typing — semantics, already covered there. It also does **not** prove the
+declared peer range: `@cerbos/orm-drizzle` claims `^0.44.0 || ^0.45.0` and this example installs
+0.45. Widening the harness matrix is the fix for that, and it is out of scope here.

--- a/drizzle/example/package-lock.json
+++ b/drizzle/example/package-lock.json
@@ -1,0 +1,1016 @@
+{
+  "name": "cerbos-orm-drizzle-example",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cerbos-orm-drizzle-example",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/grpc": "^0.28.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-orm": "^0.45.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.8",
+        "@types/node": "^24.0.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cerbos/api": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.10.0.tgz",
+      "integrity": "sha512-j+SCITUBsb4MFAml5okmXPAOOR1BVTSNLrsdS/h2v4lEYzNiO27t/zPx+779Fe9SzHOFwPT5bhEUgYdRnHa3UA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@cerbos/core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.32.0.tgz",
+      "integrity": "sha512-ZXL4qCDb+NwJmFJlWimQuegHOEIYKan6mZdYy2Jla126p+Esh5H9RNfHBnMQPbPEE35c5ShyS1ENa/wCCFtFMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/api": "^0.10.0",
+        "uuid": "^14.0.1"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.12.1"
+      }
+    },
+    "node_modules/@cerbos/grpc": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.28.0.tgz",
+      "integrity": "sha512-xfSmizAIYK9wmrCF6xVn94f0cEAGaKafJc+C8sPEfxKAO8suyI7fRK0ETYQ0QRihAUhq8+/i7E7oNJtddSOneg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/core": "^0.32.0",
+        "@grpc/grpc-js": "^1.14.4"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.12.1",
+        "@cerbos/api": "^0.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/drizzle/example/package.json
+++ b/drizzle/example/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cerbos-orm-drizzle-example",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example application for @cerbos/orm-drizzle, run against the shared demo domain",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsc --build",
+    "start": "node lib/main.js"
+  },
+  "//": "@cerbos/orm-drizzle is deliberately ABSENT from these dependencies. run.sh installs it from `npm pack`'s tarball, whose integrity hash changes on every build and would make a committed lockfile unusable with `npm ci`. The ORM and the SDK ARE pinned here, which is the half Renovate manages: an ORM bump lands as one PR touching both drizzle/package.json and this file, and the example job on that PR is what blocks automerge if the new ORM broke real usage.",
+  "dependencies": {
+    "@cerbos/grpc": "^0.28.0",
+    "better-sqlite3": "^12.0.0",
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.8",
+    "@types/node": "^24.0.0",
+    "typescript": "^6.0.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/drizzle/example/run.sh
+++ b/drizzle/example/run.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# The drizzle half of `demo/scripts/run-example.sh drizzle`: pack the adapter, install THAT, build
+# the example against it, run it. The PDP is already up and reachable at $CERBOS_HOST — the
+# shared runner owns it.
+#
+# Everything this script prints for a human goes to stderr. stdout carries exactly one JSON
+# document, which the shared runner diffs against demo/expected.json.
+
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_DIR="$(cd "${EXAMPLE_DIR}/.." && pwd)"
+
+cd "${EXAMPLE_DIR}"
+rm -f cerbos-orm-drizzle-*.tgz
+
+# 1. Build and pack the adapter into the artifact npm would publish.
+echo "==> packing @cerbos/orm-drizzle" >&2
+(cd "${ADAPTER_DIR}" && npm run build) >&2
+TARBALL="$(cd "${ADAPTER_DIR}" && npm pack --silent --pack-destination "${EXAMPLE_DIR}")"
+echo "==> packed ${TARBALL}" >&2
+
+# 2. Install the example's own pinned tree from the committed lockfile, then the tarball on top.
+#
+# The tarball is NOT a package.json dependency and NOT in the lockfile: its integrity hash changes
+# on every build, which would make `npm ci` fail on a lockfile that was correct when committed.
+# `--no-save --no-package-lock` keeps both files exactly as committed while still resolving the
+# adapter — and its peer range against this example's drizzle-orm — the way a consumer's install
+# would.
+echo "==> npm ci" >&2
+npm ci >&2
+echo "==> installing the packed adapter" >&2
+npm install --no-save --no-package-lock "./${TARBALL}" >&2
+
+# 3. Compile, from cold. This is half of the packaging proof: `moduleResolution: nodenext` reads
+#    the adapter's `exports` map, so a broken one fails HERE rather than shipping to a consumer.
+#
+#    `tsc --build` is incremental, and the state it reuses is keyed on this example's own sources
+#    — which do not change when the adapter's packaging does. A warm lib/ and tsconfig.tsbuildinfo
+#    therefore let a broken `exports` map compile clean, which is the exact break this step
+#    exists to catch. CI is always cold; a developer's tree is not, and it is the tree where
+#    someone checks the break by hand.
+#
+#    There is no schema-generation step to run first, unlike the Prisma example: a Drizzle schema
+#    is ordinary TypeScript, and src/schema.ts carries the one CREATE TABLE beside it. The SQLite
+#    file itself is scratch state main.ts deletes and recreates on every run.
+echo "==> tsc" >&2
+rm -rf lib tsconfig.tsbuildinfo
+npm run build >&2
+
+# 4. Run. stdout is the JSON document and nothing else.
+echo "==> node lib/main.js" >&2
+node lib/main.js

--- a/drizzle/example/src/main.ts
+++ b/drizzle/example/src/main.ts
@@ -1,0 +1,281 @@
+/**
+ * Example application for `@cerbos/orm-drizzle`, run against the shared demo domain.
+ *
+ * This is NOT a test of what the adapter translates — `../src/adversarial.test.ts` proves that
+ * against a hostile corpus and a live PDP oracle, on SQLite and on PostgreSQL. This proves the
+ * two things that harness structurally cannot:
+ *
+ *   1. Packaging. The import below resolves through the PUBLISHED package — `exports`, `types`,
+ *      the `files` allowlist, the peer range against this example's own `drizzle-orm` — because
+ *      run.sh installs `npm pack`'s tarball rather than linking the source directory. The harness
+ *      imports from `"."` and touches none of it. See
+ *      docs/adr/0002-examples-install-the-packed-artifact.md.
+ *   2. Usage shape. A harness runs one flat filtered query. Consumers also paginate, and compose
+ *      the adapter's filter with predicates of their own. Shape 5 below is the one that earns
+ *      the exercise.
+ *
+ * Prints one JSON document to stdout; everything a human might want to read goes to stderr.
+ * demo/scripts/run-example.sh diffs that document against demo/expected.json.
+ */
+import { readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { GRPC as Cerbos } from "@cerbos/grpc";
+import {
+  PlanKind,
+  queryPlanToDrizzle,
+  type Mapper,
+  type QueryPlanToDrizzleResult,
+} from "@cerbos/orm-drizzle";
+import Database from "better-sqlite3";
+import { and, asc, eq, type SQL } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+
+import { CREATE_TABLE, documents } from "./schema";
+
+const DEMO_DIR = resolve(__dirname, "../../../demo");
+const RESOURCE_KIND = "document";
+
+/**
+ * A dedicated file rather than `:memory:`, so a failing run leaves the seeded rows behind to
+ * inspect. It is scratch state this example owns and .gitignore excludes, so each run starts from
+ * nothing by deleting it — one `rm`, rather than a reset against whatever database a config
+ * happens to name.
+ */
+const DB_PATH = resolve(__dirname, "../demo.db");
+
+interface Seeds {
+  principals: { id: string; roles: string[] }[];
+  applicationFilter: { description: string; archived: boolean; region: string };
+  documents: {
+    id: string;
+    ownerId: string;
+    public: boolean;
+    region: string;
+    archived: boolean;
+  }[];
+}
+
+// demo/seeds.json is a repository-controlled corpus file, checked structurally by
+// demo/scripts/validate-demo.sh before this ever runs — not untrusted input.
+const seeds = JSON.parse(
+  readFileSync(resolve(DEMO_DIR, "seeds.json"), "utf8")
+) as Seeds;
+
+/**
+ * Cerbos attribute names are not column names, so a consumer always writes one of these. Without
+ * it the adapter has nothing to resolve `request.resource.attr.ownerId` to and throws — which is
+ * itself worth seeing in an example.
+ */
+const MAPPER: Mapper = {
+  "request.resource.attr.ownerId": documents.ownerId,
+  "request.resource.attr.public": documents.public,
+};
+
+/** The application's OWN predicate. Never expressed in policy; declared in demo/seeds.json. */
+const APPLICATION_FILTER = and(
+  eq(documents.archived, seeds.applicationFilter.archived),
+  eq(documents.region, seeds.applicationFilter.region)
+);
+
+/**
+ * The runner sets this, and there is deliberately no fallback. The obvious default — Cerbos's own
+ * 3592/3593 — is the address every adapter's `cerbos run` test sidecar binds, so an unset
+ * CERBOS_HOST would not fail: it would quietly plan against `../policies` and produce a diff
+ * against demo/expected.json that reads as an adapter bug. demo/README.md requires reaching the
+ * PDP at $CERBOS_HOST, "never a hardcoded address", for exactly that reason.
+ *
+ * Checked before anything is opened or deleted, so a misinvocation costs nothing.
+ */
+const cerbosHost = process.env["CERBOS_HOST"];
+if (!cerbosHost) {
+  throw new Error(
+    "CERBOS_HOST is not set — run this example through demo/scripts/run-example.sh drizzle"
+  );
+}
+
+rmSync(DB_PATH, { force: true });
+const sqlite = new Database(DB_PATH);
+const db = drizzle(sqlite);
+
+const cerbos = new Cerbos(cerbosHost, { tls: false });
+
+/** Exactly `PlanResourcesResponse`, without depending on a package this example never imports. */
+type QueryPlan = Awaited<ReturnType<Cerbos["planResources"]>>;
+
+function principal(id: string): { id: string; roles: string[] } {
+  const found = seeds.principals.find((p) => p.id === id);
+  if (!found) throw new Error(`demo/seeds.json declares no principal '${id}'`);
+  return found;
+}
+
+async function plan(principalId: string, action: string): Promise<QueryPlan> {
+  return cerbos.planResources({
+    principal: principal(principalId),
+    resource: { kind: RESOURCE_KIND },
+    action,
+  });
+}
+
+/**
+ * What a consumer actually writes at the call site. `ALWAYS_DENIED` short-circuits rather than
+ * building an impossible predicate, and `ALWAYS_ALLOWED` becomes `undefined` — Drizzle's own word
+ * for "no predicate", which `.where()` and `and()` both already understand. That second case is
+ * exactly why composing with an application filter (shape 5) is the one that breaks first.
+ */
+type Where = SQL | undefined | "denied";
+
+function toWhere(result: QueryPlanToDrizzleResult): Where {
+  switch (result.kind) {
+    case PlanKind.ALWAYS_DENIED:
+      return "denied";
+    case PlanKind.ALWAYS_ALLOWED:
+      return undefined;
+    case PlanKind.CONDITIONAL:
+      return result.filter;
+  }
+}
+
+function findIds(where: Where): string[] {
+  if (where === "denied") return [];
+  return db
+    .select({ id: documents.id })
+    .from(documents)
+    .where(where)
+    .all()
+    .map((row) => row.id)
+    .sort();
+}
+
+interface ShapeResult {
+  kind: PlanKind;
+  ids: string[];
+}
+
+interface PaginatedShapeResult extends ShapeResult {
+  pageSize: number;
+  pageSizes: number[];
+}
+
+// ---------------------------------------------------------------------------------------------
+// The five usage shapes
+// ---------------------------------------------------------------------------------------------
+
+/** Shape 1: a plain filtered list. The adapter's filter is the whole query. */
+async function filtered(
+  principalId: string,
+  action: string
+): Promise<ShapeResult> {
+  const queryPlan = await plan(principalId, action);
+  const result = queryPlanToDrizzle({ queryPlan, mapper: MAPPER });
+  return { kind: result.kind, ids: findIds(toWhere(result)) };
+}
+
+/**
+ * Shape 4: pagination applied on top of the filter. Reported as page SIZES plus the sorted union
+ * of the ids, never as per-page order — demo/expected.json is shared by ten stores and several
+ * of them have no total order to paginate by.
+ */
+async function paginated(
+  principalId: string,
+  action: string,
+  pageSize: number
+): Promise<PaginatedShapeResult> {
+  const queryPlan = await plan(principalId, action);
+  const result = queryPlanToDrizzle({ queryPlan, mapper: MAPPER });
+  const where = toWhere(result);
+
+  const pageSizes: number[] = [];
+  const ids: string[] = [];
+  if (where !== "denied") {
+    for (let offset = 0; ; offset += pageSize) {
+      const page = db
+        .select({ id: documents.id })
+        .from(documents)
+        .where(where)
+        // Required for the paging itself to be correct, not for the assertion: without a total
+        // order, limit/offset may repeat or omit rows between pages. The assertion below stays
+        // order-independent regardless — those are separate concerns.
+        .orderBy(asc(documents.id))
+        .limit(pageSize)
+        .offset(offset)
+        .all();
+      if (page.length === 0) break;
+      pageSizes.push(page.length);
+      ids.push(...page.map((row) => row.id));
+      if (page.length < pageSize) break;
+    }
+  }
+
+  return { kind: result.kind, pageSize, pageSizes, ids: ids.sort() };
+}
+
+/**
+ * Shape 5: the adapter's filter ANDed with the application's own predicate. All three plan kinds
+ * go through here on purpose — an `ALWAYS_ALLOWED` plan has no filter to AND with, and an
+ * `ALWAYS_DENIED` one must not have its denial undone by the application's predicate.
+ *
+ * `and(undefined, x)` collapsing to `x` is what makes the ALWAYS_ALLOWED case a one-liner here,
+ * and it is also why the sentinel above is a string rather than a second `undefined`: a denial
+ * that reached `and()` would come back out as the application's predicate alone.
+ */
+async function composed(
+  principalId: string,
+  action: string
+): Promise<ShapeResult> {
+  const queryPlan = await plan(principalId, action);
+  const result = queryPlanToDrizzle({ queryPlan, mapper: MAPPER });
+  const where = toWhere(result);
+  if (where === "denied") {
+    return { kind: result.kind, ids: [] };
+  }
+  return { kind: result.kind, ids: findIds(and(where, APPLICATION_FILTER)) };
+}
+
+function seed(): void {
+  sqlite.exec(CREATE_TABLE);
+  db.insert(documents).values(seeds.documents).run();
+}
+
+async function main(): Promise<void> {
+  seed();
+  console.error(`seeded ${seeds.documents.length} documents`);
+
+  const shapes = {
+    filtered: {
+      "alice/view": await filtered("alice", "view"),
+      "bob/view": await filtered("bob", "view"),
+    },
+    alwaysAllowed: {
+      "admin/admin-view": await filtered("admin", "admin-view"),
+    },
+    alwaysDenied: {
+      "alice/publish": await filtered("alice", "publish"),
+    },
+    paginated: {
+      "alice/view": await paginated("alice", "view", 2),
+      "admin/admin-view": await paginated("admin", "admin-view", 3),
+    },
+    composed: {
+      "alice/view": await composed("alice", "view"),
+      "bob/view": await composed("bob", "view"),
+      "admin/admin-view": await composed("admin", "admin-view"),
+      "alice/publish": await composed("alice", "publish"),
+    },
+  };
+
+  process.stdout.write(
+    `${JSON.stringify({ adapter: "drizzle", shapes }, null, 2)}\n`
+  );
+}
+
+void (async () => {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    sqlite.close();
+  }
+})();

--- a/drizzle/example/src/schema.ts
+++ b/drizzle/example/src/schema.ts
@@ -1,0 +1,35 @@
+/**
+ * The demo domain's single resource kind, as a consumer would model it: flat scalar columns and
+ * no relations. The richer schemas the adapter is PROVED against live in ../../src/.
+ *
+ * Column names are snake_case while the TypeScript properties are camelCase, which is ordinary
+ * Drizzle. It also makes the mapper in `main.ts` earn its place: a Cerbos attribute name is
+ * neither of those two things, and something has to say which column it means.
+ */
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const documents = sqliteTable("documents", {
+  id: text("id").primaryKey(),
+  ownerId: text("owner_id").notNull(),
+  public: integer("public", { mode: "boolean" }).notNull(),
+  // Never referenced by policy. `archived` and `region` are the application's own columns, and
+  // ANDing them with the adapter's filter is usage shape 5.
+  region: text("region").notNull(),
+  archived: integer("archived", { mode: "boolean" }).notNull(),
+});
+
+/**
+ * The DDL, kept beside the schema it has to agree with. A consumer would use drizzle-kit; one
+ * table does not earn the dependency, and the two cannot drift silently — `main.ts` inserts every
+ * seed row through the schema above, so a column this string renames or omits fails the run with
+ * "table documents has no column named …" before a single query is planned.
+ */
+export const CREATE_TABLE = `
+  CREATE TABLE documents (
+    id       TEXT    PRIMARY KEY,
+    owner_id TEXT    NOT NULL,
+    public   INTEGER NOT NULL,
+    region   TEXT    NOT NULL,
+    archived INTEGER NOT NULL
+  );
+`;

--- a/drizzle/example/tsconfig.json
+++ b/drizzle/example/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  // `nodenext` resolution is load-bearing, not a style choice: it is what makes TypeScript read
+  // the adapter's `exports` map. The legacy `node10` resolver ignores `exports` entirely and
+  // falls back to `main`/`types`, so a broken `exports` map would compile clean here and only
+  // fail for a consumer.
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/prisma/example/run.sh
+++ b/prisma/example/run.sh
@@ -46,7 +46,18 @@ npx prisma db push >&2
 
 # 4. Compile. This is half of the packaging proof: `moduleResolution: nodenext` reads the
 #    adapter's `exports` map, so a broken one fails HERE rather than shipping to a consumer.
+#
+#    Discard the incremental state first, because that proof is otherwise standing on a side
+#    effect. `tsc --build` decides it is up to date by comparing this project's OWN inputs —
+#    `include: ["src"]` — against its outputs. A dependency under node_modules is not an input,
+#    so repacking and reinstalling the adapter does not invalidate a warm `lib/`: with the
+#    tarball's `exports` map pointing at a missing file, `tsc --build` still exits 0 and the
+#    break surfaces later, as a MODULE_NOT_FOUND out of step 5, instead of as the TS2307 this
+#    step exists to raise. What saves the run today is that step 3 rewrites `src/generated` on
+#    every invocation, and those ARE inputs — so the recheck happens by accident, and only for
+#    as long as `prisma generate` keeps touching files. One `rm` makes it happen on purpose.
 echo "==> tsc" >&2
+rm -rf lib tsconfig.tsbuildinfo
 npm run build >&2
 
 # 5. Run. stdout is the JSON document and nothing else.

--- a/prisma/example/src/main.ts
+++ b/prisma/example/src/main.ts
@@ -20,7 +20,6 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { GRPC as Cerbos } from "@cerbos/grpc";
-import type { PlanResourcesResponse } from "@cerbos/core";
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import {
   PlanKind,
@@ -68,12 +67,30 @@ const APPLICATION_FILTER = {
   region: seeds.applicationFilter.region,
 } satisfies Prisma.DocumentWhereInput;
 
+/**
+ * The runner sets this, and there is deliberately no fallback. The obvious default — Cerbos's own
+ * 3592/3593 — is the address every adapter's `cerbos run` test sidecar binds, so an unset
+ * CERBOS_HOST would not fail: it would quietly plan against `../policies` and produce a diff
+ * against demo/expected.json that reads as an adapter bug. demo/README.md requires reaching the
+ * PDP at $CERBOS_HOST, "never a hardcoded address", for exactly that reason.
+ *
+ * Checked before anything is opened or deleted, so a misinvocation costs nothing.
+ */
+const cerbosHost = process.env["CERBOS_HOST"];
+if (!cerbosHost) {
+  throw new Error(
+    "CERBOS_HOST is not set — run this example through demo/scripts/run-example.sh prisma"
+  );
+}
+
 const prisma = new PrismaClient({
   adapter: new PrismaBetterSqlite3({ url: "file:./prisma/demo.db" }),
 });
-const cerbos = new Cerbos(process.env["CERBOS_HOST"] ?? "localhost:3593", {
-  tls: false,
-});
+
+const cerbos = new Cerbos(cerbosHost, { tls: false });
+
+/** Exactly `PlanResourcesResponse`, without depending on a package this example never imports. */
+type QueryPlan = Awaited<ReturnType<Cerbos["planResources"]>>;
 
 function principal(id: string): { id: string; roles: string[] } {
   const found = seeds.principals.find((p) => p.id === id);
@@ -84,7 +101,7 @@ function principal(id: string): { id: string; roles: string[] } {
 async function plan(
   principalId: string,
   action: string
-): Promise<PlanResourcesResponse> {
+): Promise<QueryPlan> {
   return cerbos.planResources({
     principal: principal(principalId),
     resource: { kind: RESOURCE_KIND },


### PR DESCRIPTION
Closes #351. Part of #349, following the reference example that landed in #366.

**Affected adapters: drizzle, prisma.** No adapter source changes in either — `drizzle/src/` and
`prisma/src/` are untouched, and neither translation contract changes. Everything here is
`example/` and CI.

Three commits, each self-contained:

| Commit | |
| --- | --- |
| `feat(drizzle)` | the new `drizzle/example/` and its CI job |
| `fix(prisma)` | fail when `CERBOS_HOST` is unset rather than fall back to the test sidecar |
| `fix(prisma)` | compile the example from cold, so the packaging proof stands on its own |

The two prisma fixes are here because writing the drizzle example is what surfaced them: it copied
the reference verbatim, and both bugs came with it.

## 1. The drizzle example

`drizzle/example/`: a program taking no arguments that exercises the five usage shapes against
the shared demo domain and prints the JSON document `demo/scripts/run-example.sh` diffs against
`demo/expected.json`.

```bash
demo/scripts/run-example.sh drizzle
```

It closes the two gaps `drizzle/src/adversarial.test.ts` structurally cannot, because of how that
harness is built:

- **Packaging.** The harness imports the adapter from `"."`, so the published surface — the
  `exports` map, `types`, the `files` allowlist, the peer range — is executed nowhere. `run.sh`
  installs `npm pack`'s tarball instead ([ADR 0002](docs/adr/0002-examples-install-the-packed-artifact.md)).
- **Usage shape.** The harness runs one flat filtered query. Shapes 4 and 5 — pagination on top of
  the filter, and the filter ANDed with an application-owned predicate across all three plan
  kinds — are the ones that earn the exercise.

`demo/expected.json` is untouched: [ADR 0001](docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md)
admits no per-adapter entries, and none were needed.

Both halves of the packaging proof were checked by breaking them:

| Break | Example | `npm test` | `npm run test:adversarial` |
| --- | --- | --- | --- |
| `exports["."]` points at a missing file | fails (TS2307) | 135 passing | 159 passing |
| `lib/**/*.js` dropped from `files` | fails (MODULE_NOT_FOUND) | 135 passing | 159 passing |

Neither break is caught by either suite, which is the point.

## 2. `CERBOS_HOST` had the worst possible default

`prisma/example/src/main.ts` read `process.env["CERBOS_HOST"] ?? "localhost:3593"`. That address is
the one every adapter's `cerbos run` test sidecar binds — and the reason `demo/docker-compose.yml`
publishes the demo PDP on 13592/13593 instead.

So with `CERBOS_HOST` unset the example did not fail. It planned against whatever sidecar was
listening, which is loaded with `policies/` rather than `demo/policies/`, and the resulting
mismatch against `demo/expected.json` read as an adapter bug. `demo/README.md` requires reaching
the PDP at `$CERBOS_HOST`, "never a hardcoded address", for exactly this reason.

Both examples now throw before anything is opened or deleted, so a misinvocation costs nothing.

The same commit drops `import type { PlanResourcesResponse } from "@cerbos/core"` from the prisma
example — `@cerbos/core` is not in its `package.json` and resolved only through hoisting. Deriving
the type from the client needs no extra pin, so there is nothing to drift from the adapter's own
`@cerbos/core` range.

## 3. The compile step was standing on a side effect

`run.sh`'s compile step exists to catch a broken `exports` map as a TS2307, and both READMEs
document it as doing so.

`tsc --build` decides it is up to date by comparing a project's **own** inputs — `include: ["src"]`
— against its outputs. A dependency under `node_modules` is not an input, so repacking and
reinstalling the adapter does not invalidate a warm `lib/`.

In the prisma example the recheck happened anyway, but by accident: `prisma generate` rewrites
`src/generated` on every run, and those files *are* inputs. It held only for as long as that step
kept touching them.

The drizzle example has no generation step at all, which is how this was found — a warm tree let a
deliberately broken `exports` map compile clean, and the break surfaced later as a
`MODULE_NOT_FOUND` instead of the TS2307 the step is for. Both `run.sh` files now discard `lib/`
and `tsconfig.tsbuildinfo` first, so the recheck happens on purpose.

CI is always cold, so this was never a CI hole — it was a hole in the local check a developer runs
by hand, which is the check both READMEs point at.

## CI

One `example` job added to `.github/workflows/drizzle.yaml`, one Node leg, path-gated on
`drizzle/**` plus `demo/**` (the `demo/**` trigger is new on this workflow).

The placement is load-bearing and the job carries a comment saying so: `renovate.json` automerges
non-major bumps, so a Drizzle bump arrives as one PR touching both `drizzle/package.json` and the
example's committed lockfile — and this job, being a check on that PR, is what blocks the
automerge when the new ORM breaks real usage. Moving it to a nightly or standalone workflow
silently restores the gap.

Neither adapter's `test` job is affected: both `tsconfig.typecheck.json` files scope to
`include: ["src"]` relative to the adapter root, so neither reaches `example/`.

## Scope

The drizzle example is SQLite only. The PostgreSQL leg in the adversarial suite exists to
discriminate collation, LIKE escaping and parameter typing — semantics, already covered there;
this proves plumbing.

The declared peer range (`^0.44.0 || ^0.45.0`) is still unproven: the example installs 0.45.
Widening the harness matrix is the fix, and it is out of scope per #349's non-goals.

## To reproduce locally

Needs `docker` (with compose), `jq`, Node 22+ and the Cerbos CLI.

```bash
demo/scripts/run-example.sh drizzle
demo/scripts/run-example.sh prisma
```

## Verification

- `demo/scripts/run-example.sh drizzle` — matched `demo/expected.json` across 5 usage shapes
- `demo/scripts/run-example.sh prisma` — matched across 5 usage shapes, after both fixes
- both examples, `CERBOS_HOST` unset — throw with a message naming the runner, before opening anything
- `demo/scripts/validate-demo.sh` — OK; example coverage now 2/10 adapters
- `conformance/scripts/validate-corpus.sh` — 152 actions, 20 seeds
- `drizzle`: `npm run typecheck` clean, `npm test` 135 passing, `npm run test:adversarial` 159
  passing — all unchanged from `main`

## For a reviewer

`drizzle/example/run.sh`, `tsconfig.json` and much of `src/main.ts` are near-copies of the prisma
example's, per #351 ("copy the pattern that lands there rather than inventing a second one").

That is now two TypeScript examples, and mongoose, convex and langchain-chromadb would make five.
Both bugs fixed here were copy-inherited, and the second one was invisible in the reference because
a Prisma-only step happened to mask it — which is the argument for a shared
`demo/scripts/ts-example.sh` rather than a sixth copy. #349 says to revisit after the first two
land; this is the second, so it is worth a decision there before the third.
