### PR TITLE
feat(convex): example application for the shared demo domain

### DIFF
--- a/.github/workflows/convex.yaml
+++ b/.github/workflows/convex.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "convex/**"
       - "conformance/**"
+      - "demo/**"
       - ".github/workflows/convex.yaml"
       - ".github/workflows/convex-publish.yaml"
   push:
@@ -118,3 +119,47 @@ jobs:
       - name: Stop Convex backend
         if: always()
         run: docker compose down -v
+
+  # The example application: the published package, installed from `npm pack`'s tarball and used
+  # the way a consumer uses it, against the shared demo domain. It covers the two things the jobs
+  # above structurally cannot — the packaging surface (`exports`, `types`, the `files` allowlist,
+  # the `@cerbos/core` peer range), which every harness bypasses by importing from `"."`, and the
+  # usage shapes past a single flat query (pagination, and composing the adapter's filter with the
+  # application's own). See cerbos/query-plan-adapters#349 and
+  # docs/adr/0002-examples-install-the-packed-artifact.md.
+  #
+  # THIS JOB MUST STAY IN THIS WORKFLOW. `renovate.json` sets `automerge: true` for every
+  # non-major bump, and that is the path a Convex regression takes into `main` today. Because the
+  # example's lockfile is committed and Renovate manages it, a Convex bump arrives as ONE PR
+  # touching both convex/package.json and convex/example/package.json — and this job, being a
+  # check on that PR, is what blocks the automerge when the new Convex breaks real usage. Moving it
+  # to a nightly run or a workflow of its own silently restores that gap.
+  #
+  # One Node leg only: the demo domain discriminates the package and the ORM, not the runtime —
+  # the same reasoning that keeps the adversarial corpus on a single leg above.
+  #
+  # No Convex backend is started here, unlike `integration-test`: the example's own run.sh starts
+  # one, on 13210 rather than 3210, because a consumer's deployment is part of what it proves.
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate conformance corpus
+        run: ../conformance/scripts/validate-corpus.sh
+
+      - name: Validate demo domain
+        run: ../demo/scripts/validate-demo.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - run: npm install
+
+      # The PDP is a container started by the runner from demo/docker-compose.yml, pinned to
+      # conformance/CERBOS_VERSION and conformance/CERBOS_IMAGE_DIGEST — no cerbos-setup-action
+      # here, because an example must reach the PDP the way a deployed application does.
+      - name: Run the example against the demo domain
+        run: ../demo/scripts/run-example.sh convex

--- a/convex/README.md
+++ b/convex/README.md
@@ -179,6 +179,23 @@ This adapter **builds no subquery.** Convex has no joins, so the mapper resolves
 | Composite association key | Not applicable — no join, so no key to compose | — |
 | Absent to-one parent | **Reproduced**, and proved by the corpus (`w1-all-chain`, `rel-not-bool-hop` and siblings) | None — the post-filter evaluates a missing path as a CEL error, which denies, so an absent parent is excluded under both polarities rather than reading as an empty collection ([#309](https://github.com/cerbos/query-plan-adapters/issues/309), [#375](https://github.com/cerbos/query-plan-adapters/issues/375)). **Behaviour change in #375:** a BARE variable in boolean position was pushed to Convex's filter engine regardless of `nullable`, and the engine cannot tell an absent path from a false one, so a negation over one readmitted every row missing that path. A `nullable` bare variable is now answered by the adapter's own evaluator instead — correct rows, and one more shape scanned rather than indexed |
 
+## Example application
+
+This repository carries a runnable [`example/`](example/), which installs the adapter from the
+artifact `npm publish` would upload and exercises it against a live PDP over the shared
+[demo domain](../demo/README.md):
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh convex
+```
+
+Unlike the test suites, it resolves the adapter through its **published** surface — the `exports`
+map, `types`, the `files` allowlist, and the `@cerbos/core` peer range — and covers usage shapes
+past a single flat query: `.paginate()` on top of the filter, and the adapter's filter composed
+with an application-owned filter. It is also the one place a plan makes the round trip a Convex
+consumer's plan actually makes, JSON-encoded into the backend and back out again.
+
 ## Testing
 
 | Command | What it proves | What it needs |

--- a/convex/example/.gitignore
+++ b/convex/example/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+lib
+tsconfig.tsbuildinfo
+# Written by `npx convex deploy`, from the schema and functions in convex/. Generated output, like
+# a Prisma client: never committed, and run.sh regenerates it on every run.
+convex/_generated/
+.env.local
+# The adapter tarball `run.sh` builds and installs. Regenerated on every run; never committed.
+cerbos-orm-convex-*.tgz

--- a/convex/example/README.md
+++ b/convex/example/README.md
@@ -1,0 +1,207 @@
+# `@cerbos/orm-convex` example application
+
+A runnable program that installs the adapter **as a published package** and uses it the way a
+consumer would, against the shared [demo domain](../../demo/README.md).
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh convex
+```
+
+Needs `docker` (with compose), `jq`, `curl` and Node 22+. The runner starts the pinned Cerbos PDP;
+this directory's `run.sh` starts a Convex backend, packs the adapter, installs the tarball, deploys
+the functions, builds the client, and runs it.
+
+It follows [`prisma/example/`](../../prisma/example/), which is the reference implementation.
+
+## What it proves
+
+Not what the adapter translates — [`../src/adversarial.test.ts`](../src/adversarial.test.ts)
+proves that against a hostile corpus with a live PDP as the oracle, inside a real Convex backend.
+This proves the two things that harness structurally cannot:
+
+**Packaging.** `run.sh` builds the artifact `npm publish` would upload and installs *that*, so the
+adapter resolves through the published surface — the `exports` map, `types`, the `files` allowlist,
+and the `@cerbos/core` peer range against the copy this example declares. The harness imports from
+`"."` and touches none of it. See
+[ADR 0002](../../docs/adr/0002-examples-install-the-packed-artifact.md).
+
+Two independent resolvers read that surface here, which is a Convex property rather than a
+belt-and-braces choice — the adapter runs in the backend and the client only talks to it:
+
+| Resolver | Reads | Where |
+| --- | --- | --- |
+| Convex's bundler and its `tsc`, under `moduleResolution: "Bundler"` | `exports`, `types`, `files` | [`convex/documents.ts`](convex/documents.ts), at `npx convex deploy` |
+| `tsc` under `moduleResolution: "nodenext"` | `exports`, `types` | [`src/main.ts`](src/main.ts), at `npm run build` |
+
+Both halves are load-bearing and both have been checked by breaking them. The bundler runs first,
+so it is what reports either break; the third column is what the client compile would have said,
+and it is the row where the two resolvers differ:
+
+| Break                                   | `npx convex deploy`                                | `npm run build` (client) | `npm test`  |
+| --------------------------------------- | -------------------------------------------------- | ------------------------ | ----------- |
+| `exports["."]` points at a missing file  | fails — `The module "./lib/missing.js" was not found on the file system` | fails (TS2307) | 457 passing |
+| `lib/**/*.js` dropped from `files`       | fails — `The module "./lib/index.js" was not found on the file system`   | **passes** — the `.d.ts` files are still shipped, so the types resolve and only the bundle does not | 457 passing |
+
+That second row is why the deploy is not redundant with the client compile: a `files` allowlist can
+ship every type declaration and no implementation, and only something that has to *execute* the
+package notices.
+
+`tsconfig.json` sets `moduleResolution: "nodenext"` for the first row specifically: the legacy
+`node10` resolver ignores `exports` entirely and falls back to `main`/`types`, so a broken
+`exports` map would compile clean here and only fail for a consumer.
+
+`run.sh` deletes `lib/` and `tsconfig.tsbuildinfo` before compiling for the same row. `tsc --build`
+is incremental and keys its state on this example's own sources, which do not change when the
+adapter's packaging does. CI is always cold; the tree where someone checks the break by hand is
+not.
+
+**Usage shape.** A harness runs one flat filtered query. This runs all
+[five shapes](../../demo/README.md#the-five-usage-shapes), including pagination and — the one that
+earns the exercise — the adapter's filter ANDed with the application's own predicate, across all
+three plan kinds.
+
+## Layout
+
+| Path                     | What it is                                                          |
+| ------------------------ | ------------------------------------------------------------------- |
+| `run.sh`                 | backend up → pack → install → deploy → compile cold → run. Prints the JSON document on stdout. |
+| `src/main.ts`            | The client: plans against the PDP, seeds, walks the shapes, prints the document. |
+| `convex/documents.ts`    | The backend: where the adapter runs, beside `ctx.db`.               |
+| `convex/schema.ts`       | The demo domain's one table, as a consumer would model it: flat scalar fields, no relations. |
+| `package.json`           | The ORM, the SDK and the `@cerbos/core` peer, all pins Renovate manages. |
+| `package-lock.json`      | Committed. See below.                                               |
+
+## Why this example has two halves
+
+Every other TypeScript example calls its adapter in the process it runs in. This one cannot, and
+not by preference: `queryPlanToConvex` returns a **function of Convex's `FilterBuilder`**, and the
+only place that builder exists is inside a Convex query. So the plan travels to the backend and the
+adapter runs there — `src/main.ts` plans, seeds and reports; `convex/documents.ts` translates and
+queries.
+
+That shape has three consequences a consumer meets on day one, and this example meets all three.
+
+**The plan is serialized on the way in.** `@cerbos/core` builds a plan out of `PlanExpression`
+class instances, and Convex's argument encoder rejects a class instance outright:
+
+```
+Error: PlanExpression {"operator":"or",…} is not a supported Convex type
+```
+
+So `src/main.ts` round-trips the plan through JSON, and the backend receives the same tree with the
+prototypes gone. Which is exactly why the adapter classifies operands by their shape rather than
+with `instanceof`: an `instanceof` check could not survive this crossing on *any* consumer's
+machine ([#419](https://github.com/cerbos/query-plan-adapters/issues/419)).
+
+**The plan kind comes back as a bare string.** A Convex function's return value is data, so the
+`PlanKind` the adapter reported arrives with nothing left of its type. `src/main.ts` re-narrows it
+against the adapter's own re-exported `PlanKind` — which is also what makes that reported kind the
+adapter's answer rather than the plan kind the client already had in hand.
+
+**These queries are `query`, and yours should be `internalQuery`.** The example's client is an
+outside process, so it needs public functions to call. A real application calls Cerbos from trusted
+code and passes the plan to an `internalQuery`: anyone who can hand you a plan can hand you an
+`ALWAYS_ALLOWED` one. See the adapter README's "Trusted usage pattern".
+
+## Three things that look odd and are not
+
+**`@cerbos/orm-convex` is not in `package.json`.** `npm pack`'s tarball gets a fresh integrity hash
+on every build, so a committed lockfile naming it would break `npm ci` the moment the adapter
+changed. `run.sh` runs `npm ci` for the pinned tree and then installs the tarball on top with
+`--no-save --no-package-lock`, which leaves both manifests exactly as committed while still
+resolving the adapter and its peers the way a consumer's install does.
+
+**`@cerbos/core` *is* in `package.json`,** even though neither half imports much from it. It is the
+adapter's peer dependency — the copy of the query-plan types the Cerbos client and the adapter have
+to share — and `npm install @cerbos/orm-convex @cerbos/core` is what the adapter's README tells a
+consumer to run. npm 7+ would install the missing peer on its own; pnpm and Yarn would not, so
+declaring it is what a real consumer does.
+
+**The lockfile is committed anyway,** because it is what makes the CI job load-bearing.
+`renovate.json` automerges every non-major bump, so a Convex bump arrives as one PR touching both
+`convex/package.json` and this file — and the `example` job on that PR is what blocks the automerge
+when the new Convex breaks real usage. That only works while the job stays in
+[`.github/workflows/convex.yaml`](../../.github/workflows/convex.yaml); there is a comment on the
+job saying so.
+
+## The mapper
+
+Cerbos attribute paths are not document field names, so a consumer always writes one of these:
+
+```ts
+const MAPPER: Mapper = {
+  "request.resource.attr.ownerId": { field: "ownerId" },
+  "request.resource.attr.public": { field: "public" },
+};
+```
+
+Leaving it out does not throw here — it silently returns nothing. Convex reads a dotted field name
+as a path *into* the document, so an unmapped `request.resource.attr.ownerId` becomes a lookup for
+a `request` field that no document has, and an absent path is not an error to the filter engine.
+That is worth seeing in an example.
+
+`region` and `archived` are deliberately absent from the mapper: they are the application's own
+fields, never referenced by [`demo/policies/document.yaml`](../../demo/policies/document.yaml), and
+composing them with the adapter's filter is shape 5.
+
+## Shape 4 is `.paginate()`
+
+Convex has no filtered count, which is why count is not one of the five shapes. `convex/documents.ts`
+applies `.filter()` and then `.paginate()`, so a page holds `numItems` documents the adapter
+**allowed** rather than `numItems` documents of which some are then dropped, and the client walks
+the cursor. Pages are asserted by their sizes and by the sorted union of their ids, never by
+per-page order — `demo/expected.json` is shared by every store and several of them have no total
+order to paginate by.
+
+`isDone` is the only end condition the client accepts. A filtered `.paginate()` walks the table
+under a read budget, so a page shorter than `numItems` is not the end and an empty one is not
+either; treating either as terminal would truncate the union quietly. The loop is bounded by the
+seed-row count instead, so a cursor that never reports itself done fails the run rather than
+hanging it.
+
+## Shape 5 is one `.filter()` call
+
+Convex takes a single predicate, so composing means building both halves inside it:
+
+```ts
+return (q) => q.and(
+  adapterFilter(q),                               // KIND_CONDITIONAL: the adapter's filter
+  q.eq(q.field("archived"), application.archived), // the application's own predicate,
+  q.eq(q.field("region"), application.region),     // declared in demo/seeds.json
+);
+```
+
+Both halves are optional and the two absences mean different things. `KIND_ALWAYS_ALLOWED` has no
+adapter filter, so the application's predicate stands alone. `KIND_ALWAYS_DENIED` never reaches the
+composition at all — the query returns before a predicate is built, because a denial ANDed with
+anything is still a denial and it must not be reachable through that path.
+
+## Ports
+
+The Convex backend runs on **13210/13211**, not Convex's default 3210/3211, and the PDP on
+13592/13593. Those defaults are what `npm run convex:up` and every adapter's `cerbos run` test
+sidecar bind, and a demo container holding one of them would not fail — it would let this example
+deploy over the functions a conformance run is using, or plan against the conformance corpus while
+diffing against the demo expectations. Both are reached through the environment (`$CONVEX_URL`,
+`$CERBOS_HOST`) with no fallback, so neither number is written down twice and neither can be
+defaulted into.
+
+The backend is started from [`../docker-compose.yml`](../docker-compose.yml) — the adapter's own
+file, with the ports overridden — rather than a copy, so the image pin stays in one place.
+
+## Scope
+
+This example is a JSON-printing CLI, not an onboarding artifact — that is
+[`spring-data/example/`](../../spring-data/example/), and the floor/ceiling rule in
+[ADR 0001](../../docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md) is why both exist.
+
+It uses `makeFunctionReference` rather than the generated `api` object: `convex/_generated/` is
+written by a deploy and is not committed, and it is ESM while this client compiles to CommonJS. A
+Convex application that ships its own `_generated` would use `api` instead — the reference is the
+same value either way.
+
+It does **not** prove `allowPostFilter`. Every shape in the demo domain is a flat comparison
+Convex's filter engine evaluates itself, so the adapter is called at its default of `false` and a
+post-filter appearing at all would fail the run. Post-filter semantics are the conformance corpus's
+job, and it carries them.

--- a/convex/example/convex/documents.ts
+++ b/convex/example/convex/documents.ts
@@ -1,0 +1,182 @@
+/**
+ * The trusted-backend half of the example: the Convex functions the CLI in ../src/main.ts calls.
+ *
+ * Convex is the one adapter whose filter cannot be applied by the caller. `queryPlanToConvex`
+ * returns a FUNCTION of Convex's own `FilterBuilder`, and the only place that builder exists is
+ * inside a Convex query — so the plan crosses the wire and the adapter runs in here, beside
+ * `ctx.db`. That is also what makes this file the packaging proof: `npx convex deploy` bundles
+ * `@cerbos/orm-convex` out of node_modules, where run.sh installed the artifact `npm publish`
+ * would upload, resolving it through the published `exports` map and `files` allowlist.
+ *
+ * The plan arrives as `v.any()` and is cast, exactly as the adapter's README's "Trusted usage
+ * pattern" shows: this argument must be the response Cerbos returned. Note what the crossing
+ * costs — @cerbos/core builds a plan out of `PlanExpression` class instances, and Convex's
+ * argument encoding keeps the fields and drops the prototypes. The adapter classifies operands by
+ * shape rather than with `instanceof`, which is why that survives (cerbos/query-plan-adapters#419).
+ *
+ * These are PUBLIC queries because the example's client is an outside process. A real application
+ * makes them `internalQuery` and calls them from trusted backend code — an untrusted caller who
+ * can hand you a plan can hand you an ALWAYS_ALLOWED one. See the adapter README's "Trusted usage
+ * pattern".
+ */
+import type { PlanResourcesResponse } from "@cerbos/core";
+import { PlanKind, queryPlanToConvex, type Mapper } from "@cerbos/orm-convex";
+import {
+  paginationOptsValidator,
+  type Expression,
+  type FilterBuilder,
+  type Query,
+} from "convex/server";
+import { v, type Infer } from "convex/values";
+
+import type { DataModel } from "./_generated/dataModel";
+import { mutation, query } from "./_generated/server";
+import { documentFields } from "./schema";
+
+type Documents = DataModel["documents"];
+/** What `queryPlanToConvex` hands back, and what `.filter()` takes: a function of the builder. */
+type Predicate = (q: FilterBuilder<Documents>) => Expression<boolean>;
+
+/**
+ * The one piece of configuration a Convex consumer must not skip. A Cerbos plan names its
+ * operands `request.resource.attr.ownerId`; a Convex document field is `ownerId`, and Convex reads
+ * a dotted field name as a path INTO the document. Without this mapper the filter would ask each
+ * document for `request.resource.attr.ownerId`, find nothing there, and return no rows at all —
+ * quietly, because an absent path is not an error to the filter engine.
+ *
+ * `region` and `archived` are deliberately absent: they are the application's own fields, never
+ * referenced by demo/policies/document.yaml, and composing them with the adapter's filter is
+ * shape 5.
+ */
+const MAPPER: Mapper = {
+  "request.resource.attr.ownerId": { field: "ownerId" },
+  "request.resource.attr.public": { field: "public" },
+};
+
+/** The application's OWN predicate, passed in by the application. Declared in demo/seeds.json. */
+const applicationFilterValidator = v.object({
+  archived: v.boolean(),
+  region: v.string(),
+});
+type ApplicationFilter = Infer<typeof applicationFilterValidator>;
+
+/**
+ * `allowPostFilter` is left at its default of `false` on purpose. Every shape in
+ * demo/policies/document.yaml is a flat comparison Convex's filter engine evaluates itself, so a
+ * postFilter appearing here would mean the demo domain had grown a shape the engine cannot
+ * express — and the adapter throwing is how that should arrive, rather than as documents read
+ * before the whole authorization predicate has run.
+ */
+const translate = (queryPlan: unknown) =>
+  queryPlanToConvex<FilterBuilder<Documents>, Expression<boolean>>({
+    queryPlan: queryPlan as PlanResourcesResponse,
+    mapper: MAPPER,
+  });
+
+/**
+ * Usage shape 5, and the reason this example is worth running: the adapter's filter and the
+ * application's own predicate, ANDed into the single `.filter()` call Convex allows.
+ *
+ * Both halves are optional and the two absences mean different things. No adapter filter is
+ * KIND_ALWAYS_ALLOWED — nothing to AND with, so the application's predicate stands alone. No
+ * application predicate is shape 1, the plain filtered list. Neither is KIND_ALWAYS_DENIED, which
+ * never reaches here: `list` returns before building a predicate, because a denial ANDed with
+ * anything is still a denial and it must not be reachable through this function at all.
+ */
+const compose = (
+  filter: Predicate | undefined,
+  application: ApplicationFilter | undefined,
+): Predicate | undefined => {
+  if (!filter && !application) return undefined;
+  return (q) => {
+    const clauses: Expression<boolean>[] = [];
+    if (filter) clauses.push(filter(q));
+    if (application) {
+      clauses.push(q.eq(q.field("archived"), application.archived));
+      clauses.push(q.eq(q.field("region"), application.region));
+    }
+    const [only] = clauses;
+    return clauses.length === 1 && only ? only : q.and(...clauses);
+  };
+};
+
+/**
+ * `.filter()` if there is a predicate, and the unfiltered query if there is not.
+ * `KIND_ALWAYS_ALLOWED` is the second case and it must return every document, not none.
+ */
+const withPredicate = (
+  documents: Query<Documents>,
+  predicate: Predicate | undefined,
+): Query<Documents> => (predicate ? documents.filter(predicate) : documents);
+
+/** Replaces the table contents with demo/seeds.json. The client owns the rows; this stores them. */
+export const seed = mutation({
+  args: { documents: v.array(v.object(documentFields)) },
+  handler: async (ctx, args) => {
+    for (const stored of await ctx.db.query("documents").collect()) {
+      await ctx.db.delete(stored._id);
+    }
+    for (const document of args.documents) {
+      await ctx.db.insert("documents", document);
+    }
+  },
+});
+
+/**
+ * Usage shapes 1, 2, 3 and 5: the whole answer in one call. `applicationFilter` is what separates
+ * shape 5 from shape 1 — the same plan, composed with a predicate the policy never mentions.
+ *
+ * The plan `kind` is reported from the TRANSLATED result rather than from the plan the client
+ * already holds, so the ids and the kind come from the same call and an example that never
+ * reached the adapter cannot report one of them.
+ */
+export const list = query({
+  args: {
+    queryPlan: v.any(),
+    applicationFilter: v.optional(applicationFilterValidator),
+  },
+  handler: async (ctx, args) => {
+    const { kind, filter } = translate(args.queryPlan);
+    // Short-circuited before any predicate is built: the application's predicate must not be able
+    // to turn a denial into a query that returns rows.
+    if (kind === PlanKind.ALWAYS_DENIED) return { kind, ids: [] as string[] };
+
+    const documents = await withPredicate(
+      ctx.db.query("documents"),
+      compose(filter, args.applicationFilter),
+    ).collect();
+    return { kind, ids: documents.map((document) => document.id).sort() };
+  },
+});
+
+/**
+ * Usage shape 4: one page of the filtered answer. Convex has no filtered count, which is why
+ * count is not one of the five shapes and why this is `.paginate()`.
+ *
+ * `.filter()` is applied by the query engine as it walks the table, so a page holds `numItems`
+ * documents the adapter ALLOWED rather than `numItems` documents of which some are then dropped.
+ * The client walks the cursor and asserts page sizes plus the sorted union.
+ */
+export const page = query({
+  args: { queryPlan: v.any(), paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    const { kind, filter } = translate(args.queryPlan);
+    if (kind === PlanKind.ALWAYS_DENIED) {
+      return { kind, ids: [] as string[], isDone: true, cursor: null };
+    }
+
+    // The adapter's filter alone: shape 4 pages over the adapter's answer, not over a composed
+    // one. `compose` is not called here, because with nothing to compose it would only re-wrap
+    // this same predicate.
+    const result = await withPredicate(
+      ctx.db.query("documents"),
+      filter,
+    ).paginate(args.paginationOpts);
+    return {
+      kind,
+      ids: result.page.map((document) => document.id).sort(),
+      isDone: result.isDone,
+      cursor: result.continueCursor,
+    };
+  },
+});

--- a/convex/example/convex/schema.ts
+++ b/convex/example/convex/schema.ts
@@ -1,0 +1,30 @@
+/**
+ * The demo domain's single resource kind, as a Convex consumer would model it: one table of flat
+ * scalar fields and no relations. The richer schema the adapter is PROVED against lives in
+ * ../../convex/schema.ts.
+ *
+ * `id` is the demo domain's own identifier and is not Convex's `_id`. Every example reports the
+ * ids in demo/seeds.json, and a Convex document id is minted by the backend on insert — so the
+ * two cannot be the same field, and the filter shapes below read the one the corpus names.
+ */
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * Exported because `documents.ts` validates the seeding mutation's argument against the same
+ * fields. One declaration: a table and a mutation that disagreed about a field would fail at the
+ * schema check on insert, which is late and reads as a seeding bug.
+ */
+export const documentFields = {
+  id: v.string(),
+  ownerId: v.string(),
+  public: v.boolean(),
+  // Never referenced by policy. `region` and `archived` are the application's own fields, and
+  // ANDing them with the adapter's filter is usage shape 5.
+  region: v.string(),
+  archived: v.boolean(),
+};
+
+export default defineSchema({
+  documents: defineTable(documentFields),
+});

--- a/convex/example/convex/tsconfig.json
+++ b/convex/example/convex/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  // The BACKEND half: the functions `npx convex deploy` bundles and pushes. Convex reads this when
+  // it type-checks the push, which is where a broken `exports` map on @cerbos/orm-convex would
+  // surface — `Bundler` resolution reads `exports` just as the `nodenext` in ../tsconfig.json does.
+  //
+  // Kept exactly as Convex generates it for a new project, and identical to the adapter's own
+  // ../../convex/tsconfig.json. `jsx`, the `dom` lib and `allowJs` are unused by these two files;
+  // trimming them would make this the one Convex project in the repository whose compiler options
+  // someone has to reason about, to save nothing.
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/convex/example/package-lock.json
+++ b/convex/example/package-lock.json
@@ -1,0 +1,959 @@
+{
+  "name": "cerbos-orm-convex-example",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cerbos-orm-convex-example",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/core": "^0.33.0",
+        "@cerbos/grpc": "^0.29.0",
+        "convex": "^1.21.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cerbos/api": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-Wk9SrcwI75tWFxk065y95+4gFQKCUD7yd0q+OYbW2we9APeBWkJd0voFh2RbPvk4QR23Sz9ozowsZd4Vwtf90Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.13.0"
+      },
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@cerbos/core": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.33.0.tgz",
+      "integrity": "sha512-cf7oZlbLY2+p9pkDgpZycv1xZ8ZmPI5pJJgcm0ct4uCut3m1EzRWSBIfkRBIhEKhL3apPuSVQzevH4Pis0f7Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/api": "^0.11.0",
+        "uuid": "^14.0.1"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.13.0"
+      }
+    },
+    "node_modules/@cerbos/grpc": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.29.0.tgz",
+      "integrity": "sha512-qo2D7UPqvGp8+/tp8uIN+lCgVd+LVp8thHaVQa07/gSQ1xI7scvZTsmiA49dV3L40gYkmx+942RVWxoCzyfI0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/core": "^0.33.0",
+        "@grpc/grpc-js": "^1.14.4"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.13.0",
+        "@cerbos/api": "^0.11.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/convex": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.44.0.tgz",
+      "integrity": "sha512-84bBa1ufSX4qohXdycXuQl2c2kAmfVpTCpypcmIgxpS5rUBgv5qjhArYugTkJVbljMs5SH2mW30bjJo+SQwe1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esbuild": "0.27.0",
+        "prettier": "^3.0.0",
+        "ws": "8.21.0"
+      },
+      "bin": {
+        "convex": "bin/main.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@auth0/auth0-react": "^2.0.1",
+        "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.4.3",
+        "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@auth0/auth0-react": {
+          "optional": true
+        },
+        "@clerk/clerk-react": {
+          "optional": true
+        },
+        "@clerk/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/convex/example/package.json
+++ b/convex/example/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cerbos-orm-convex-example",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example application for @cerbos/orm-convex, run against the shared demo domain",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsc --build",
+    "start": "node lib/main.js"
+  },
+  "//": "@cerbos/orm-convex is deliberately ABSENT from these dependencies. run.sh installs it from `npm pack`'s tarball, whose integrity hash changes on every build and would make a committed lockfile unusable with `npm ci`. The ORM and the SDK ARE pinned here, which is the half Renovate manages: a Convex bump lands as one PR touching both convex/package.json and this file, and the example job on that PR is what blocks automerge if the new Convex broke real usage.",
+  "//peer": "@cerbos/core is declared because the adapter declares it as a PEER dependency, not because this example imports it directly — it is the copy of the query-plan types the Cerbos client and the adapter have to share, and the adapter's README tells a consumer to `npm install @cerbos/orm-convex @cerbos/core` for exactly that reason. npm 7+ would install the missing peer on its own; pnpm and Yarn would not, so a consumer declares it and so does this. @cerbos/grpc pulls core ^0.33.0, so one copy resolves rather than two.",
+  "dependencies": {
+    "@cerbos/core": "^0.33.0",
+    "@cerbos/grpc": "^0.29.0",
+    "convex": "^1.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^6.0.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/convex/example/run.sh
+++ b/convex/example/run.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# The convex half of `demo/scripts/run-example.sh convex`: start the backend, pack the adapter,
+# install THAT, deploy the functions against it, build the client, run it. The PDP is already up
+# and reachable at $CERBOS_HOST — the shared runner owns it.
+#
+# The Convex backend is this script's job rather than the runner's. demo/docker-compose.yml holds
+# the one thing every example genuinely shares, and nearly every store is somebody else's; putting
+# them there would grow it into the language switch the split exists to avoid. Starting it here is
+# also what keeps `demo/scripts/run-example.sh convex` a single command on a laptop.
+#
+# It is started from the ADAPTER's compose file rather than a copy, so the backend this example
+# proves the packaging against is the one the adapter is developed and tested against, and the
+# image pin — tag AND digest, which conformance/scripts/validate-corpus.sh asserts on every service
+# image in the repository — stays in one place. The ports are the one thing overridden.
+#
+# Everything this script prints for a human goes to stderr. stdout carries exactly one JSON
+# document, which the shared runner diffs against demo/expected.json.
+
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_DIR="$(cd "${EXAMPLE_DIR}/.." && pwd)"
+
+# 13210/13211, not Convex's default 3210/3211: those are the ports `npm run convex:up` and the
+# adapter's own CI bind, and a demo backend holding them would let this example deploy over the
+# functions a conformance run is using — and read its data. demo/docker-compose.yml publishes the
+# PDP on 13592/13593 for exactly the same reason. src/main.ts reaches this through $CONVEX_URL, so
+# neither number is written down twice.
+CONVEX_PORT=13210
+CONVEX_SITE_PROXY_PORT=13211
+CONVEX_URL="http://127.0.0.1:${CONVEX_PORT}"
+
+# `PORT` and `SITE_PROXY_PORT` are the names ../docker-compose.yml interpolates, and they are set
+# for compose alone rather than exported: `PORT` is a variable half the Node ecosystem reads, and
+# an exported one would reach `npm ci`, the Convex CLI and the example itself.
+#
+# The project name must NOT be `cerbos-demo-convex`: that is the one demo/scripts/run-example.sh
+# gives the PDP it started, and a `compose down` here would be scoped to the same project and take
+# that PDP with it — the example would then fail with ECONNREFUSED against $CERBOS_HOST and read
+# as a broken adapter rather than as two compose files sharing a namespace.
+COMPOSE=(
+  env "PORT=${CONVEX_PORT}" "SITE_PROXY_PORT=${CONVEX_SITE_PROXY_PORT}"
+  docker compose -f "${ADAPTER_DIR}/docker-compose.yml" -p cerbos-demo-convex-backend
+)
+
+cd "${EXAMPLE_DIR}"
+rm -f cerbos-orm-convex-*.tgz
+
+cleanup() {
+  local status=$?
+  if (( status != 0 )); then
+    echo "==> convex example failed (exit ${status}): Convex backend logs" >&2
+    "${COMPOSE[@]}" logs --no-color backend >&2 2>/dev/null || true
+  fi
+  # `-v` because the backend's state is a named volume: a run that left the demo documents behind
+  # would seed on top of them, and the next run's counts would depend on the previous one.
+  "${COMPOSE[@]}" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+# 1. Start the backend. First, so it warms up while the adapter is packed and installed — the
+#    readiness wait below is what actually gates the deploy, not this line.
+echo "==> starting the Convex backend on ${CONVEX_PORT}" >&2
+"${COMPOSE[@]}" down -v >/dev/null 2>&1 || true
+"${COMPOSE[@]}" up -d >&2
+
+# 2. Build and pack the adapter into the artifact npm would publish.
+echo "==> packing @cerbos/orm-convex" >&2
+(cd "${ADAPTER_DIR}" && npm run build) >&2
+TARBALL="$(cd "${ADAPTER_DIR}" && npm pack --silent --pack-destination "${EXAMPLE_DIR}")"
+echo "==> packed ${TARBALL}" >&2
+
+# 3. Install the example's own pinned tree from the committed lockfile, then the tarball on top.
+#
+# The tarball is NOT a package.json dependency and NOT in the lockfile: its integrity hash changes
+# on every build, which would make `npm ci` fail on a lockfile that was correct when committed.
+# `--no-save --no-package-lock` keeps both files exactly as committed while still resolving the
+# adapter — and its `@cerbos/core` peer range against the copy this example declares — the way a
+# consumer's install would.
+echo "==> npm ci" >&2
+npm ci >&2
+echo "==> installing the packed adapter" >&2
+npm install --no-save --no-package-lock "./${TARBALL}" >&2
+
+# 4. Wait for the backend. Deliberately after the install: the container has been starting
+#    underneath steps 2-3, so by here there is usually nothing left to wait for.
+echo "==> waiting for the Convex backend" >&2
+for _ in $(seq 1 60); do
+  if curl -sf "${CONVEX_URL}/version" >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+curl -sf "${CONVEX_URL}/version" >/dev/null || {
+  echo "the Convex backend did not become ready" >&2
+  # The trap dumps its logs, which are empty when the container never got as far as running. The
+  # container's own state is the other half of that answer.
+  "${COMPOSE[@]}" ps >&2 || true
+  exit 1
+}
+
+# 5. Deploy the functions in convex/. This is the packaging proof: Convex's bundler resolves
+#    `@cerbos/orm-convex` out of node_modules through its published `exports` map, and type-checks
+#    the push against the `types` the tarball shipped. A `files` allowlist that omitted lib/ would
+#    fail here, before a single plan is made.
+CONVEX_SELF_HOSTED_URL="${CONVEX_URL}"
+CONVEX_SELF_HOSTED_ADMIN_KEY="$("${COMPOSE[@]}" exec -T backend ./generate_admin_key.sh 2>/dev/null | tail -1)"
+export CONVEX_SELF_HOSTED_URL CONVEX_SELF_HOSTED_ADMIN_KEY
+[[ -n "${CONVEX_SELF_HOSTED_ADMIN_KEY}" ]] || {
+  echo "could not generate a Convex admin key" >&2
+  exit 1
+}
+echo "==> npx convex deploy" >&2
+npx convex deploy -y >&2
+
+# 6. Compile the client, from cold. This is the other half of the packaging proof:
+#    `moduleResolution: nodenext` reads the adapter's `exports` map, so a broken one fails HERE
+#    rather than shipping to a consumer.
+#
+#    `tsc --build` is incremental, and the state it reuses is keyed on this example's own sources
+#    — which do not change when the adapter's packaging does. A warm lib/ and tsconfig.tsbuildinfo
+#    therefore let a broken `exports` map compile clean, which is the exact break this step
+#    exists to catch. CI is always cold; a developer's tree is not, and it is the tree where
+#    someone checks the break by hand.
+echo "==> tsc" >&2
+rm -rf lib tsconfig.tsbuildinfo
+npm run build >&2
+
+# 7. Run. stdout is the JSON document and nothing else.
+echo "==> node lib/main.js" >&2
+CONVEX_URL="${CONVEX_URL}" node lib/main.js

--- a/convex/example/src/main.ts
+++ b/convex/example/src/main.ts
@@ -1,0 +1,321 @@
+/**
+ * Example application for `@cerbos/orm-convex`, run against the shared demo domain.
+ *
+ * This is NOT a test of what the adapter translates — `../src/adversarial.test.ts` proves that
+ * against a hostile corpus with a live PDP as the oracle, inside a real Convex backend. This
+ * proves the two things that harness structurally cannot:
+ *
+ *   1. Packaging. The adapter is resolved through its PUBLISHED package — the `exports` map,
+ *      `types`, the `files` allowlist, and the `@cerbos/core` peer range against the copy this
+ *      example installs — because run.sh installs `npm pack`'s tarball rather than linking the
+ *      source directory. The harness imports from `"."` and touches none of it. See
+ *      docs/adr/0002-examples-install-the-packed-artifact.md. Two resolvers read it here: `tsc`
+ *      under `moduleResolution: nodenext` for this file, and Convex's own bundler for
+ *      ../convex/documents.ts, which is where the translation actually happens.
+ *   2. Usage shape. A harness runs one flat filtered query. Consumers also paginate, and compose
+ *      the adapter's filter with predicates of their own. Shape 5 below is the one that earns
+ *      the exercise.
+ *
+ * The division of labour is Convex's, not a choice: `queryPlanToConvex` returns a function of
+ * Convex's `FilterBuilder`, which exists only inside a Convex query. So this file plans, seeds and
+ * reports, and ../convex/documents.ts translates and queries.
+ *
+ * Prints one JSON document to stdout; everything a human might want to read goes to stderr.
+ * demo/scripts/run-example.sh diffs that document against demo/expected.json.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { PlanKind } from "@cerbos/orm-convex";
+import { GRPC as Cerbos } from "@cerbos/grpc";
+import { ConvexHttpClient } from "convex/browser";
+import { makeFunctionReference } from "convex/server";
+
+const DEMO_DIR = resolve(__dirname, "../../../demo");
+const RESOURCE_KIND = "document";
+
+interface SeedDocument {
+  id: string;
+  ownerId: string;
+  public: boolean;
+  region: string;
+  archived: boolean;
+}
+
+interface Seeds {
+  principals: { id: string; roles: string[] }[];
+  applicationFilter: { description: string; archived: boolean; region: string };
+  documents: SeedDocument[];
+}
+
+// demo/seeds.json is a repository-controlled corpus file, checked structurally by
+// demo/scripts/validate-demo.sh before this ever runs — not untrusted input.
+const seeds = JSON.parse(
+  readFileSync(resolve(DEMO_DIR, "seeds.json"), "utf8")
+) as Seeds;
+
+/**
+ * The application's OWN predicate, never expressed in policy. Rebuilt field by field rather than
+ * forwarded whole: the corpus entry carries a `description` alongside the two fields, and the
+ * Convex validator on the other side accepts exactly the fields it declares.
+ */
+const APPLICATION_FILTER = {
+  archived: seeds.applicationFilter.archived,
+  region: seeds.applicationFilter.region,
+};
+
+/**
+ * The runner sets this, and there is deliberately no fallback. The obvious default — Cerbos's own
+ * 3592/3593 — is the address every adapter's `cerbos run` test sidecar binds, so an unset
+ * CERBOS_HOST would not fail: it would quietly plan against the conformance corpus that sidecar
+ * serves, and produce a diff against demo/expected.json that reads as an adapter bug.
+ * demo/README.md requires reaching the PDP at $CERBOS_HOST, "never a hardcoded address", for
+ * exactly that reason.
+ */
+const cerbosHost = process.env["CERBOS_HOST"];
+if (!cerbosHost) {
+  throw new Error(
+    "CERBOS_HOST is not set — run this example through demo/scripts/run-example.sh convex"
+  );
+}
+
+/**
+ * The Convex backend run.sh started, on the same terms and for the same reason: 3210 is the port
+ * `npm run convex:up` and the adapter's own CI bind, so a default of it would let this example
+ * deploy over — and read from — the backend a conformance run is using.
+ *
+ * demo/scripts/run-example.sh's contract — "reads no environment except CERBOS_HOST" — is between
+ * the runner and `run.sh`, and it still holds: CERBOS_HOST is the only thing the runner supplies.
+ * CONVEX_URL is passed by run.sh to the process it starts, and it is an environment variable
+ * rather than a literal for the same reason CERBOS_HOST is one: the port belongs to whoever
+ * started the backend, and writing it here would be a second copy of a number that must not drift.
+ */
+const convexUrl = process.env["CONVEX_URL"];
+if (!convexUrl) {
+  throw new Error(
+    "CONVEX_URL is not set — run this example through demo/scripts/run-example.sh convex"
+  );
+}
+
+const cerbos = new Cerbos(cerbosHost, { tls: false });
+const convex = new ConvexHttpClient(convexUrl);
+
+/** Exactly `PlanResourcesResponse`, without depending on a package this example never imports. */
+type QueryPlan = Awaited<ReturnType<Cerbos["planResources"]>>;
+
+interface ListResult {
+  kind: string;
+  ids: string[];
+}
+
+interface PageResult extends ListResult {
+  isDone: boolean;
+  cursor: string | null;
+}
+
+/**
+ * Convex's documented way to name a deployed function without the generated `api` object. An
+ * application that ships its own `convex/_generated/` would import `api` instead and get the same
+ * references; this example does not, because that directory is deploy output rather than source —
+ * gitignored, and ESM where this client compiles to CommonJS. The trade is that the argument and
+ * return types are stated here rather than inferred from the handlers, which is why each one is
+ * written out.
+ */
+const seedDocuments = makeFunctionReference<
+  "mutation",
+  { documents: SeedDocument[] },
+  null
+>("documents:seed");
+
+const listDocuments = makeFunctionReference<
+  "query",
+  { queryPlan: QueryPlan; applicationFilter?: typeof APPLICATION_FILTER },
+  ListResult
+>("documents:list");
+
+const pageDocuments = makeFunctionReference<
+  "query",
+  {
+    queryPlan: QueryPlan;
+    paginationOpts: { numItems: number; cursor: string | null };
+  },
+  PageResult
+>("documents:page");
+
+function principal(id: string): { id: string; roles: string[] } {
+  const found = seeds.principals.find((p) => p.id === id);
+  if (!found) throw new Error(`demo/seeds.json declares no principal '${id}'`);
+  return found;
+}
+
+/**
+ * Plans, and hands back something Convex will accept as an argument.
+ *
+ * The round trip is not decoration. `@cerbos/core` builds a plan out of `PlanExpression`,
+ * `PlanExpressionValue` and `PlanExpressionVariable` CLASS instances, and Convex's argument
+ * encoder rejects a class instance outright — `... is not a supported Convex type`. So a Convex
+ * consumer serializes the plan on the way in, and what the backend receives is the same tree with
+ * the prototypes gone.
+ *
+ * Which is exactly why the adapter classifies operands by their shape rather than with
+ * `instanceof`: an `instanceof` check could not survive this crossing at all, on any consumer's
+ * machine (cerbos/query-plan-adapters#419).
+ */
+async function plan(principalId: string, action: string): Promise<QueryPlan> {
+  const queryPlan = await cerbos.planResources({
+    principal: principal(principalId),
+    resource: { kind: RESOURCE_KIND },
+    action,
+  });
+  return JSON.parse(JSON.stringify(queryPlan)) as QueryPlan;
+}
+
+const PLAN_KINDS: PlanKind[] = [
+  PlanKind.CONDITIONAL,
+  PlanKind.ALWAYS_ALLOWED,
+  PlanKind.ALWAYS_DENIED,
+];
+
+/**
+ * The plan kind comes back from the backend as a bare string: a Convex function's return value is
+ * data, so the enum the adapter reported arrives with nothing left of its type. Re-narrowing it
+ * against the adapter's own re-exported `PlanKind` is the same crossing the plan itself makes on
+ * the way in, where the class instances @cerbos/core built arrive as plain objects — and it fails
+ * the run rather than emitting a kind demo/expected.json has never heard of.
+ */
+function asPlanKind(reported: string): PlanKind {
+  const kind = PLAN_KINDS.find((candidate) => candidate === reported);
+  if (!kind) throw new Error(`unknown plan kind '${reported}'`);
+  return kind;
+}
+
+interface ShapeResult {
+  kind: PlanKind;
+  ids: string[];
+}
+
+interface PaginatedShapeResult extends ShapeResult {
+  pageSize: number;
+  pageSizes: number[];
+}
+
+// ---------------------------------------------------------------------------------------------
+// The five usage shapes
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Shapes 1, 2, 3 and 5. The only difference between a plain filtered list and the composed one is
+ * whether the application hands its own predicate over to be ANDed in, which is why they share a
+ * call rather than being two similar-looking ones.
+ */
+async function listed(
+  principalId: string,
+  action: string,
+  applicationFilter?: typeof APPLICATION_FILTER
+): Promise<ShapeResult> {
+  const queryPlan = await plan(principalId, action);
+  const result = await convex.query(listDocuments, {
+    queryPlan,
+    ...(applicationFilter ? { applicationFilter } : {}),
+  });
+  return { kind: asPlanKind(result.kind), ids: result.ids };
+}
+
+/**
+ * Shape 4: pagination applied on top of the filter, walked with Convex's cursor. Reported as page
+ * SIZES plus the sorted union of the ids, never as per-page order — demo/expected.json is shared
+ * by every store and several of them have no total order to paginate by.
+ *
+ * Convex has no filtered count, which is why count is not one of the five shapes.
+ */
+async function paginated(
+  principalId: string,
+  action: string,
+  pageSize: number
+): Promise<PaginatedShapeResult> {
+  const queryPlan = await plan(principalId, action);
+
+  const pageSizes: number[] = [];
+  const ids: string[] = [];
+  let cursor: string | null = null;
+
+  // `isDone` is the ONLY end condition. A page shorter than `numItems` is not the end — a filtered
+  // `.paginate()` walks the table under a read budget, so Convex may hand back fewer documents
+  // than asked for and more to come — and by the same argument an empty page is not the end
+  // either. Treating either as terminal would silently truncate the union.
+  //
+  // Which leaves the loop needing a bound rather than a second exit: at least one document per
+  // request in the ordinary case means no more requests than seed rows, plus the one that reports
+  // itself done. Overrunning it is a failed run rather than a hung one.
+  for (let request = 0; request <= seeds.documents.length; request++) {
+    // Annotated rather than inferred: `cursor` is assigned from this same value further down, so
+    // inferring it here would be circular.
+    const result: PageResult = await convex.query(pageDocuments, {
+      queryPlan,
+      paginationOpts: { numItems: pageSize, cursor },
+    });
+    if (result.ids.length > 0) {
+      pageSizes.push(result.ids.length);
+      ids.push(...result.ids);
+    }
+    if (result.isDone) {
+      return {
+        kind: asPlanKind(result.kind),
+        pageSize,
+        pageSizes,
+        ids: ids.sort(),
+      };
+    }
+    cursor = result.cursor;
+  }
+
+  throw new Error(
+    `paginating ${principalId}/${action} did not reach the end of the table in ` +
+      `${seeds.documents.length + 1} pages`
+  );
+}
+
+async function main(): Promise<void> {
+  await convex.mutation(seedDocuments, { documents: seeds.documents });
+  console.error(`seeded ${seeds.documents.length} documents`);
+
+  const shapes = {
+    filtered: {
+      "alice/view": await listed("alice", "view"),
+      "bob/view": await listed("bob", "view"),
+    },
+    alwaysAllowed: {
+      "admin/admin-view": await listed("admin", "admin-view"),
+    },
+    alwaysDenied: {
+      "alice/publish": await listed("alice", "publish"),
+    },
+    paginated: {
+      "alice/view": await paginated("alice", "view", 2),
+      "admin/admin-view": await paginated("admin", "admin-view", 3),
+    },
+    composed: {
+      "alice/view": await listed("alice", "view", APPLICATION_FILTER),
+      "bob/view": await listed("bob", "view", APPLICATION_FILTER),
+      "admin/admin-view": await listed(
+        "admin",
+        "admin-view",
+        APPLICATION_FILTER
+      ),
+      "alice/publish": await listed("alice", "publish", APPLICATION_FILTER),
+    },
+  };
+
+  process.stdout.write(
+    `${JSON.stringify({ adapter: "convex", shapes }, null, 2)}\n`
+  );
+}
+
+void (async () => {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/convex/example/tsconfig.json
+++ b/convex/example/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  // The CLIENT half of the example — src/main.ts, which runs in Node. The Convex functions under
+  // convex/ are compiled by Convex's own bundler and have a tsconfig of their own.
+  //
+  // `nodenext` resolution is load-bearing, not a style choice: it is what makes TypeScript read
+  // the adapter's `exports` map. The legacy `node10` resolver ignores `exports` entirely and
+  // falls back to `main`/`types`, so a broken `exports` map would compile clean here and only
+  // fail for a consumer.
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Fixes #353. Part of #349.

Adds `convex/example/`: a program taking no arguments that installs `@cerbos/orm-convex` from
`npm pack`'s tarball, exercises the five usage shapes against the shared demo domain, and prints
the JSON document `demo/scripts/run-example.sh` diffs against `demo/expected.json`.

Affected adapter: **convex** only. No corpus file, no `demo/expected.json` entry, no adapter source
changed.

## Why this example has two halves

Convex is the first adapter whose filter cannot be applied by the caller. `queryPlanToConvex`
returns a **function of Convex's `FilterBuilder`**, and that builder exists only inside a Convex
query — so the plan crosses the wire and the adapter runs in the backend, beside `ctx.db`.

- `src/main.ts` plans against the PDP, seeds, walks the shapes, prints the document.
- `convex/documents.ts` translates and queries. This is where the packed adapter is imported.

That also means the published surface is read by **two** resolvers rather than one: Convex's
bundler (and its `tsc`, under `moduleResolution: "Bundler"`) at `npx convex deploy`, and `tsc`
under `nodenext` at `npm run build`. Both were checked by breaking the package:

| Break | `npx convex deploy` | client `npm run build` | `npm test` |
| --- | --- | --- | --- |
| `exports["."]` points at a missing file | fails — `The module "./lib/missing.js" was not found on the file system` | fails (TS2307) | 457 passing |
| `lib/**/*.js` dropped from `files` | fails — `The module "./lib/index.js" was not found on the file system` | **passes** — the `.d.ts` files still ship, so the types resolve and only the bundle does not | 457 passing |

The second row is the one worth keeping: a `files` allowlist can ship every type declaration and no
implementation, and only something that has to *execute* the package notices.

## The five shapes

| Shape | How it is expressed |
| --- | --- |
| 1. Plain filtered list | `ctx.db.query("documents").filter(result.filter).collect()` — `alice/view`, `bob/view` |
| 2. `KIND_ALWAYS_ALLOWED` | no filter to apply; the same query without `.filter()` — `admin/admin-view` |
| 3. `KIND_ALWAYS_DENIED` | returns `[]` before a predicate is built at all — `alice/publish` |
| 4. Pagination | `.filter(...).paginate({numItems, cursor})`, the client walking the cursor |
| 5. Composed | the adapter's filter ANDed with the application's own predicate, in the one `.filter()` call Convex allows |

**Shape 4 is `.paginate()`**, not `.take()`: Convex has no filtered count, which is why count is not
one of the five shapes at all. `.filter()` is applied by the query engine as it walks the table, so
a page holds `numItems` documents the adapter *allowed* rather than `numItems` documents of which
some are then dropped. Observed page sizes matched `demo/expected.json` exactly — `[2,2,1]` for
`alice/view` at `pageSize` 2, `[3,3,2]` for `admin/admin-view` at 3 — asserted as sizes plus the
sorted union, never per-page order.

`isDone` is the only end condition the client accepts. A filtered `.paginate()` walks under a read
budget, so a short page is not the end and an empty one is not either; treating either as terminal
would truncate the union quietly. The loop is bounded by the seed-row count instead, so a cursor
that never reports itself done fails the run rather than hanging it.

**Shape 5** builds both halves inside the single predicate Convex takes:

```ts
return (q) => q.and(
  adapterFilter(q),                                 // KIND_CONDITIONAL: the adapter's filter
  q.eq(q.field("archived"), application.archived),  // the application's own predicate,
  q.eq(q.field("region"), application.region),      // read from demo/seeds.json
);
```

`archived` and `region` are never referenced by `demo/policies/document.yaml` and are absent from
the mapper. The two absences mean different things: `KIND_ALWAYS_ALLOWED` has no adapter filter, so
the application's predicate stands alone; `KIND_ALWAYS_DENIED` never reaches the composition,
because a denial ANDed with anything is still a denial and the application's predicate must not be
able to resurrect denied documents.

## The new peer-dependency arrangement (#420) works from a packed-artifact consumer's side

This is the first thing in the repository to execute #420's arrangement end to end, so it is worth
stating what was observed rather than assumed.

The example declares `@cerbos/core` itself, which is what `convex/README.md`'s installation section
tells a consumer to do (`npm install @cerbos/orm-convex @cerbos/core`) and what pnpm and Yarn
require. With `@cerbos/grpc@^0.29.0` beside it, **one** deduped `@cerbos/core@0.33.0` resolves and
satisfies the adapter's `^0.32.0 || ^0.33.0` peer range.

A bare consumer who does *not* declare it also works — npm 7+ auto-installs the missing peer:

```
$ npm install ./cerbos-orm-convex-0.2.0.tgz     # nothing else in package.json
probe@0.0.0
`-- @cerbos/orm-convex@0.2.0
  `-- @cerbos/core@0.33.0

$ node -e "const a=require('@cerbos/orm-convex'); …"
kinds: KIND_ALWAYS_ALLOWED,KIND_ALWAYS_DENIED,KIND_CONDITIONAL
{"kind":"KIND_ALWAYS_ALLOWED"}
```

No warnings, no unmet peer, no duplicate copy. Nothing here needs fixing.

## One consumer-facing fact this example surfaced

Convex's argument encoder **rejects a class instance**, and `@cerbos/core` builds a plan out of
`PlanExpression` / `PlanExpressionValue` / `PlanExpressionVariable` instances:

```
Error: PlanExpression {"operator":"or",…} is not a supported Convex type
```

So a Convex consumer has to serialize the plan on the way in, and the backend receives the same
tree with the prototypes gone. The conformance harness already does this
(`JSON.parse(JSON.stringify(queryPlan))`) but nothing said why; the example now says so at the call
site and in its README. It is also the sharpest possible statement of why the adapter classifies
operands by shape rather than with `instanceof` — an `instanceof` check could not survive this
crossing on *any* consumer's machine (#419, closed by #420).

## CI

An `example` job in `.github/workflows/convex.yaml`, one Node leg (22), with `demo/**` added to the
workflow's path filter. It carries the comment #349 asks for: `renovate.json` automerges every
non-major bump, so a Convex bump arrives as one PR touching both `convex/package.json` and
`convex/example/package.json`, and this job — being a check on that PR — is what blocks the
automerge when the new Convex breaks real usage. Moving it to a nightly or standalone workflow
silently restores that gap. The example's lockfile is committed for the same reason.

No Convex backend is started by the job: the example's own `run.sh` starts one, on 13210/13211
rather than 3210/3211, because a consumer's deployment is part of what it proves — and because
3210 is the port `npm run convex:up` and the `integration-test` job bind.

## Commands run, and results

Against the PDP pinned in `conformance/CERBOS_VERSION` / `conformance/CERBOS_IMAGE_DIGEST`
(0.54.0, `sha256:211c261f…6537ef`), started from `demo/docker-compose.yml` by the shared runner —
not the local Cerbos CLI, which is 0.55.0 here.

| Command | Result |
| --- | --- |
| `demo/scripts/run-example.sh convex` | OK — matched `demo/expected.json` across 5 usage shapes. Also run once from an empty npm cache, since CI's is cold every time |
| `demo/scripts/validate-demo.sh` | OK — 5/5 checks; example coverage now 5/10 adapters |
| `conformance/scripts/validate-corpus.sh` | OK — 199 actions, 21 seeds |
| `conformance/scripts/check-docs.sh` | OK — TOC in sync, no roster counts in prose |
| `convex`: `npm run build` | OK |
| `convex`: `npm test` | 457 passing |
| `convex`: `npm run typecheck` | OK (after `npx convex codegen` against a live backend, as the workflow does) |
| `convex`: adversarial conformance suite | `PASS (218) FAIL (0)` — run against the pinned image directly rather than through `npm run test:adversarial`, whose `cerbos run` would have used the local CLI at 0.55.0 |

The container's own labels, for the record: `Config.Image` =
`ghcr.io/cerbos/cerbos:0.54.0@sha256:211c261f…6537ef`, `org.opencontainers.image.version` = `0.54.0`.

## For a reviewer

- The example's Convex functions are **public** `query`s because the client is an outside process.
  A real application uses `internalQuery`, and both the file header and the example README say so,
  pointing at the adapter README's "Trusted usage pattern". If that is too sharp an edge to ship in
  an example even with the warning, say so.
- `src/main.ts` uses `makeFunctionReference` rather than the generated `api` object:
  `convex/_generated/` is deploy output, gitignored, and ESM where this client compiles to CommonJS.
  The trade is that argument and return types are written out rather than inferred.
- The example reads **two** environment variables, `CERBOS_HOST` and `CONVEX_URL`, where
  `demo/scripts/run-example.sh`'s header says "reads no environment except CERBOS_HOST". That
  contract is between the runner and `run.sh`, and it holds — CERBOS_HOST is still the only thing
  the runner supplies. `CONVEX_URL` is passed by `run.sh` to the process it starts, and it is a
  variable rather than a literal for the same reason `CERBOS_HOST` is: the port belongs to whoever
  started the backend. `mongoose/example/` instead writes its `27117` out twice. If the line in
  `demo/README.md` should be amended to say so, that is a corpus edit and belongs in its own PR.
- One review pass hit a one-off `npx convex deploy` failure on a cold npm cache
  (`Could not resolve "convex/server" … "./dist/esm/server/index.js" was not found`) that did not
  reproduce: a deliberate empty-cache run here passed, and the file is present in a normal install.
  Worth a glance at the first CI run, which is always cold.
- The commit is **unsigned**: the 1Password SSH agent on this machine refused to sign
  (`error: 1Password: agent returned an error`). Amend with a signature before merging if the
  branch protection wants one.
