### PR TITLE
fix(demo): fail the build on an example that hardcodes the PDP address

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -86,10 +86,16 @@ adapter. Its `run.sh` must:
 - pack the adapter into a real distributable and install **that** (ADR 0002; Go uses `replace` and
   proves usage shapes only)
 - print exactly one JSON document to stdout, with everything else on stderr
-- reach the PDP at `$CERBOS_HOST`, which the runner sets — never a hardcoded address. The demo PDP
-  is published on `13592`/`13593` rather than the default `3592`/`3593` on purpose: those are the
-  ports every adapter's `cerbos run` test sidecar binds, and a demo PDP still holding them makes
-  that sidecar fail to bind while the suite silently talks to the demo policies instead.
+- reach the PDP at `$CERBOS_HOST`, which the runner sets — never a hardcoded address, and
+  `validate-demo.sh` fails the build on one. The demo PDP is published on `13592`/`13593` rather
+  than the default `3592`/`3593` on purpose: those are the ports every adapter's `cerbos run` test
+  sidecar binds, and a demo PDP still holding them makes that sidecar fail to bind while the suite
+  silently talks to the demo policies instead.
+
+  This is a check rather than prose because prose did not hold it: the first two examples both
+  shipped `?? "localhost:3593"`, so an unset `CERBOS_HOST` did not fail — it planned against a
+  sidecar loaded with `policies/` and the mismatch against `expected.json` read as an adapter bug
+  (cerbos/query-plan-adapters#367).
 
 The document is:
 
@@ -135,8 +141,12 @@ The rot risk is real, and `validate-demo.sh` is what answers it:
    and the example could drop the application predicate; equal to the application predicate's own
    result and the example could drop **the adapter** — an authorization hole that reads as a green
    build.
-3. **Pin reuse.** The demo domain has no `CERBOS_VERSION` of its own. One PDP pin in the
-   repository, reused, and every example reaches it.
+3. **Pin reuse and reachability.** The demo domain has no `CERBOS_VERSION` of its own. One PDP pin
+   in the repository, reused, and every example reaches it — *at `$CERBOS_HOST`*. No example may
+   name a PDP client address of its own, because the obvious one to reach for is the port the test
+   sidecar binds, and that failure is silent rather than loud. The scan is for a client address
+   specifically: `docker-compose.yml`'s `"13592:3592"` names the PDP's own listen port on the
+   container side, which is correct.
 4. **Example coverage.** Every adapter has an `example/`. **Currently disabled** — it cannot pass
    until the last child of cerbos/query-plan-adapters#349 merges, and enabling it is
    cerbos/query-plan-adapters#360's job. Run with `DEMO_REQUIRE_ALL_EXAMPLES=1` to see where it

--- a/demo/scripts/validate-demo.sh
+++ b/demo/scripts/validate-demo.sh
@@ -15,7 +15,9 @@
 #   2. Non-degeneracy: the expectations still discriminate — a proper subset somewhere, and
 #      shape 5 differing from both of the two filters it composes.
 #   3. Pin reuse: the demo domain has no PDP version of its own and every example reaches the one
-#      in conformance/.
+#      in conformance/ — at $CERBOS_HOST, never at an address of its own. That second half is
+#      not fussiness: 3592/3593 are the ports every adapter's `cerbos run` test sidecar binds,
+#      so a hardcoded default does not fail, it silently plans against the wrong policy suite.
 #   4. Every adapter has an example/ directory. Landed DISABLED — it cannot pass until the last
 #      child of cerbos/query-plan-adapters#349 merges, and turning it on is #360's job.
 
@@ -264,7 +266,7 @@ done < <(jq -r '.shapes | to_entries[] | .key as $s | .value.results | keys[] | 
 # ---------------------------------------------------------------------------------------------
 # 3. PDP pin reuse
 # ---------------------------------------------------------------------------------------------
-echo "==> [3/4] PDP pin: one pin in the repository, reused"
+echo "==> [3/4] PDP pin: one pin in the repository, reused, and reached at \$CERBOS_HOST"
 
 pinned_version="$(tr -d '[:space:]' <"${REPO_ROOT}/conformance/CERBOS_VERSION")"
 pinned_digest="$(tr -d '[:space:]' <"${REPO_ROOT}/conformance/CERBOS_IMAGE_DIGEST")"
@@ -309,6 +311,22 @@ for adapter in $(jq -r '.adapters[]' "${ACTIONS}"); do
     [[ "${ref}" == "${pinned_image}" ]] || \
       fail "${adapter}/example pins Cerbos as '${ref}', expected '${pinned_image}'"
   done < <(grep -rhoE 'ghcr\.io/cerbos/cerbos:[^@"'"'"' )]*(@sha256:[0-9a-f]{64})?' \
+    "${SOURCE_INCLUDES[@]}" "${SOURCE_EXCLUDES[@]}" "${example_dir}" 2>/dev/null || true)
+
+  # ...and must reach it at the address the runner sets, never one of its own. Both examples that
+  # existed when this check was written had shipped `?? "localhost:3593"`, which is not a harmless
+  # default: 3592/3593 are the ports every adapter's `cerbos run` test sidecar binds, and it is
+  # why demo/docker-compose.yml publishes the demo PDP on 13592/13593 instead. An unset
+  # CERBOS_HOST therefore did not fail — the example planned against a sidecar loaded with
+  # `policies/` rather than `demo/policies/`, and the mismatch against expected.json read as an
+  # adapter bug. The rule was already in demo/README.md's "What an example must do" and both
+  # examples broke it anyway, which is what makes it a check rather than prose.
+  #
+  # A CLIENT address specifically. `demo/docker-compose.yml` maps "13592:3592", and the
+  # container-side half of a port mapping is the PDP's own listen port, which is correct.
+  while IFS= read -r addr; do
+    fail "${adapter}/example hardcodes the PDP address '${addr}' — read \$CERBOS_HOST instead (demo/README.md)"
+  done < <(grep -rhoE '(localhost|127\.0\.0\.1):359[23]' \
     "${SOURCE_INCLUDES[@]}" "${SOURCE_EXCLUDES[@]}" "${example_dir}" 2>/dev/null || true)
 done
 


### PR DESCRIPTION
Follow-up to #367, which fixed two examples that had both hardcoded the PDP address. This makes the
rule they broke enforceable rather than aspirational.

**Affected: `demo/` only.** No adapter source, no example source, no CI config. `demo/` re-runs
every adapter's example job, so the two currently wired up (prisma, drizzle) both exercise this.

## Why

`demo/README.md`'s "What an example must do" already said:

> reach the PDP at `$CERBOS_HOST`, which the runner sets — never a hardcoded address

and spelled out why. Both examples that existed when this was written shipped
`?? "localhost:3593"` anyway.

That default is not harmless. 3592/3593 are the ports every adapter's `cerbos run` test sidecar
binds — which is the reason `demo/docker-compose.yml` publishes the demo PDP on 13592/13593. So an
unset `CERBOS_HOST` did not fail: the example planned against a sidecar loaded with `policies/`
rather than `demo/policies/`, and the resulting mismatch against `expected.json` read as an adapter
bug rather than a misinvocation.

Two for two is the argument for a check. Eight examples are still to be written (#349), and each
will be copied from one of these.

## What

Check 3 in `validate-demo.sh` already walks every `<adapter>/example/` to assert the Cerbos image
pin agrees. It now also rejects a PDP **client** address, reusing the same file set — so the scan
skips `node_modules`, build output and prose, exactly as the pin scan does.

Scoped to `localhost:359[23]` and `127.0.0.1:359[23]`. The container side of a compose port mapping
is the PDP's own listen port and is correct, so `demo/docker-compose.yml`'s `"13592:3592"` must not
trip it — a naive `:3592` grep would.

## What it deliberately does not do

It does not reject an example that **binds** 3592/3593 on the host.
`spring-data/example/docker-compose.yml` does exactly that today, and it is a genuine collision with
every adapter's test sidecar — but that example predates the demo domain and joins it in #359, so a
check that fails the build before anyone can act on it would just have to be reverted. Noted on
#359 instead: https://github.com/cerbos/query-plan-adapters/issues/359#issuecomment-5242709484

A behavioural check — invoke `run.sh` with `CERBOS_HOST` unset and require a non-zero exit — was
considered and rejected. It is the real contract rather than a proxy, but `run.sh` packs, installs
and builds, so a second invocation roughly doubles every example job across ten adapters. The
static check enforces the same rule at its source for nothing.

## Verification

Both directions, which is the point of a check like this:

- passes on the current tree (prisma, drizzle, spring-data all clean)
- reintroducing `?? "localhost:3593"` into `drizzle/example/src/main.ts` fails it with
  `✗ drizzle/example hardcodes the PDP address 'localhost:3593' — read $CERBOS_HOST instead`

`demo/README.md` updated in the same commit: the "What an example must do" bullet now says the
build fails on a hardcoded address and records why it is a check, and check 3's description covers
the reachability half.