### PR TITLE
conformance: give the corpus principal the declared-key guard the seeds already have

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,9 +255,11 @@ attribute allowlist, a fixed column list). A projection silently drops anything 
 depends on, and because the same projected input feeds both the plan and the check() oracle, the
 two agree and the action passes vacuously. Pass corpus data through verbatim.
 
-Every harness declares the exact `seeds.json` keys and `derived-fields.json` fields it consumes and
-asserts set equality against the corpus, so adding a seed field fails all ten loudly instead of
-being dropped from both sides at once. Adding a field means updating those declarations
+Every harness declares the exact `seeds.json` keys, corpus **principal** keys (`{id, roles, attr}`
+and the attribute names inside `attr`, with the two value shapes those attributes take) and
+`derived-fields.json` fields it consumes and asserts set equality against the corpus, so adding a
+seed field or a principal attribute fails all ten loudly instead of being dropped from both sides at
+once. Adding one means updating those declarations
 deliberately — that is the point of the guard, not an obstacle to route around. The derived fields
 (`createdBy`, `aDouble`, `createdAt`, `scope`, `labels`) live in `conformance/derived-fields.json`;
 never recompute them in a harness.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -690,7 +690,7 @@ The rules the file materialises:
 These are part of the shared contract. Do not replace them with adapter-specific fixtures, and do
 not recompute them in a harness — read `derived-fields.json`.
 
-### Seed and derived-field coverage
+### Seed, principal and derived-field coverage
 
 The projection trap this README documents for `actions.json` applies to the seeds too, and it is
 worse there: a seed key a harness does not consume is dropped from the stored row **and** the
@@ -710,8 +710,30 @@ and fails if the file's `fields` list, or any entry's key set, differs. Concrete
 seed field by field (mongoose, langchain-chromadb) assert against the *raw* JSON — a rebuilt object
 can only ever report the keys the parser already names, so asserting on it would pass vacuously.
 
-Adding a field to a seed must fail every harness loudly. That is the acceptance test for this
-guard; run it before trusting it.
+The **principal** is guarded the same way, and it is the input the trap actually caught: the same
+principal feeds the plan under test and the check() oracle, so an attribute dropped on the way in
+vanishes from both sides at once — the plan folds to `ALWAYS_DENIED`, the oracle agrees, and the
+action passes while testing nothing. Every harness therefore declares two key sets,
+`{id, roles, attr}` and the attribute names inside `attr`, and asserts equality in both directions,
+exactly as it does for a seed row and its `tags[]` elements.
+
+`id` and `roles` are deliberately **inside** the guard rather than documented as an exclusion. A
+role dropped on the way in changes every policy decision at once; that it is less likely to be
+projected away than an attribute is a reason to expect that half of the assertion to stay quiet, not
+a reason to omit it.
+
+The attribute *values* are asserted too, because the key set says nothing about a change inside one
+and three of the four attributes are lists. The corpus carries exactly two shapes — a string and a
+list of strings — and the Java harnesses convert on exactly that basis, so a third shape has to fail
+at the declaration rather than be reshaped by one adapter's SDK and passed through untyped by
+another. That is the same reason the seed guard descends into `tags[]`.
+
+The construction itself stays verbatim pass-through: the guard exists to keep it that way, not to
+replace it. `scripts/regenerate-wire-fixtures.sh` needs no equivalent — it copies `.principal`
+wholesale with `jq` and never names a key.
+
+Adding a field to a seed, or an attribute to the principal, must fail every harness loudly. That is
+the acceptance test for these guards; run it before trusting them.
 
 ## Adding a new hostile shape
 
@@ -725,6 +747,8 @@ guard; run it before trusting it.
    entry in the same commit — `scripts/validate-corpus.sh` names the expected values when it fails.
    A seed field that is genuinely new (rather than a new row) has to be added to every harness's
    consumed key set too; the guard described above makes that a loud failure, not a silent drop.
+   The same applies to a new **principal attribute**: every harness declares those as well, so
+   adding one fails all ten until each declaration names it.
 4. Run `scripts/regenerate-wire-fixtures.sh` and commit the new fixture alongside the policy change.
 5. Every adapter harness picks up the new action automatically from `actions.json` on next run;
    triage any divergence into a per-adapter fix issue rather than special-casing it in the harness.
@@ -750,7 +774,9 @@ guard; run it before trusting it.
    rebuild the principal from a hardcoded attribute allowlist; when `pv-exists` added
    `principal.attr.manyTeams`, the projection dropped it, the plan folded to `ALWAYS_DENIED`, and
    the oracle — built from the same projected principal — agreed. The action passed on both sides
-   while testing nothing. Pass corpus data through verbatim.
+   while testing nothing. Pass corpus data through verbatim. Every harness now declares the
+   principal keys it consumes and asserts them, so that particular projection fails loudly — see
+   "Seed, principal and derived-field coverage" above.
 
    The one exception is a `nullRepresentationOmitted` action: its oracle is empty *by
    construction*, which the degeneracy guard asserts against, so it must stay out of that list.
@@ -801,9 +827,10 @@ unsupported before you have watched it fail is how a translatable shape gets per
    three-valued-logic probes discriminate on. Getting them wrong makes the oracle agree with the
    adapter for the wrong reason.
 
-   Declare the seed keys and derived fields the harness consumes and assert set equality against
-   the JSON, as "Seed and derived-field coverage" above describes. A harness without that guard
-   silently drops the next corpus field from both sides of its own differential.
+   Declare the seed keys, the principal keys and the derived fields the harness consumes and assert
+   set equality against the JSON, as "Seed, principal and derived-field coverage" above describes. A
+   harness without those guards silently drops the next corpus field from both sides of its own
+   differential.
 
 4. **Assert the degeneracy guard** (see above) and pin the corpus size, so a silently broken PDP
    connection or a newly added action cannot pass vacuously. Derive the guard's compared list from

--- a/convex/src/adversarial.test.ts
+++ b/convex/src/adversarial.test.ts
@@ -273,6 +273,40 @@ const DERIVED_KEYS = [
   "labels",
 ] as const;
 
+// The corpus principal is guarded the same way and for the same reason. It feeds the PLAN under
+// test AND the check() oracle, so an attribute dropped on the way in vanishes from both sides at
+// once: the plan folds to ALWAYS_DENIED and the oracle, built from the same principal, agrees. That
+// is how langchain-chromadb's hardcoded attribute allowlist let `pv-exists` pass while testing
+// nothing (conformance/README.md, "Adding a new hostile shape", step 7). This harness passes the
+// principal through verbatim, which is correct; the guard is what proves it still does.
+//
+// `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level above the
+// attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for a row and its `tags[]`
+// elements. A role dropped on the way in changes every policy decision at once; that it is less
+// likely to be projected away than an attribute is a reason to expect the assertion to stay quiet,
+// not a reason to omit it.
+const PRINCIPAL_KEYS = ["id", "roles", "attr"] as const;
+
+const PRINCIPAL_ATTR_KEYS = [
+  "allowedTags",
+  "context",
+  "fewTeams",
+  "manyTeams",
+] as const;
+
+/**
+ * One principal attribute, checked against the two JSON shapes the corpus carries. A key-set guard
+ * says nothing about a change inside a value and three of the four attributes are lists, so the
+ * element type is asserted for the same reason the seed guard descends into `tags[]`.
+ */
+function assertPrincipalAttrShape(label: string, value: unknown): void {
+  if (typeof value === "string") return;
+  if (isStringArray(value)) return;
+  throw new Error(
+    `${label} is neither a string nor an array of strings, the only two shapes this harness consumes: a reshaped principal attribute feeds the plan and the check() oracle at once`,
+  );
+}
+
 function assertKeys(
   label: string,
   got: string[],
@@ -328,6 +362,25 @@ seedsFile.seeds.forEach((seed, index) => {
     assertKeys(`${label}.tags[${tagIndex}]`, Object.keys(tag), TAG_KEYS);
   });
 });
+
+// seedsFile.principal is the parsed JSON object — isPrincipal validates it rather than rebuilding
+// it — so Object.keys reports the corpus key set on both levels.
+assertKeys(
+  "seeds.json principal",
+  Object.keys(seedsFile.principal),
+  PRINCIPAL_KEYS,
+);
+// `attr` is optional on the SDK's Principal type; the corpus always carries it, and the assertion
+// above is what proves it rather than this fallback.
+const PRINCIPAL_ATTR = seedsFile.principal.attr ?? {};
+assertKeys(
+  "seeds.json principal.attr",
+  Object.keys(PRINCIPAL_ATTR),
+  PRINCIPAL_ATTR_KEYS,
+);
+for (const [key, value] of Object.entries(PRINCIPAL_ATTR)) {
+  assertPrincipalAttrShape(`seeds.json principal.attr.${key}`, value);
+}
 
 assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);
 if (Object.keys(derivedFile.derived).length !== seedsFile.seeds.length) {

--- a/drizzle/src/adversarial.test.ts
+++ b/drizzle/src/adversarial.test.ts
@@ -157,6 +157,27 @@ const DERIVED_KEYS = [
   "labels",
 ] as const;
 
+// The corpus principal is guarded the same way and for the same reason. It feeds the PLAN under
+// test AND the check() oracle, so an attribute dropped on the way in vanishes from both sides at
+// once: the plan folds to ALWAYS_DENIED and the oracle, built from the same principal, agrees. That
+// is how langchain-chromadb's hardcoded attribute allowlist let `pv-exists` pass while testing
+// nothing (conformance/README.md, "Adding a new hostile shape", step 7). This harness passes the
+// principal through verbatim, which is correct; the guard is what proves it still does.
+//
+// `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level above the
+// attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for a row and its `tags[]`
+// elements. A role dropped on the way in changes every policy decision at once; that it is less
+// likely to be projected away than an attribute is a reason to expect the assertion to stay quiet,
+// not a reason to omit it.
+const PRINCIPAL_KEYS = ["id", "roles", "attr"] as const;
+
+const PRINCIPAL_ATTR_KEYS = [
+  "allowedTags",
+  "context",
+  "fewTeams",
+  "manyTeams",
+] as const;
+
 /** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
 interface DerivedEntry {
   createdBy: string;
@@ -195,6 +216,21 @@ function assertKeys(
   }
 }
 
+/**
+ * One principal attribute, checked against the two JSON shapes the corpus carries. A key-set guard
+ * says nothing about a change inside a value and three of the four attributes are lists, so the
+ * element type is asserted for the same reason the seed guard descends into `tags[]`.
+ */
+function assertPrincipalAttrShape(label: string, value: unknown): void {
+  if (typeof value === "string") return;
+  if (Array.isArray(value) && value.every((el) => typeof el === "string")) {
+    return;
+  }
+  throw new Error(
+    `${label} is neither a string nor an array of strings, the only two shapes this harness consumes: a reshaped principal attribute feeds the plan and the check() oracle at once`,
+  );
+}
+
 const seedsFile: SeedsFile = JSON.parse(
   fs.readFileSync(path.join(CONFORMANCE_DIR, "seeds.json"), "utf8"),
 );
@@ -216,6 +252,25 @@ SEEDS.forEach((seed, index) => {
     assertKeys(`${label}.tags[${tagIndex}]`, Object.keys(tag), TAG_KEYS);
   });
 });
+
+// seedsFile.principal is the parsed JSON object, handed to the SDK untouched, so Object.keys
+// reports the corpus key set on both levels.
+assertKeys(
+  "seeds.json principal",
+  Object.keys(seedsFile.principal),
+  PRINCIPAL_KEYS,
+);
+// `attr` is optional on the SDK's Principal type; the corpus always carries it, and the assertion
+// above is what proves it rather than this fallback.
+const PRINCIPAL_ATTR = seedsFile.principal.attr ?? {};
+assertKeys(
+  "seeds.json principal.attr",
+  Object.keys(PRINCIPAL_ATTR),
+  PRINCIPAL_ATTR_KEYS,
+);
+for (const [key, value] of Object.entries(PRINCIPAL_ATTR)) {
+  assertPrincipalAttrShape(`seeds.json principal.attr.${key}`, value);
+}
 
 assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);
 const DERIVED_IDS = Object.keys(derivedFile.derived);

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchAdversarialConformanceTest.java
@@ -205,6 +205,25 @@ class ElasticsearchAdversarialConformanceTest {
     private static final List<String> DERIVED_KEYS =
             List.of("createdBy", "aDouble", "createdAt", "scope", "labels");
 
+    // The corpus principal is guarded the same way and for the same reason. It feeds the PLAN under
+    // test AND the check() oracle, so an attribute dropped on the way in vanishes from both sides
+    // at once: the plan folds to ALWAYS_DENIED and the oracle, built from the same principal,
+    // agrees. That is how langchain-chromadb's hardcoded attribute allowlist let `pv-exists` pass
+    // while testing nothing (conformance/README.md, "Adding a new hostile shape", step 7).
+    // principal() iterates the whole attr map, which is correct; the guard is what proves it does.
+    //
+    // `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level above the
+    // attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for a row and its `tags[]`
+    // elements. A role dropped on the way in changes every policy decision at once; that it is less
+    // likely to be projected away than an attribute is a reason to expect the assertion to stay
+    // quiet, not a reason to omit it. PrincipalSpec ignores unknown properties so that this
+    // assertion, not a Jackson decode error, is what names an added key.
+
+    private static final List<String> PRINCIPAL_KEYS = List.of("id", "roles", "attr");
+
+    private static final List<String> PRINCIPAL_ATTR_KEYS =
+            List.of("allowedTags", "context", "fewTeams", "manyTeams");
+
     /** The corpus key for this adapter — its directory name, as every other harness uses. */
     private static final String ADAPTER = "elasticsearch-java";
 
@@ -954,13 +973,14 @@ class ElasticsearchAdversarialConformanceTest {
     }
 
     /**
-     * Proves this harness consumes every seed key and every derived field the corpus defines, and
-     * nothing it does not. Rejecting unknown properties on decode cannot do this alone: it catches
-     * an added key but says nothing about one that disappears, and a disappeared key decodes to its
-     * default on both sides of the differential.
+     * Proves this harness consumes every seed key, every principal key and every derived field the
+     * corpus defines, and nothing it does not. Rejecting unknown properties on decode cannot do
+     * this alone: it catches an added key but says nothing about one that disappears, and a
+     * disappeared key decodes to its default on both sides of the differential.
      */
     private static void assertCorpusCoverage(Path conformance) throws IOException {
-        JsonNode rawSeeds = MAPPER.readTree(conformance.resolve("seeds.json").toFile()).get("seeds");
+        JsonNode rawSeedsFile = MAPPER.readTree(conformance.resolve("seeds.json").toFile());
+        JsonNode rawSeeds = rawSeedsFile.get("seeds");
         assertEquals(seeds.size(), rawSeeds.size(), "seeds.json rows lost in decoding");
         for (int i = 0; i < rawSeeds.size(); i++) {
             String label = "seeds.json seeds[" + i + "]";
@@ -972,6 +992,8 @@ class ElasticsearchAdversarialConformanceTest {
             }
         }
 
+        assertPrincipalCoverage(rawSeedsFile.get("principal"));
+
         assertKeys("derived-fields.json fields", derivedFile.fields(), DERIVED_KEYS, List.of());
         assertEquals(seeds.stream().map(Seed::id).collect(Collectors.toCollection(TreeSet::new)),
                 new TreeSet<>(derivedFile.derived().keySet()),
@@ -981,6 +1003,36 @@ class ElasticsearchAdversarialConformanceTest {
         for (Map.Entry<String, JsonNode> entry : rawDerived.properties()) {
             assertKeys("derived-fields.json derived[\"" + entry.getKey() + "\"]",
                     keysOf(entry.getValue()), DERIVED_KEYS, List.of());
+        }
+    }
+
+    /**
+     * Guards the corpus principal the way {@link #assertCorpusCoverage} guards a seed row: the
+     * top-level keys, then the keys one level in.
+     *
+     * <p>Asserted against the RAW JSON because {@link #principal()} rebuilds the principal from
+     * {@link PrincipalSpec} — a rebuilt object could only ever report the keys this harness already
+     * names. The attribute VALUES are asserted too: a key-set guard says nothing about a change
+     * inside one, and three of the four attributes are lists. {@link #principalAttribute} accepts
+     * exactly a string and a list of strings, so a third shape fails here, next to the
+     * declaration, rather than deep in the conversion. It is the same reason the seed guard
+     * descends into {@code tags[]}.
+     */
+    private static void assertPrincipalCoverage(JsonNode principal) {
+        assertKeys("seeds.json principal", keysOf(principal), PRINCIPAL_KEYS, List.of());
+        JsonNode attr = principal.get("attr");
+        assertKeys("seeds.json principal.attr", keysOf(attr), PRINCIPAL_ATTR_KEYS, List.of());
+        for (Map.Entry<String, JsonNode> entry : attr.properties()) {
+            String label = "seeds.json principal.attr." + entry.getKey();
+            JsonNode value = entry.getValue();
+            boolean listOfStrings = value.isArray();
+            for (JsonNode element : value) {
+                listOfStrings &= element.isTextual();
+            }
+            assertTrue(value.isTextual() || listOfStrings, () -> label
+                    + " is neither a string nor a list of strings, the only two shapes this harness"
+                    + " consumes: a reshaped principal attribute feeds the plan and the check()"
+                    + " oracle at once");
         }
     }
 

--- a/ent/corpus_test.go
+++ b/ent/corpus_test.go
@@ -173,6 +173,26 @@ var tagKeys = []string{"id", "name"}
 // way and for the same reason as seedKeys.
 var derivedKeys = []string{"aDouble", "createdAt", "createdBy", "labels", "scope"}
 
+// principalKeys is the exact set of top-level keys the corpus principal carries.
+//
+// `id` and `roles` are deliberately IN scope, not excluded. A role dropped on the way in changes
+// every policy decision at once, which is at least as bad as a dropped attribute; that it is less
+// likely to happen is a reason to expect the assertion to stay quiet, not a reason to omit it.
+// Guarding them one level above the attributes is the same two-level shape seedKeys and tagKeys
+// use for a row and its `tags[]` elements.
+var principalKeys = []string{"attr", "id", "roles"}
+
+// principalAttrKeys is the exact set of principal attributes this harness consumes.
+//
+// The corpus principal feeds the PLAN under test and the check() ORACLE, so an attribute dropped on
+// the way in vanishes from both sides at once: the plan folds to ALWAYS_DENIED and the oracle,
+// built from the same principal, agrees. That is how langchain-chromadb's hardcoded attribute
+// allowlist let `pv-exists` pass while testing nothing (conformance/README.md, "Adding a new
+// hostile shape", step 7). This harness hands Principal.Attr to the SDK verbatim, which is correct;
+// the guard is what proves it still does, in both directions — a corpus attribute nothing here
+// consumes, and a consumed attribute the corpus no longer carries.
+var principalAttrKeys = []string{"allowedTags", "context", "fewTeams", "manyTeams"}
+
 // cerbosImageRepository is the PDP image the corpus pins. The tag comes from CERBOS_VERSION and
 // the digest from CERBOS_IMAGE_DIGEST; conformance/scripts/validate-corpus.sh asserts the two
 // agree everywhere they are restated.
@@ -376,15 +396,16 @@ func readJSONStrict(tb testing.TB, path string, out any) {
 	}
 }
 
-// assertCorpusCoverage proves the harness consumes every seed key and every derived field the
-// corpus defines, and nothing it does not. Strict decoding alone cannot do this: it rejects an
-// added key but says nothing about one that disappears, and a disappeared key decodes to its zero
-// value on both sides of the differential.
+// assertCorpusCoverage proves the harness consumes every seed key, every principal key and every
+// derived field the corpus defines, and nothing it does not. Strict decoding alone cannot do this:
+// it rejects an added key but says nothing about one that disappears, and a disappeared key decodes
+// to its zero value on both sides of the differential.
 func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 	tb.Helper()
 
 	var raw struct {
-		Seeds []map[string]json.RawMessage `json:"seeds"`
+		Principal map[string]json.RawMessage   `json:"principal"`
+		Seeds     []map[string]json.RawMessage `json:"seeds"`
 	}
 	readJSON(tb, filepath.Join(dir, "seeds.json"), &raw)
 	if len(raw.Seeds) != len(c.Seeds.Seeds) {
@@ -403,6 +424,8 @@ func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 		}
 	}
 
+	assertPrincipalCoverage(tb, raw.Principal)
+
 	assertKeys(tb, "derived-fields.json fields", c.Derived.Fields, derivedKeys)
 
 	var rawDerived struct {
@@ -419,6 +442,44 @@ func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 	if len(rawDerived.Derived) != len(c.Seeds.Seeds) {
 		tb.Fatalf("derived-fields.json has %d entries for %d seeds", len(rawDerived.Derived), len(c.Seeds.Seeds))
 	}
+}
+
+// assertPrincipalCoverage guards the corpus principal the way assertCorpusCoverage guards a seed
+// row: the top-level keys, then the keys one level in.
+//
+// The attribute VALUES are asserted too, because a key-set guard says nothing about a change inside
+// one and three of the four attributes are lists. The corpus carries exactly two shapes — a string
+// and a list of strings — and every harness converts on that basis, so a third shape has to fail
+// here rather than be coerced by one adapter's SDK and passed through untyped by another. It is the
+// same reason the seed guard descends into `tags[]`.
+func assertPrincipalCoverage(tb testing.TB, principal map[string]json.RawMessage) {
+	tb.Helper()
+
+	assertKeys(tb, "seeds.json principal", keysOf(principal), principalKeys)
+
+	var attr map[string]json.RawMessage
+	if err := json.Unmarshal(principal["attr"], &attr); err != nil {
+		tb.Fatalf("parsing seeds.json principal.attr: %v", err)
+	}
+	assertKeys(tb, "seeds.json principal.attr", keysOf(attr), principalAttrKeys)
+	for key, value := range attr {
+		assertPrincipalAttrShape(tb, "seeds.json principal.attr."+key, value)
+	}
+}
+
+// assertPrincipalAttrShape fails unless the value is one of the two shapes the corpus carries.
+func assertPrincipalAttrShape(tb testing.TB, label string, value json.RawMessage) {
+	tb.Helper()
+
+	var scalar string
+	if json.Unmarshal(value, &scalar) == nil {
+		return
+	}
+	var list []string
+	if json.Unmarshal(value, &list) == nil {
+		return
+	}
+	tb.Fatalf("%s is neither a string nor a list of strings, the only two shapes this harness consumes: a reshaped principal attribute feeds the plan and the check() oracle at once", label)
 }
 
 // assertKeys fails unless got is exactly want, ignoring order, plus any of the optional keys.

--- a/langchain-chromadb/src/adversarial.test.ts
+++ b/langchain-chromadb/src/adversarial.test.ts
@@ -209,6 +209,28 @@ const DERIVED_KEYS = [
   "labels",
 ] as const;
 
+// The corpus principal is guarded the same way and for the same reason — and this harness is why
+// the guard exists. It feeds the PLAN under test AND the check() oracle, so an attribute dropped on
+// the way in vanishes from both sides at once: the plan folds to ALWAYS_DENIED and the oracle,
+// built from the same principal, agrees. This harness used to rebuild the principal from a
+// hardcoded attribute allowlist, and when `pv-exists` added `manyTeams` the projection dropped it
+// and the action passed while testing nothing (conformance/README.md, "Adding a new hostile
+// shape", step 7). The attributes are carried through verbatim now; the guard is what proves it.
+//
+// `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level above the
+// attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for a row and its `tags[]`
+// elements. A role dropped on the way in changes every policy decision at once; that it is less
+// likely to be projected away than an attribute is a reason to expect the assertion to stay quiet,
+// not a reason to omit it.
+const PRINCIPAL_KEYS = ["id", "roles", "attr"] as const;
+
+const PRINCIPAL_ATTR_KEYS = [
+  "allowedTags",
+  "context",
+  "fewTeams",
+  "manyTeams",
+] as const;
+
 function assertKeys(
   label: string,
   got: string[],
@@ -250,6 +272,39 @@ function assertSeedKeyCoverage(value: unknown): void {
       assertKeys(tagLabel, Object.keys(requireRecord(tag, tagLabel)), TAG_KEYS);
     });
   });
+}
+
+/**
+ * Asserted against the RAW json for the same reason as the seed keys: parseSeedsFile rebuilds
+ * `id` and `roles`, so a rebuilt principal could only ever report the keys this harness already
+ * names.
+ *
+ * The attribute VALUES are asserted too. A key-set guard says nothing about a change inside one and
+ * three of the four attributes are lists, so the element type is asserted for the same reason the
+ * seed guard descends into `tags[]`.
+ */
+function assertPrincipalKeyCoverage(value: unknown): void {
+  const principal = requireRecord(
+    requireRecord(value, "seeds.json")["principal"],
+    "seeds.json principal",
+  );
+  assertKeys("seeds.json principal", Object.keys(principal), PRINCIPAL_KEYS);
+  const attr = requireRecord(principal["attr"], "seeds.json principal.attr");
+  assertKeys(
+    "seeds.json principal.attr",
+    Object.keys(attr),
+    PRINCIPAL_ATTR_KEYS,
+  );
+  for (const [key, entry] of Object.entries(attr)) {
+    const label = `seeds.json principal.attr.${key}`;
+    if (typeof entry === "string") continue;
+    if (Array.isArray(entry) && entry.every((el) => typeof el === "string")) {
+      continue;
+    }
+    throw Error(
+      `${label} is neither a string nor an array of strings, the only two shapes this harness consumes: a reshaped principal attribute feeds the plan and the check() oracle at once`,
+    );
+  }
 }
 
 function parseDerivedEntry(value: unknown, label: string): DerivedEntry {
@@ -461,6 +516,7 @@ function readJson(fileName: string): unknown {
 
 const rawSeedsJson = readJson("seeds.json");
 assertSeedKeyCoverage(rawSeedsJson);
+assertPrincipalKeyCoverage(rawSeedsJson);
 const seedsFile = parseSeedsFile(rawSeedsJson);
 const actionsFile = parseActionsFile(readJson("actions.json"));
 const derivedFile = parseDerivedFile(readJson("derived-fields.json"));

--- a/mongoose/src/adversarial.test.ts
+++ b/mongoose/src/adversarial.test.ts
@@ -134,6 +134,27 @@ const DERIVED_KEYS = [
   "labels",
 ] as const;
 
+// The corpus principal is guarded the same way and for the same reason. It feeds the PLAN under
+// test AND the check() oracle, so an attribute dropped on the way in vanishes from both sides at
+// once: the plan folds to ALWAYS_DENIED and the oracle, built from the same principal, agrees. That
+// is how langchain-chromadb's hardcoded attribute allowlist let `pv-exists` pass while testing
+// nothing (conformance/README.md, "Adding a new hostile shape", step 7). parsePrincipal carries
+// every attribute through verbatim, which is correct; the guard is what proves it still does.
+//
+// `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level above the
+// attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for a row and its `tags[]`
+// elements. A role dropped on the way in changes every policy decision at once; that it is less
+// likely to be projected away than an attribute is a reason to expect the assertion to stay quiet,
+// not a reason to omit it.
+const PRINCIPAL_KEYS = ["id", "roles", "attr"] as const;
+
+const PRINCIPAL_ATTR_KEYS = [
+  "allowedTags",
+  "context",
+  "fewTeams",
+  "manyTeams",
+] as const;
+
 /**
  * Asserted against the RAW json rather than the parsed seeds: parseSeed rebuilds each row field by
  * field, so a parsed seed can only ever carry the keys this harness already names and the
@@ -157,6 +178,39 @@ function assertSeedKeyCoverage(value: unknown): void {
       assertKeys(tagLabel, Object.keys(expectRecord(tag, tagLabel)), TAG_KEYS);
     });
   });
+}
+
+/**
+ * Asserted against the RAW json for the same reason as the seed keys: parsePrincipal rebuilds `id`
+ * and `roles`, so a rebuilt principal could only ever report the keys this harness already names.
+ *
+ * The attribute VALUES are asserted too. parsePrincipal accepts any Cerbos `Value`, but the corpus
+ * carries exactly two shapes — a string and a list of strings — and every other harness converts on
+ * that basis, so a third has to fail here rather than be reshaped by one adapter and passed through
+ * by another. A key-set guard says nothing about a change inside a value, and three of the four
+ * attributes are lists; this is the same reason the seed guard descends into `tags[]`.
+ */
+function assertPrincipalKeyCoverage(value: unknown): void {
+  const principal = expectRecord(
+    expectRecord(value, "seeds.json")["principal"],
+    "seeds.json principal"
+  );
+  assertKeys("seeds.json principal", Object.keys(principal), PRINCIPAL_KEYS);
+  const attr = expectRecord(principal["attr"], "seeds.json principal.attr");
+  assertKeys(
+    "seeds.json principal.attr",
+    Object.keys(attr),
+    PRINCIPAL_ATTR_KEYS
+  );
+  for (const [key, entry] of Object.entries(attr)) {
+    if (typeof entry === "string") continue;
+    if (Array.isArray(entry) && entry.every((el) => typeof el === "string")) {
+      continue;
+    }
+    throw new Error(
+      `seeds.json principal.attr.${key} is neither a string nor an array of strings, the only two shapes this harness consumes: a reshaped principal attribute feeds the plan and the check() oracle at once`
+    );
+  }
 }
 
 function parseDerivedEntry(value: unknown, label: string): DerivedEntry {
@@ -256,6 +310,7 @@ function parseSeedsFile(value: unknown): SeedsFile {
 
 const rawSeedsJson = readJson("seeds.json");
 assertSeedKeyCoverage(rawSeedsJson);
+assertPrincipalKeyCoverage(rawSeedsJson);
 const seedsFile = parseSeedsFile(rawSeedsJson);
 const actionsFile = parseActionsFile(readJson("actions.json"));
 const derivedFile = parseDerivedFile(readJson("derived-fields.json"));

--- a/pgx/corpus_test.go
+++ b/pgx/corpus_test.go
@@ -157,6 +157,26 @@ var tagKeys = []string{"id", "name"}
 // way and for the same reason as seedKeys.
 var derivedKeys = []string{"aDouble", "createdAt", "createdBy", "labels", "scope"}
 
+// principalKeys is the exact set of top-level keys the corpus principal carries.
+//
+// `id` and `roles` are deliberately IN scope, not excluded. A role dropped on the way in changes
+// every policy decision at once, which is at least as bad as a dropped attribute; that it is less
+// likely to happen is a reason to expect the assertion to stay quiet, not a reason to omit it.
+// Guarding them one level above the attributes is the same two-level shape seedKeys and tagKeys
+// use for a row and its `tags[]` elements.
+var principalKeys = []string{"attr", "id", "roles"}
+
+// principalAttrKeys is the exact set of principal attributes this harness consumes.
+//
+// The corpus principal feeds the PLAN under test and the check() ORACLE, so an attribute dropped on
+// the way in vanishes from both sides at once: the plan folds to ALWAYS_DENIED and the oracle,
+// built from the same principal, agrees. That is how langchain-chromadb's hardcoded attribute
+// allowlist let `pv-exists` pass while testing nothing (conformance/README.md, "Adding a new
+// hostile shape", step 7). This harness hands Principal.Attr to the SDK verbatim, which is correct;
+// the guard is what proves it still does, in both directions — a corpus attribute nothing here
+// consumes, and a consumed attribute the corpus no longer carries.
+var principalAttrKeys = []string{"allowedTags", "context", "fewTeams", "manyTeams"}
+
 // Corpus is the parsed corpus plus this adapter's derived classification.
 type Corpus struct {
 	Dir           string
@@ -381,15 +401,16 @@ func readJSONStrict(tb testing.TB, path string, out any) {
 	}
 }
 
-// assertCorpusCoverage proves the harness consumes every seed key and every derived field the
-// corpus defines, and nothing it does not. Strict decoding alone cannot do this: it rejects an
-// added key but says nothing about one that disappears, and a disappeared key decodes to its zero
-// value on both sides of the differential.
+// assertCorpusCoverage proves the harness consumes every seed key, every principal key and every
+// derived field the corpus defines, and nothing it does not. Strict decoding alone cannot do this:
+// it rejects an added key but says nothing about one that disappears, and a disappeared key decodes
+// to its zero value on both sides of the differential.
 func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 	tb.Helper()
 
 	var raw struct {
-		Seeds []map[string]json.RawMessage `json:"seeds"`
+		Principal map[string]json.RawMessage   `json:"principal"`
+		Seeds     []map[string]json.RawMessage `json:"seeds"`
 	}
 	readJSON(tb, filepath.Join(dir, "seeds.json"), &raw)
 	if len(raw.Seeds) != len(c.Seeds.Seeds) {
@@ -408,6 +429,8 @@ func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 		}
 	}
 
+	assertPrincipalCoverage(tb, raw.Principal)
+
 	assertKeys(tb, "derived-fields.json fields", c.Derived.Fields, derivedKeys)
 
 	var rawDerived struct {
@@ -424,6 +447,44 @@ func assertCorpusCoverage(tb testing.TB, dir string, c *Corpus) {
 	if len(rawDerived.Derived) != len(c.Seeds.Seeds) {
 		tb.Fatalf("derived-fields.json has %d entries for %d seeds", len(rawDerived.Derived), len(c.Seeds.Seeds))
 	}
+}
+
+// assertPrincipalCoverage guards the corpus principal the way assertCorpusCoverage guards a seed
+// row: the top-level keys, then the keys one level in.
+//
+// The attribute VALUES are asserted too, because a key-set guard says nothing about a change inside
+// one and three of the four attributes are lists. The corpus carries exactly two shapes — a string
+// and a list of strings — and every harness converts on that basis, so a third shape has to fail
+// here rather than be coerced by one adapter's SDK and passed through untyped by another. It is the
+// same reason the seed guard descends into `tags[]`.
+func assertPrincipalCoverage(tb testing.TB, principal map[string]json.RawMessage) {
+	tb.Helper()
+
+	assertKeys(tb, "seeds.json principal", keysOf(principal), principalKeys)
+
+	var attr map[string]json.RawMessage
+	if err := json.Unmarshal(principal["attr"], &attr); err != nil {
+		tb.Fatalf("parsing seeds.json principal.attr: %v", err)
+	}
+	assertKeys(tb, "seeds.json principal.attr", keysOf(attr), principalAttrKeys)
+	for key, value := range attr {
+		assertPrincipalAttrShape(tb, "seeds.json principal.attr."+key, value)
+	}
+}
+
+// assertPrincipalAttrShape fails unless the value is one of the two shapes the corpus carries.
+func assertPrincipalAttrShape(tb testing.TB, label string, value json.RawMessage) {
+	tb.Helper()
+
+	var scalar string
+	if json.Unmarshal(value, &scalar) == nil {
+		return
+	}
+	var list []string
+	if json.Unmarshal(value, &list) == nil {
+		return
+	}
+	tb.Fatalf("%s is neither a string nor a list of strings, the only two shapes this harness consumes: a reshaped principal attribute feeds the plan and the check() oracle at once", label)
 }
 
 // assertKeys fails unless got is exactly want, ignoring order, plus any of the optional keys.

--- a/prisma/src/adversarial.test.ts
+++ b/prisma/src/adversarial.test.ts
@@ -163,6 +163,27 @@ const DERIVED_KEYS = [
   "labels",
 ] as const;
 
+// The corpus principal is guarded the same way and for the same reason. It feeds the PLAN under
+// test AND the check() oracle, so an attribute dropped on the way in vanishes from both sides at
+// once: the plan folds to ALWAYS_DENIED and the oracle, built from the same principal, agrees. That
+// is how langchain-chromadb's hardcoded attribute allowlist let `pv-exists` pass while testing
+// nothing (conformance/README.md, "Adding a new hostile shape", step 7). This harness passes the
+// principal through verbatim, which is correct; the guard is what proves it still does.
+//
+// `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level above the
+// attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for a row and its `tags[]`
+// elements. A role dropped on the way in changes every policy decision at once; that it is less
+// likely to be projected away than an attribute is a reason to expect the assertion to stay quiet,
+// not a reason to omit it.
+const PRINCIPAL_KEYS = ["id", "roles", "attr"] as const;
+
+const PRINCIPAL_ATTR_KEYS = [
+  "allowedTags",
+  "context",
+  "fewTeams",
+  "manyTeams",
+] as const;
+
 /** One seed's derived fields, exactly as conformance/derived-fields.json carries them. */
 interface DerivedEntry {
   createdBy: string;
@@ -201,6 +222,21 @@ function assertKeys(
   }
 }
 
+/**
+ * One principal attribute, checked against the two JSON shapes the corpus carries. A key-set guard
+ * says nothing about a change inside a value and three of the four attributes are lists, so the
+ * element type is asserted for the same reason the seed guard descends into `tags[]`.
+ */
+function assertPrincipalAttrShape(label: string, value: unknown): void {
+  if (typeof value === "string") return;
+  if (Array.isArray(value) && value.every((el) => typeof el === "string")) {
+    return;
+  }
+  throw new Error(
+    `${label} is neither a string nor an array of strings, the only two shapes this harness consumes: a reshaped principal attribute feeds the plan and the check() oracle at once`
+  );
+}
+
 const seedsFile: SeedsFile = JSON.parse(
   fs.readFileSync(path.join(CONFORMANCE_DIR, "seeds.json"), "utf8")
 );
@@ -222,6 +258,25 @@ SEEDS.forEach((seed, index) => {
     assertKeys(`${label}.tags[${tagIndex}]`, Object.keys(tag), TAG_KEYS);
   });
 });
+
+// seedsFile.principal is the parsed JSON object, handed to the SDK untouched, so Object.keys
+// reports the corpus key set on both levels.
+assertKeys(
+  "seeds.json principal",
+  Object.keys(seedsFile.principal),
+  PRINCIPAL_KEYS
+);
+// `attr` is optional on the SDK's Principal type; the corpus always carries it, and the assertion
+// above is what proves it rather than this fallback.
+const PRINCIPAL_ATTR = seedsFile.principal.attr ?? {};
+assertKeys(
+  "seeds.json principal.attr",
+  Object.keys(PRINCIPAL_ATTR),
+  PRINCIPAL_ATTR_KEYS
+);
+for (const [key, value] of Object.entries(PRINCIPAL_ATTR)) {
+  assertPrincipalAttrShape(`seeds.json principal.attr.${key}`, value);
+}
 
 assertKeys("derived-fields.json fields", derivedFile.fields, DERIVED_KEYS);
 const DERIVED_IDS = Object.keys(derivedFile.derived);

--- a/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
+++ b/spring-data/src/test/java/dev/cerbos/queryplan/springdata/AdversarialConformanceTest.java
@@ -304,6 +304,25 @@ class AdversarialConformanceTest {
     private static final List<String> DERIVED_KEYS =
             List.of("createdBy", "aDouble", "createdAt", "scope", "labels");
 
+    // The corpus principal is guarded the same way and for the same reason. It feeds the PLAN under
+    // test AND the check() oracle, so an attribute dropped on the way in vanishes from both sides
+    // at once: the plan folds to ALWAYS_DENIED and the oracle, built from the same principal,
+    // agrees. That is how langchain-chromadb's hardcoded attribute allowlist let `pv-exists` pass
+    // while testing nothing (conformance/README.md, "Adding a new hostile shape", step 7).
+    // principal() iterates the whole attr map, which is correct; the guard is what proves it does.
+    //
+    // `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level above the
+    // attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for a row and its `tags[]`
+    // elements. A role dropped on the way in changes every policy decision at once; that it is less
+    // likely to be projected away than an attribute is a reason to expect the assertion to stay
+    // quiet, not a reason to omit it. PrincipalSpec ignores unknown properties so that this
+    // assertion, not a Jackson decode error, is what names an added key.
+
+    private static final List<String> PRINCIPAL_KEYS = List.of("id", "roles", "attr");
+
+    private static final List<String> PRINCIPAL_ATTR_KEYS =
+            List.of("allowedTags", "context", "fewTeams", "manyTeams");
+
     private static SeedsFile seedsFile;
     private static ActionsFile actionsFile;
     private static DerivedFile derivedFile;
@@ -473,14 +492,15 @@ class AdversarialConformanceTest {
     }
 
     /**
-     * Proves this harness consumes every seed key and every derived field the corpus defines, and
-     * nothing it does not. Rejecting unknown properties on decode cannot do this alone: it catches
-     * an added key but says nothing about one that disappears, and a disappeared key decodes to its
-     * default on both sides of the differential.
+     * Proves this harness consumes every seed key, every principal key and every derived field the
+     * corpus defines, and nothing it does not. Rejecting unknown properties on decode cannot do
+     * this alone: it catches an added key but says nothing about one that disappears, and a
+     * disappeared key decodes to its default on both sides of the differential.
      */
     private static void assertCorpusCoverage(ObjectMapper mapper, Path conformance)
             throws IOException {
-        JsonNode rawSeeds = mapper.readTree(conformance.resolve("seeds.json").toFile()).get("seeds");
+        JsonNode rawSeedsFile = mapper.readTree(conformance.resolve("seeds.json").toFile());
+        JsonNode rawSeeds = rawSeedsFile.get("seeds");
         assertEquals(SEEDS.size(), rawSeeds.size(), "seeds.json rows lost in decoding");
         for (int i = 0; i < rawSeeds.size(); i++) {
             String label = "seeds.json seeds[" + i + "]";
@@ -492,6 +512,8 @@ class AdversarialConformanceTest {
             }
         }
 
+        assertPrincipalCoverage(rawSeedsFile.get("principal"));
+
         assertKeys("derived-fields.json fields", derivedFile.fields(), DERIVED_KEYS, List.of());
         assertEquals(SEEDS.stream().map(Seed::id).collect(Collectors.toCollection(TreeSet::new)),
                 new TreeSet<>(derivedFile.derived().keySet()),
@@ -501,6 +523,36 @@ class AdversarialConformanceTest {
         for (Map.Entry<String, JsonNode> entry : rawDerived.properties()) {
             assertKeys("derived-fields.json derived[\"" + entry.getKey() + "\"]",
                     keysOf(entry.getValue()), DERIVED_KEYS, List.of());
+        }
+    }
+
+    /**
+     * Guards the corpus principal the way {@link #assertCorpusCoverage} guards a seed row: the
+     * top-level keys, then the keys one level in.
+     *
+     * <p>Asserted against the RAW JSON because {@link #principal()} rebuilds the principal from
+     * {@link PrincipalSpec} — a rebuilt object could only ever report the keys this harness already
+     * names. The attribute VALUES are asserted too: a key-set guard says nothing about a change
+     * inside one, and three of the four attributes are lists. {@link #asPrincipalAttribute} accepts
+     * exactly a string and a list of strings, so a third shape fails here, next to the
+     * declaration, rather than deep in the conversion. It is the same reason the seed guard
+     * descends into {@code tags[]}.
+     */
+    private static void assertPrincipalCoverage(JsonNode principal) {
+        assertKeys("seeds.json principal", keysOf(principal), PRINCIPAL_KEYS, List.of());
+        JsonNode attr = principal.get("attr");
+        assertKeys("seeds.json principal.attr", keysOf(attr), PRINCIPAL_ATTR_KEYS, List.of());
+        for (Map.Entry<String, JsonNode> entry : attr.properties()) {
+            String label = "seeds.json principal.attr." + entry.getKey();
+            JsonNode value = entry.getValue();
+            boolean listOfStrings = value.isArray();
+            for (JsonNode element : value) {
+                listOfStrings &= element.isTextual();
+            }
+            assertTrue(value.isTextual() || listOfStrings, () -> label
+                    + " is neither a string nor a list of strings, the only two shapes this harness"
+                    + " consumes: a reshaped principal attribute feeds the plan and the check()"
+                    + " oracle at once");
         }
     }
 

--- a/sqlalchemy/tests/test_adversarial_conformance.py
+++ b/sqlalchemy/tests/test_adversarial_conformance.py
@@ -93,6 +93,23 @@ SEED_NOTE_KEY = "note"
 TAG_KEYS = {"id", "name"}
 DERIVED_KEYS = {"createdBy", "aDouble", "createdAt", "scope", "labels"}
 
+# The corpus principal is guarded the same way and for the same reason. It feeds
+# the PLAN under test AND the check() oracle, so an attribute dropped on the way
+# in vanishes from both sides at once: the plan folds to ALWAYS_DENIED and the
+# oracle, built from the same principal, agrees. That is how langchain-chromadb's
+# hardcoded attribute allowlist let `pv-exists` pass while testing nothing
+# (conformance/README.md, "Adding a new hostile shape", step 7). _principal()
+# passes the attributes through verbatim; the guard is what proves it still does.
+#
+# `id` and `roles` are deliberately IN scope, guarded by PRINCIPAL_KEYS one level
+# above the attributes — the same two-level shape SEED_KEYS and TAG_KEYS use for
+# a row and its `tags[]` elements. A role dropped on the way in changes every
+# policy decision at once; that it is less likely to be projected away than an
+# attribute is a reason to expect the assertion to stay quiet, not a reason to
+# omit it.
+PRINCIPAL_KEYS = {"id", "roles", "attr"}
+PRINCIPAL_ATTR_KEYS = {"allowedTags", "context", "fewTeams", "manyTeams"}
+
 
 def _assert_keys(
     label: str,
@@ -114,11 +131,37 @@ def _assert_keys(
         )
 
 
+def _assert_principal_attr_shape(label: str, value: Any) -> None:
+    """One principal attribute, checked against the two JSON shapes the corpus carries.
+
+    A key-set guard says nothing about a change inside a value and three of the
+    four attributes are lists, so the element type is asserted for the same
+    reason the seed guard descends into ``tags[]``.
+    """
+    if isinstance(value, str):
+        return
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return
+    raise AssertionError(
+        f"{label} is neither a string nor a list of strings, the only two shapes "
+        "this harness consumes: a reshaped principal attribute feeds the plan and "
+        "the check() oracle at once"
+    )
+
+
 for _index, _seed in enumerate(SEEDS):
     _label = f"seeds.json seeds[{_index}]"
     _assert_keys(_label, set(_seed), SEED_KEYS, {SEED_NOTE_KEY})
     for _tag_index, _tag in enumerate(_seed["tags"]):
         _assert_keys(f"{_label}.tags[{_tag_index}]", set(_tag), TAG_KEYS)
+
+# SEEDS_FILE["principal"] is the parsed JSON object, handed to the SDK untouched,
+# so its keys are the corpus key set on both levels.
+_PRINCIPAL: Dict[str, Any] = SEEDS_FILE["principal"]
+_assert_keys("seeds.json principal", set(_PRINCIPAL), PRINCIPAL_KEYS)
+_assert_keys("seeds.json principal.attr", set(_PRINCIPAL["attr"]), PRINCIPAL_ATTR_KEYS)
+for _attr_key, _attr_value in _PRINCIPAL["attr"].items():
+    _assert_principal_attr_shape(f"seeds.json principal.attr.{_attr_key}", _attr_value)
 
 DERIVED: Dict[str, Dict[str, Any]] = DERIVED_FILE["derived"]
 _assert_keys("derived-fields.json fields", set(DERIVED_FILE["fields"]), DERIVED_KEYS)


### PR DESCRIPTION
Closes #399.

## What the guard does

`seeds.json` rows and `derived-fields.json` fields are each protected: every harness names the
exact key set it consumes and asserts set equality against the corpus, so a divergence in either
direction fails loudly. The corpus **principal** was the one input left out — read and passed
through verbatim by all ten harnesses, which is correct, but with nothing asserting it stays that
way.

That matters because the same principal feeds the plan under test **and** the `check()` oracle. An
attribute dropped on the way in vanishes from both sides at once: the plan folds to
`ALWAYS_DENIED`, the oracle built from the same principal agrees, and the action passes while
testing nothing. That is precisely how langchain-chromadb's hardcoded attribute allowlist let
`pv-exists` pass.

Each harness now declares two key sets — `{id, roles, attr}` and the attribute names inside `attr`
(`allowedTags`, `context`, `fewTeams`, `manyTeams`) — and asserts both directions, in the shape
that harness already uses for its seed and derived-field guards:

| Language | Form |
|---|---|
| Go (ent, pgx) | `principalKeys` / `principalAttrKeys` slices + the existing `assertKeys`, called from `assertCorpusCoverage` |
| Java (elasticsearch-java, spring-data) | `PRINCIPAL_KEYS` / `PRINCIPAL_ATTR_KEYS` `List.of` + the existing `assertKeys` against the raw `JsonNode` |
| TypeScript (convex, drizzle, langchain-chromadb, mongoose, prisma) | `PRINCIPAL_KEYS` / `PRINCIPAL_ATTR_KEYS` `as const` arrays + the existing `assertKeys`, at module load |
| Python (sqlalchemy) | `PRINCIPAL_KEYS` / `PRINCIPAL_ATTR_KEYS` sets + the existing `_assert_keys`, at import |

The harnesses that rebuild the principal field by field (mongoose, langchain-chromadb) and the Java
ones assert against the **raw** JSON, for the same reason their seed guards do: a rebuilt object
could only ever report the keys the parser already names.

**No harness changes how it builds its principal.** Verbatim pass-through was already correct; this
only adds the assertion that keeps it that way. `conformance/scripts/regenerate-wire-fixtures.sh`
needs no equivalent — it copies `.principal` wholesale with `jq` and never names a key.

## The two decisions the issue asked to be made deliberately

**`id` and `roles` are IN scope**, not documented as an exclusion. A role dropped on the way in
changes every policy decision at once; that it is less likely to be projected away than an
attribute is a reason to expect that half of the assertion to stay quiet, not a reason to omit it.
They are guarded one level above the attributes — the same two-level shape the seed guard uses for
a row and its `tags[]` elements. The reasoning is stated in a comment in every harness.

**Nested values are covered by asserting the attribute value shapes.** A key-set guard says nothing
about a change inside a value and three of the four attributes are lists. The corpus carries
exactly two shapes — a string and a list of strings — and the Java harnesses' `AttributeValue`
conversion accepts exactly those two, so a third shape now fails at the declaration rather than
being reshaped by one adapter's SDK and passed through untyped by another. This is the analogue of
the seed guard descending into `tags[]`; the elements there are objects with keys, here they are
strings, so the element *type* is what there is to assert.

## Verification

The acceptance criteria ask for the guard to be proved by running, not by reading. Three temporary
corpus mutations were applied to `conformance/seeds.json` and reverted (`git diff` against
`conformance/seeds.json` is empty on this branch):

| Mutation | Result |
|---|---|
| add `principal.attr.probeAttr` | **all ten harnesses fail** — `seeds.json principal.attr carries "probeAttr", which this harness does not consume: an unconsumed corpus field is dropped from the … and the check() oracle at once` |
| remove `principal.attr.allowedTags` | **all ten harnesses fail** — `seeds.json principal.attr is missing "allowedTags", which this harness consumes` |
| add a top-level `principal.policyVersion` | **all ten fail** — eight with `seeds.json principal carries "policyVersion", …`; ent/pgx one step earlier, at Go's `DisallowUnknownFields` (`unknown field "policyVersion"`), which is the same both-directions split the seed guard already has in Go |

A fourth probe (removing `principal.roles`) also fails all ten: eight with
`seeds.json principal is missing "roles", which this harness consumes`, and convex one step earlier
in its pre-existing `isPrincipal` predicate (`Invalid conformance seeds`).

### Ran and passed

- `conformance/scripts/validate-corpus.sh` → `Corpus valid: 199 actions, 21 seeds`
- ent: `go test -run TestCorpusCoverage -count=1 ./...`, `go test -skip TestAdversarialConformance -count=1 ./...` (133 pass), `golangci-lint run ./...` + `golangci-lint fmt --diff ./...` clean
- pgx: the same three (96 pass), clean
- spring-data: full `gradle test --tests '*AdversarialConformanceTest'` in the documented `gradle:8.12-jdk17` container — **208 tests, 0 failures** (Cerbos PDP + H2 containers really started)
- elasticsearch-java: full `gradle test --tests '*ElasticsearchAdversarialConformanceTest'` the same way — **203 tests, 0 failures**
- sqlalchemy: `pdm run test` → **371 passed** (includes the adversarial suite); `black --check` clean
- drizzle: full `npm run test:adversarial` (SQLite leg) → **208 tests, 0 failures**; `npm run typecheck` clean
- mongoose: `npm test` (translator unit test) → 223 pass; `npm run typecheck` clean
- prisma: `npm test` (translator unit test) → 226 pass
- convex: `npm run typecheck` clean (after `docker compose up` + `npx convex codegen`)
- langchain-chromadb: `npm run typecheck` clean

### Ran the guard, but not the full suite

For convex, langchain-chromadb, mongoose and prisma the guard itself was executed — the TypeScript
guards run at **module load**, so `jest -t <no-such-test>` evaluates them without a sidecar — and it
passed on the clean corpus and failed on each mutation. Their full adversarial suites were not run
here:

- **prisma** — `npm run test:adversarial` begins with `prisma db push --force-reset`, which
  destroys the local dev database. I did not run a destructive reset without explicit consent.
  Prisma's PostgreSQL leg was likewise not run.
- **mongoose, langchain-chromadb, convex** — need a MongoDB server, ChromaDB and a Convex backend
  respectively; not started for this change.
- **drizzle PostgreSQL leg** (`ADAPTER_TEST_DB=postgres`) — not run; the SQLite leg was.

CI covers all of these. Nothing in this change is adapter-behaviour: no translator, mapper or
seeding code is touched, only the corpus-loading guards.

## Affected adapters

All ten, plus `conformance/README.md` ("Seed, principal and derived-field coverage", the
add-a-shape checklist, the add-an-adapter checklist) and the corresponding paragraph in `CLAUDE.md`.
No behaviour change for consumers of any published package.
