### PR TITLE
chore(prisma): update @cerbos/core to 0.33.0 and @cerbos/grpc to 0.29.0

### DIFF
--- a/prisma/example/package-lock.json
+++ b/prisma/example/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cerbos/grpc": "^0.28.0",
+        "@cerbos/grpc": "^0.29.0",
         "@prisma/adapter-better-sqlite3": "^7.5.0",
         "@prisma/client": "^7.5.0"
       },
@@ -23,54 +23,54 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
-      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cerbos/api": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.10.0.tgz",
-      "integrity": "sha512-j+SCITUBsb4MFAml5okmXPAOOR1BVTSNLrsdS/h2v4lEYzNiO27t/zPx+779Fe9SzHOFwPT5bhEUgYdRnHa3UA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-Wk9SrcwI75tWFxk065y95+4gFQKCUD7yd0q+OYbW2we9APeBWkJd0voFh2RbPvk4QR23Sz9ozowsZd4Vwtf90Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.12.1"
+        "@bufbuild/protobuf": "^2.13.0"
       },
       "engines": {
         "node": ">= 22"
       }
     },
     "node_modules/@cerbos/core": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.32.0.tgz",
-      "integrity": "sha512-ZXL4qCDb+NwJmFJlWimQuegHOEIYKan6mZdYy2Jla126p+Esh5H9RNfHBnMQPbPEE35c5ShyS1ENa/wCCFtFMg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.33.0.tgz",
+      "integrity": "sha512-cf7oZlbLY2+p9pkDgpZycv1xZ8ZmPI5pJJgcm0ct4uCut3m1EzRWSBIfkRBIhEKhL3apPuSVQzevH4Pis0f7Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cerbos/api": "^0.10.0",
+        "@cerbos/api": "^0.11.0",
         "uuid": "^14.0.1"
       },
       "engines": {
         "node": ">= 22"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.12.1"
+        "@bufbuild/protobuf": "^2.13.0"
       }
     },
     "node_modules/@cerbos/grpc": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.28.0.tgz",
-      "integrity": "sha512-xfSmizAIYK9wmrCF6xVn94f0cEAGaKafJc+C8sPEfxKAO8suyI7fRK0ETYQ0QRihAUhq8+/i7E7oNJtddSOneg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.29.0.tgz",
+      "integrity": "sha512-qo2D7UPqvGp8+/tp8uIN+lCgVd+LVp8thHaVQa07/gSQ1xI7scvZTsmiA49dV3L40gYkmx+942RVWxoCzyfI0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cerbos/core": "^0.32.0",
+        "@cerbos/core": "^0.33.0",
         "@grpc/grpc-js": "^1.14.4"
       },
       "engines": {
         "node": ">= 22"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.12.1",
-        "@cerbos/api": "^0.10.0"
+        "@bufbuild/protobuf": "^2.13.0",
+        "@cerbos/api": "^0.11.0"
       }
     },
     "node_modules/@electric-sql/pglite": {

--- a/prisma/example/package.json
+++ b/prisma/example/package.json
@@ -10,7 +10,7 @@
   },
   "//": "@cerbos/orm-prisma is deliberately ABSENT from these dependencies. run.sh installs it from `npm pack`'s tarball, whose integrity hash changes on every build and would make a committed lockfile unusable with `npm ci`. The ORM and the SDK ARE pinned here, which is the half Renovate manages: an ORM bump lands as one PR touching both prisma/package.json and this file, and the example job on that PR is what blocks automerge if the new ORM broke real usage.",
   "dependencies": {
-    "@cerbos/grpc": "^0.28.0",
+    "@cerbos/grpc": "^0.29.0",
     "@prisma/adapter-better-sqlite3": "^7.5.0",
     "@prisma/client": "^7.5.0"
   },

--- a/prisma/package-lock.json
+++ b/prisma/package-lock.json
@@ -9,8 +9,8 @@
       "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cerbos/core": "^0.32.0",
-        "@cerbos/grpc": "^0.28.0"
+        "@cerbos/core": "^0.33.0",
+        "@cerbos/grpc": "^0.29.0"
       },
       "devDependencies": {
         "@jest/globals": "^30.2.0",
@@ -549,48 +549,48 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cerbos/api": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.10.0.tgz",
-      "integrity": "sha512-j+SCITUBsb4MFAml5okmXPAOOR1BVTSNLrsdS/h2v4lEYzNiO27t/zPx+779Fe9SzHOFwPT5bhEUgYdRnHa3UA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-Wk9SrcwI75tWFxk065y95+4gFQKCUD7yd0q+OYbW2we9APeBWkJd0voFh2RbPvk4QR23Sz9ozowsZd4Vwtf90Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.12.1"
+        "@bufbuild/protobuf": "^2.13.0"
       },
       "engines": {
         "node": ">= 22"
       }
     },
     "node_modules/@cerbos/core": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.32.0.tgz",
-      "integrity": "sha512-ZXL4qCDb+NwJmFJlWimQuegHOEIYKan6mZdYy2Jla126p+Esh5H9RNfHBnMQPbPEE35c5ShyS1ENa/wCCFtFMg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.33.0.tgz",
+      "integrity": "sha512-cf7oZlbLY2+p9pkDgpZycv1xZ8ZmPI5pJJgcm0ct4uCut3m1EzRWSBIfkRBIhEKhL3apPuSVQzevH4Pis0f7Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cerbos/api": "^0.10.0",
+        "@cerbos/api": "^0.11.0",
         "uuid": "^14.0.1"
       },
       "engines": {
         "node": ">= 22"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.12.1"
+        "@bufbuild/protobuf": "^2.13.0"
       }
     },
     "node_modules/@cerbos/grpc": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.28.0.tgz",
-      "integrity": "sha512-xfSmizAIYK9wmrCF6xVn94f0cEAGaKafJc+C8sPEfxKAO8suyI7fRK0ETYQ0QRihAUhq8+/i7E7oNJtddSOneg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.29.0.tgz",
+      "integrity": "sha512-qo2D7UPqvGp8+/tp8uIN+lCgVd+LVp8thHaVQa07/gSQ1xI7scvZTsmiA49dV3L40gYkmx+942RVWxoCzyfI0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cerbos/core": "^0.32.0",
+        "@cerbos/core": "^0.33.0",
         "@grpc/grpc-js": "^1.14.4"
       },
       "engines": {
         "node": ">= 22"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.12.1",
-        "@cerbos/api": "^0.10.0"
+        "@bufbuild/protobuf": "^2.13.0",
+        "@cerbos/api": "^0.11.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/prisma/package.json
+++ b/prisma/package.json
@@ -80,8 +80,8 @@
     "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
-    "@cerbos/core": "^0.32.0",
-    "@cerbos/grpc": "^0.28.0"
+    "@cerbos/core": "^0.33.0",
+    "@cerbos/grpc": "^0.29.0"
   },
   "overrides": {
     "@prisma/dev": {


### PR DESCRIPTION
## Summary

Updates `@cerbos/orm-prisma`'s Cerbos SDK dependencies to the latest releases:

| Package | From | To |
|---|---|---|
| `@cerbos/core` | `^0.32.0` | `^0.33.0` |
| `@cerbos/grpc` | `^0.28.0` | `^0.29.0` |
| `@cerbos/api` (transitive) | 0.10.0 | 0.11.0 |

**Affected adapter:** prisma only. The other four TypeScript adapters (mongoose, drizzle, convex, langchain-chromadb) are still on `core@^0.32.0` / `grpc@^0.28.0` and are deliberately out of scope here.

## Why both packages move together

`@cerbos/grpc@0.28.0` depends on `@cerbos/core@^0.32.0`. A caret on a `0.x` range pins the minor, so `^0.32.0` will not accept `0.33.0` — bumping core alone resolves **two** copies of core, and the plan-response types the adapter declares stop being the same types `grpc` returns. `@cerbos/grpc@0.29.0` is the release that moves its floor to `^0.33.0`. Verified one deduped copy after the bump:

```
├─┬ @cerbos/core@0.33.0
│ └─┬ @cerbos/api@0.11.0
└─┬ @cerbos/grpc@0.29.0
  └── @cerbos/core@0.33.0 deduped
```

`@cerbos/api` needs no direct entry — no tracked file imports it, and it arrives transitively via core. Core's `@bufbuild/protobuf` **peer** moves `^2.12.1 → ^2.13.0`, already satisfied at 2.13.0.

`example/package.json` carries its own SDK pin (the half Renovate manages) and is bumped to match, with its committed lockfile regenerated so `npm ci` stays valid.

## Is anything consumer-visible?

No. `@cerbos/core@0.33.0` adds multi-JWT `AuxData` support, changing `AuxData` and `DecodedAuxData` from interfaces to unions. The adapter touches neither — `src/index.ts` imports `PlanKind` (re-exported) plus `PlanResourcesResponse`, `PlanExpressionOperand` and `Value`, none of which changed between 0.32.0 and 0.33.0. No change to what the adapter can translate, so no `conformance/actions.json` or README contract-table edit is required.

## Verification

All green, no source or expectation changes (the diff is 4 manifest/lockfile files):

| Check | Result |
|---|---|
| `npm run build` | pass |
| `npm run typecheck` (v7 + v6) | pass |
| `npm test` (translator unit test) | 226/226 |
| `npm run test:adversarial` (SQLite, Prisma v7) | 211/211 |
| `npm run test:adversarial` (SQLite, Prisma v6) | 211/211 |
| `npm run test:adversarial:postgres` (Prisma v7) | 211/211 |
| `demo/scripts/run-example.sh prisma` | matched `demo/expected.json` across 5 usage shapes |
| `conformance/scripts/validate-corpus.sh` | 199 actions, 21 seeds |

## Reproducing locally

The adversarial suite needs the PDP pinned in `conformance/CERBOS_VERSION` — **v0.54.0**. The `test:adversarial*` scripts shell out to whatever `cerbos` CLI is on `PATH` (CI installs the pinned one via `cerbos-setup-action`), so a newer local CLI silently runs the corpus against the wrong PDP. On a v24.18.1 CLI, four `nan-ord-*` actions and the null-literal rejection check fail with `google.protobuf.Value cannot be NaN or Infinity`. That failure reproduces identically on `core@0.32.0`, so it is a local-PDP artifact and not related to this change — but it costs time to rediscover.

Docker is also required for the PostgreSQL leg (testcontainers) and the example (`demo/docker-compose.yml`).

## Versioning

No version bump in this PR, following the precedent for dependency updates (490f42e). See the release note on the PR thread.
