### PR TITLE
feat(demo): fail the build on an example that restates a principal inline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Two rules that are easy to get wrong:
 
 **Read [demo/README.md](demo/README.md) before changing the demo domain.** It covers the five
 usage shapes, the emitted JSON contract, why the expectations are hardcoded here but banned in
-`conformance/`, and what each of `validate-demo.sh`'s four checks stops.
+`conformance/`, and what each of `validate-demo.sh`'s five checks stops.
 
 ## Code Style
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -97,6 +97,10 @@ adapter. Its `run.sh` must:
   sidecar loaded with `policies/` and the mismatch against `expected.json` read as an adapter bug
   (cerbos/query-plan-adapters#367).
 
+- take its principal from `seeds.json` — look the id up in `principals` and plan with what comes
+  back, never write out an `{ id, roles }` of its own. `validate-demo.sh` fails the build on a
+  restated one. The id itself is fine to name; its **roles** are the half that exists nowhere else.
+
 The document is:
 
 ```jsonc
@@ -152,6 +156,32 @@ The rot risk is real, and `validate-demo.sh` is what answers it:
    cerbos/query-plan-adapters#360's job. Run with `DEMO_REQUIRE_ALL_EXAMPLES=1` to see where it
    stands. The roster it reads is `adapters` in `conformance/actions.json`; there is deliberately
    no second list.
+5. **Principal provenance.** An example looks its principal up in `seeds.json` rather than writing
+   one out. Unlike the hardcoded PDP address check 3 catches, a restated principal does **not** fail
+   quietly — it matches the corpus until someone edits `seeds.json`, and then that example's frozen
+   id lists mismatch and it fails loudly, as an adapter bug rather than as the misinvocation it is.
+   So this is a latency problem, and it earns a check only because six more examples are queued
+   (cerbos/query-plan-adapters#349): a rule constraining examples being *written* is worth more than
+   one added after they exist.
+
+   The signal is an id **next to a role**: naming `alice` is unavoidable (it is the lookup key, the
+   `expected.json` entry key, and the word a printed line uses), but naming `alice` alongside `user`
+   restates the record, because roles come from nowhere else. Comments are skipped and literals are
+   matched whole, so an id in prose, in a Javadoc block, or inside a printed message is fine —
+   `spring-data/example/`'s photo domain documents `?user=alice&role=user` and passes untouched. An
+   example's **own Cerbos policies are skipped**, identified by their `apiVersion`: a policy is the
+   one file where writing a role out is the point, and two rules four lines apart granting `user`
+   and `admin` would otherwise pair exactly like a restated principal.
+
+   Three limits, stated rather than hidden. A role that is **also a principal id** is dropped from
+   the role side — `admin` is both here, so restating *only* the admin principal is not caught (it
+   stays a principal id, so `{ id: "admin", roles: ["user"] }` still pairs). A diagnostic passing an
+   id and a role as two separate literals reads as a restatement; put both in the message, or
+   interpolate the id. And the pairing is **windowed**, so an id and a role bound to variables far
+   enough apart are not seen — widening it is not the fix, because the shapes block every example
+   emits puts `alice` and `admin` within a few lines of each other. This catches a principal
+   *written out*, which is the mistake copying a literal makes; it is not a proof that one was not
+   assembled piecewise.
 
 ## Changing the demo domain
 

--- a/demo/scripts/validate-demo.sh
+++ b/demo/scripts/validate-demo.sh
@@ -20,6 +20,8 @@
 #      so a hardcoded default does not fail, it silently plans against the wrong policy suite.
 #   4. Every adapter has an example/ directory. Landed DISABLED — it cannot pass until the last
 #      child of cerbos/query-plan-adapters#349 merges, and turning it on is #360's job.
+#   5. Principal provenance: an example reads its principal out of seeds.json rather than
+#      restating one inline.
 
 set -euo pipefail
 
@@ -63,7 +65,7 @@ echo "==> demo domain: ${SEED_COUNT} seed rows, application filter selects $(jq 
 # ---------------------------------------------------------------------------------------------
 # 1. Structural
 # ---------------------------------------------------------------------------------------------
-echo "==> [1/4] structural: five usage shapes, well-formed entries"
+echo "==> [1/5] structural: five usage shapes, well-formed entries"
 
 declared="$(jq -r '.shapes | keys_unsorted | join(",")' "${EXPECTED}")"
 expected_shapes="$(IFS=,; echo "${SHAPES[*]}")"
@@ -154,7 +156,7 @@ done < <(jq -r --argjson seedIds "${SEED_IDS}" '
 # ---------------------------------------------------------------------------------------------
 # 2. Non-degeneracy
 # ---------------------------------------------------------------------------------------------
-echo "==> [2/4] non-degeneracy: the expectations still discriminate"
+echo "==> [2/5] non-degeneracy: the expectations still discriminate"
 
 # The analogue of the conformance degeneracy guard. Without it these lists can rot to all-empty,
 # or to every-seed-row, and still pass every diff.
@@ -266,7 +268,7 @@ done < <(jq -r '.shapes | to_entries[] | .key as $s | .value.results | keys[] | 
 # ---------------------------------------------------------------------------------------------
 # 3. PDP pin reuse
 # ---------------------------------------------------------------------------------------------
-echo "==> [3/4] PDP pin: one pin in the repository, reused, and reached at \$CERBOS_HOST"
+echo "==> [3/5] PDP pin: one pin in the repository, reused, and reached at \$CERBOS_HOST"
 
 pinned_version="$(tr -d '[:space:]' <"${REPO_ROOT}/conformance/CERBOS_VERSION")"
 pinned_digest="$(tr -d '[:space:]' <"${REPO_ROOT}/conformance/CERBOS_IMAGE_DIGEST")"
@@ -344,14 +346,215 @@ for adapter in $(jq -r '.adapters[]' "${ACTIONS}"); do
 done
 
 if [[ "${REQUIRE_ALL_EXAMPLES}" == "1" ]]; then
-  echo "==> [4/4] example coverage: enforced"
+  echo "==> [4/5] example coverage: enforced"
   if (( ${#missing[@]} > 0 )); then
     fail "no runnable example/run.sh for: ${missing[*]}"
   fi
 else
-  echo "==> [4/4] example coverage: ${#have[@]}/$(( ${#have[@]} + ${#missing[@]} )) adapters" \
+  echo "==> [4/5] example coverage: ${#have[@]}/$(( ${#have[@]} + ${#missing[@]} )) adapters" \
     "(check disabled until cerbos/query-plan-adapters#360; still missing: ${missing[*]:-none})"
 fi
+
+# ---------------------------------------------------------------------------------------------
+# 5. Principal provenance
+# ---------------------------------------------------------------------------------------------
+echo "==> [5/5] principal provenance: examples read their principal from seeds.json"
+
+# Every example plans for the principals seeds.json declares, and is supposed to look them up
+# there rather than write one out. Nothing said so.
+#
+# Unlike the hardcoded PDP address check 3 catches, a restated principal does NOT fail quietly: it
+# matches what the corpus carries until someone edits seeds.json, and then that example's frozen
+# id lists stop matching and it fails loudly — as an adapter bug rather than as the misinvocation
+# it is. So this is a latency problem, not a correctness hole, and it earns a check only because
+# six more examples are queued (cerbos/query-plan-adapters#349): a rule constraining examples
+# being written is worth more than one added after they exist.
+#
+# What makes it checkable is that a principal is an id AND its roles, and only the roles are
+# unobtainable any other way. An example naming `alice` is fine and unavoidable — it is the
+# lookup key, the expected.json entry key, and the word a printed line uses. An example naming
+# `alice` NEXT TO `user` has restated the corpus record, because roles are what the policy's
+# rules are keyed on and the corpus is the only place they come from.
+#
+# A role that is ALSO a principal id cannot carry that signal, and `admin` is both here. Every
+# example emits `"admin/admin-view": filtered("admin", "admin-view")` two lines from an `alice`,
+# so pairing on it would fail all four; suppressing that pair is not tuning around a false
+# positive, it is that the two readings are genuinely indistinguishable from the literals alone.
+# Note what is and is not dropped: `admin` leaves the ROLE set only. It is still a principal id,
+# so `{ id: "admin", roles: ["user"] }` pairs like any other. The consequence is stated rather
+# than hidden: a restatement of the `admin` principal ALONE, with only its `admin` role, is not
+# caught. Restating the other two is, and an example that looks two principals up in the corpus
+# and writes the third out by hand is not the mistake this exists to stop.
+PRINCIPAL_IDS="$(jq -r '[.principals[].id] | unique | join(",")' "${SEEDS}")"
+PRINCIPAL_ROLES="$(jq -r '([.principals[].roles[]] - [.principals[].id]) | unique | join(",")' \
+  "${SEEDS}")"
+
+# Both derived from seeds.json rather than spelled here, for the same reason check 2 derives the
+# action names from the policy: renaming a principal or a role in the corpus must not leave a
+# stale literal in this script silently guarding nothing.
+#
+# And the corpus can empty that second list — give every principal a role named after a principal
+# and there is nothing left to pair, so the scan below would pass every example vacuously. That is
+# a corpus problem with a corpus fix (one principal holding one role no principal is named after),
+# which is why it fails here rather than being worked around in the scan.
+if [[ -z "${PRINCIPAL_IDS}" || -z "${PRINCIPAL_ROLES}" ]]; then
+  fail "seeds.json must declare a principal, and a role no principal is NAMED after —" \
+    "otherwise every role reads as an id and the scan below guards nothing"
+fi
+
+# Extracts every string literal outside comments, and reports two things per example:
+#
+#   INLINE  a window of consecutive lines carrying a principal id and a role as two distinct
+#           literals — the signature of `{ id: "alice", roles: ["user"] }` in any of the five
+#           languages, however it is wrapped.
+#   CORPUS  whether the example names seeds.json and its principals array in code at all.
+#
+# Comments are skipped rather than scanned, because an id in a comment or a printed line of
+# output is a legitimate mention: spring-data's photo domain documents `?user=alice&role=user` in
+# a Javadoc block and must keep passing unmodified. Only string LITERALS count, and they are
+# matched WHOLE, so that same domain's `new Album("a1", "acme", "alice", …)` rows and
+# `@RequestParam(defaultValue = "user")` defaults stay clear of each other, and a printed
+# `"planning for alice as user"` is one literal matching neither. It is the pairing that means
+# something, not either half.
+#
+# The one shape that reads as a restatement without being one is a diagnostic passing the id and
+# the role as SEPARATE literals — `console.error("principal", "alice", "role", "user")`. Nothing
+# in the literals distinguishes that from building a principal out of them; put both words in the
+# message, or interpolate the id, and it is a whole literal matching neither.
+#
+# And the window cuts the other way too: an id and a role bound to separate variables far enough
+# apart — `const id = "bob"` with `const roles = ["user"]` six lines later — is a restatement this
+# does not see. Widening the window is not the fix, because the shapes block every example emits
+# puts `alice` and `admin` within a few lines of each other and a wide enough window starts
+# reporting those. This catches a principal WRITTEN OUT, which is the mistake a new example makes
+# by copying a literal; it is not a proof that one was not assembled piecewise.
+#
+# One lexer nuance in the same spirit: `#` ends a line, which is right for shell, YAML and Python
+# and wrong for a shell parameter expansion like `${ref##*/}`, where it drops the rest of that
+# line. It costs a finding rather than inventing one, so it stays the simple rule.
+read -r -d '' AWK_PRINCIPALS <<'AWK' || true
+BEGIN {
+  n = split(IDS, a, ",");   for (i = 1; i <= n; i++) isId[a[i]] = 1
+  n = split(ROLES, a, ","); for (i = 1; i <= n; i++) isRole[a[i]] = 1
+}
+
+# Comment state is per file; so is the window, which must not straddle two files.
+FNR == 1 { inBlock = 0; inDoc = 0; head = 1; tail = 0; split("", lit); split("", ln) }
+
+{
+  code = ""
+  i = 1
+  len = length($0)
+  while (i <= len) {
+    if (inBlock) {                                  # inside /* ... */
+      p = index(substr($0, i), "*/")
+      if (p == 0) break
+      i += p + 1; inBlock = 0; continue
+    }
+    if (inDoc) {                                    # inside a Python docstring
+      p = index(substr($0, i), docDelim)
+      if (p == 0) break
+      i += p + 2; inDoc = 0; continue
+    }
+    c = substr($0, i, 1)
+    if (substr($0, i, 3) == "\"\"\"" || substr($0, i, 3) == "'''") {
+      inDoc = 1; docDelim = substr($0, i, 3); i += 3; continue
+    }
+    if (substr($0, i, 2) == "/*") { inBlock = 1; i += 2; continue }
+    if (substr($0, i, 2) == "//" || c == "#") break  # to end of line
+    # A template literal is one literal, not a window onto the quotes inside it: `${a} 'b'` must
+    # not yield `b`, and an apostrophe in interpolated prose must not swallow the rest of the line.
+    if (c == "\"" || c == "'" || c == "`") {
+      q = c; i++; buf = ""
+      while (i <= len) {
+        ch = substr($0, i, 1)
+        if (ch == "\\") { i += 2; continue }
+        if (ch == q) { i++; break }
+        buf = buf ch; i++
+      }
+      tail++; lit[tail] = buf; ln[tail] = FNR
+      code = code " " buf " "                       # a path or key may sit inside the quotes
+      continue
+    }
+    code = code c
+    i++
+  }
+
+  if (code ~ /seeds\.json/) sawSeeds = 1
+  if (code ~ /principals/)  sawPrincipals = 1
+
+  while (head <= tail && ln[head] < FNR - WINDOW + 1) { delete lit[head]; delete ln[head]; head++ }
+
+  # Deduplicated on the MESSAGE, not on the pair of literals that produced it. Every window
+  # holding both halves re-examines the same pair, and one line can hold a literal several times
+  # over — `{ id: "admin", roles: ["admin"], fallback: "admin" }` is three pairs saying one thing.
+  # Keying on the indices deduplicates the wrong one and reports the same sentence three times,
+  # which inflates the failure count the summary line prints.
+  for (x = head; x <= tail; x++) {
+    if (!isId[lit[x]]) continue
+    for (y = head; y <= tail; y++) {
+      if (x == y || !isRole[lit[y]]) continue
+      message = sprintf("INLINE %s:%d: id \"%s\" alongside role \"%s\" (line %d)",
+        FILENAME, ln[x], lit[x], lit[y], ln[y])
+      if (message in seen) continue
+      seen[message] = 1
+      print message
+    }
+  }
+}
+
+END {
+  if (!sawSeeds)      print "CORPUS demo/seeds.json"
+  if (!sawPrincipals) print "CORPUS its principals array"
+}
+AWK
+
+for adapter in $(jq -r '.adapters[]' "${ACTIONS}"); do
+  example_dir="${REPO_ROOT}/${adapter}/example"
+  [[ -d "${example_dir}" ]] || continue
+
+  # Same file set as check 3 and as validate-corpus.sh: things that RUN, never prose, and never
+  # installed or built output. Minus the Cerbos policies, which that set includes as *.yaml.
+  #
+  # A policy is the one file where writing a role out is the POINT — it is what the PDP keys its
+  # rules on, and an example is free to carry policies of its own (spring-data's photo domain
+  # does). Two rules four lines apart, one granting `user` and one granting `admin`, pair exactly
+  # like a restated principal and would be reported as "look it up in demo/seeds.json", which is
+  # meaningless advice for a policy. spring-data's happen to sit ten lines apart, so this is a
+  # trap the next example walks into rather than a failure today.
+  #
+  # Identified by the apiVersion every Cerbos policy declares, not by living under policies/: a
+  # path rule is a carve-out the next adapter has to know about, and ADR 0001 is about not having
+  # those. A file that says what it is gets taken at its word.
+  sources=()
+  while IFS= read -r file; do
+    grep -qE '^[[:space:]]*apiVersion:[[:space:]]*"?api\.cerbos\.dev/' "${file}" && continue
+    sources+=("${file}")
+  done < <(grep -rlE '.' "${SOURCE_INCLUDES[@]}" "${SOURCE_EXCLUDES[@]}" \
+    "${example_dir}" 2>/dev/null || true)
+  if (( ${#sources[@]} == 0 )); then
+    fail "${adapter}/example has no scannable source files — there is nothing here to scan"
+    continue
+  fi
+
+  # A four-line window rather than a single line: prettier and google-java-format both break a
+  # principal literal across its `id:` and `roles:` lines, and a per-line scan would see one half
+  # of it at a time and report neither.
+  while IFS= read -r finding; do
+    case "${finding}" in
+      INLINE\ *)
+        location="${finding#INLINE }"
+        fail "${adapter}/example restates a principal at ${location#"${REPO_ROOT}/"} — look it" \
+          "up in demo/seeds.json instead (demo/README.md)"
+        ;;
+      CORPUS\ *)
+        fail "${adapter}/example never reads ${finding#CORPUS } — its principal must come from" \
+          "demo/seeds.json, not be restated (demo/README.md)"
+        ;;
+    esac
+  done < <(awk -v IDS="${PRINCIPAL_IDS}" -v ROLES="${PRINCIPAL_ROLES}" -v WINDOW=4 \
+    "${AWK_PRINCIPALS}" "${sources[@]}")
+done
 
 if (( failures > 0 )); then
   echo >&2


### PR DESCRIPTION
Closes #404.

**Affected: `demo/` only.** No adapter source, no example source, no CI config. `demo/` re-runs every adapter's example job, so all four examples that exist today (prisma, mongoose, drizzle, spring-data) exercise this.

## Why

`demo/seeds.json` declares the principals every example plans for, and every example is supposed to look its principal up there rather than restate one. All four do. Nothing asserted it — a new example could hardcode `alice` with role `user` and pass every check, because the hardcoded value happens to match what the corpus carries.

Worth being honest about the size of this: unlike the hardcoded PDP address check 3 catches, the failure is **not silent**. A restated principal stays correct right up until someone edits `seeds.json`, at which point that example's frozen id lists stop matching and it fails loudly. So this is a latency problem, not a correctness hole.

The reason to hold it now is timing. Six more examples are queued (#349), and a check that constrains six examples being *written* is worth more than one added after they exist.

## What

Check 5 in `validate-demo.sh`, in the shape of the existing four: no database, no network, scanning the committed example sources with the same file set check 3 and `validate-corpus.sh` share.

**The signal is an id next to a role.** Naming `alice` is unavoidable — it is the lookup key, the `expected.json` entry key, and the word a printed line uses — but naming it alongside `user` restates the corpus record, because roles are what the policy keys its rules on and the corpus is the only place they come from. A second half fails an example that never names `seeds.json` or its `principals` array in code at all.

An example's **own Cerbos policies are skipped**, identified by the `apiVersion` they declare rather than by a path rule (a path carve-out is what ADR 0001 exists to avoid). A policy is the one file where writing a role out is the point, and two rules four lines apart granting `user` and `admin` pair exactly like a restated principal — `spring-data/example/`'s sit ten lines apart, so this was a trap the next example walked into rather than a failure today.

Comments are skipped and string literals matched whole, so an id in prose, in a Javadoc block, or inside a printed message stays clear of it. `spring-data/example/`'s photo domain documents `?user=alice&role=user` and passes untouched, as do its `new Album("a1", "acme", "alice", …)` rows and its `@RequestParam(defaultValue = "user")` defaults. The window is four lines rather than one because prettier and google-java-format both break a principal literal across its `id:` and `roles:` lines.

### Three limits, stated in the script rather than tuned around

- **A role that is also a principal id carries no signal**, and `admin` is both here: every example emits `"admin/admin-view": filtered("admin", "admin-view")` two lines from an `alice`, so pairing on it would fail all four. The two readings are genuinely indistinguishable from the literals alone. `admin` leaves the **role** set only — it is still a principal id, so `{ id: "admin", roles: ["user"] }` pairs like any other. Restating the `admin` principal *alone* is therefore not caught; restating the other two is. A corpus edit that left no role no principal is named after would make the scan vacuous, so that fails loudly instead of passing everything.
- **A diagnostic passing an id and a role as two separate literals** reads as a restatement. The message says so and names the fix.
- **The pairing is windowed**, so an id and a role bound to variables far enough apart are not seen. Widening is not the fix — a wide enough window starts reporting the shapes block. This catches a principal *written out*; it is not a proof that one was not assembled piecewise.

## Verification

The four existing examples pass unmodified, which #404 makes the test of whether the check is right rather than the examples. Verified by mutation rather than by reading the code — 14 probes, all passing:

- **five violation shapes caught** — single-line and multi-line TypeScript principal literals, a restated roles table, and the Java SDK builder taking literals both on one line and wrapped;
- **seven incidental mentions tolerated** — an id and a role in a line comment, a block comment and a Javadoc block; an id in printed output; an id and a role inside one printed message and interpolated into a template literal; an extra fixture label naming the `admin` id;
- **a from-scratch `example/` hardcoding a principal** caught on all three counts (restatement, no `seeds.json`, no `principals`);
- **the six adapters with no `example/`** untouched.

`demo/scripts/validate-demo.sh` and `conformance/scripts/validate-corpus.sh` both pass on the repository as it stands.

### Reviewer notes

- **Portability.** CI's `awk` on `ubuntu-latest` is mawk, not the BSD awk this was written against. The scanner produces byte-identical output under mawk, gawk and original-awk (verified in a container, matching checksums). No bash 4+ constructs.
- **Runtime.** The whole script stays under half a second; 6 source files per TypeScript example, 36 for spring-data.
- **Out of scope, per the issue:** no principal *attribute* guard in `demo/` (the issue rejects it on two grounds), nothing in `conformance/`, no existing example modified, and check 4 stays disabled — enabling it is #360's job.

### Review

Both axes of `/code-review` ran against this branch. Everything they found is fixed in the commit:

- **Duplicate findings** (spec) — dedup keyed on the pair of literal *indices* while the message carries only values and line numbers, so `{ id: "admin", roles: ["admin"], fallback: "admin" }` printed the same sentence three times and inflated the summary's failure count. Now keyed on the message.
- **Example policies tripping the check** (standards) — proven with a fixture, then with `spring-data/example/policies/album.yaml` tightened so its `user` and `admin` rules sit two lines apart. Fixed by skipping self-declared Cerbos policies.
- **A third limit I'd documented as exhaustive without** (spec) — a restatement assembled piecewise across more than the window. Now stated in both the script and the README.
- **Script and README describing the same mechanism in opposite words** (standards) — "the failure is quiet" vs "does not fail quietly". Both now say what the issue says: it fails loudly, just late.

One finding I did not action: the anti-vacuity guard that fails when the corpus leaves no role that isn't also a principal id was read as scope creep onto the corpus. Guards that cannot pass vacuously are this repo's documented house style throughout `conformance/`, so it stays; I did soften the adjacent message that spoke on check 3's behalf.
