### PR TITLE
feat(langchain-chromadb): add the example application for the shared demo domain

### DIFF
--- a/.github/workflows/chromadb.yaml
+++ b/.github/workflows/chromadb.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "langchain-chromadb/**"
       - "conformance/**"
+      - "demo/**"
       - ".github/workflows/chromadb.yaml"
       - ".github/workflows/chromadb-publish.yaml"
   push:
@@ -86,3 +87,48 @@ jobs:
       - name: Stop ChromaDB
         if: always() && matrix.node-version == '22'
         run: docker rm -f chromadb
+
+  # The example application: the published package, installed from `npm pack`'s tarball and used
+  # the way a consumer uses it, against the shared demo domain. It covers the two things the job
+  # above structurally cannot — the packaging surface (`exports`, `types`, the `files` allowlist,
+  # the `@cerbos/core` peer range), which both suites bypass by importing from `"."`, and the usage
+  # shapes past a single flat query (a limit walked to the end of the result set, and composing the
+  # adapter's filter with the application's own). See cerbos/query-plan-adapters#349 and
+  # docs/adr/0002-examples-install-the-packed-artifact.md.
+  #
+  # THIS JOB MUST STAY IN THIS WORKFLOW. `renovate.json` sets `automerge: true` for every
+  # non-major bump, and that is the path a ChromaDB client regression takes into `main` today.
+  # Because the example's lockfile is committed and Renovate manages it, a `chromadb` bump arrives
+  # as ONE PR touching both langchain-chromadb/package.json and
+  # langchain-chromadb/example/package.json — and this job, being a check on that PR, is what
+  # blocks the automerge when the new client breaks real usage. Moving it to a nightly run or a
+  # workflow of its own silently restores that gap.
+  #
+  # One Node leg only: the demo domain discriminates the package and the client, not the runtime —
+  # the same reasoning that gates the adversarial step above to Node 22.
+  #
+  # No ChromaDB is started here, unlike the job above: the example's own run.sh starts one, on
+  # 18234 rather than 8234, because bringing the store up is part of what a consumer does.
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate conformance corpus
+        run: ../conformance/scripts/validate-corpus.sh
+
+      - name: Validate demo domain
+        run: ../demo/scripts/validate-demo.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - run: npm install
+
+      # The PDP is a container started by the runner from demo/docker-compose.yml, pinned to
+      # conformance/CERBOS_VERSION and conformance/CERBOS_IMAGE_DIGEST — no cerbos-setup-action
+      # here, because an example must reach the PDP the way a deployed application does.
+      - name: Run the example against the demo domain
+        run: ../demo/scripts/run-example.sh langchain-chromadb

--- a/langchain-chromadb/README.md
+++ b/langchain-chromadb/README.md
@@ -179,6 +179,9 @@ if (result.kind === PlanKind.CONDITIONAL) {
 }
 ```
 
+`QueryPlanToChromaDBArgs` and `QueryPlanToChromaDBResult` are exported alongside the function, so a
+caller passing either one to a function of its own has a name to write.
+
 `PlanKind` is re-exported from `@cerbos/core`:
 
 ```ts
@@ -285,6 +288,24 @@ const matches = await chroma.similaritySearch("query", 10, filters);
 - A filter literal is null, nested, non-finite, or otherwise invalid for Chroma metadata.
 - `$ne` or `$nin` targets a field that is not declared `required: true`.
 - A fractional ordered comparison targets a field that is not configured with `numericType: "float"`.
+
+## Example application
+
+This repository carries a runnable [`example/`](example/), which installs the adapter from the
+artifact `npm publish` would upload and exercises it against a live PDP and a real ChromaDB server
+over the shared [demo domain](../demo/README.md):
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh langchain-chromadb
+```
+
+Unlike the test suites, it resolves the adapter through its **published** surface — the `exports`
+map, `types`, the `files` allowlist, and the `@cerbos/core` peer range — and covers usage shapes
+past a single flat query: a limit walked to the end of the result set through `collection.get`, and
+the adapter's `Where` clause composed with an application-owned one under `$and`. It is also where
+the empty clause an `ALWAYS_ALLOWED` plan returns meets Chroma's own validator, which rejects `{}`
+— so a caller omits `where` rather than forwarding it.
 
 ## Testing
 

--- a/langchain-chromadb/example/.gitignore
+++ b/langchain-chromadb/example/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+lib
+tsconfig.tsbuildinfo
+# The adapter tarball `run.sh` builds and installs. Regenerated on every run; never committed.
+cerbos-langchain-chromadb-*.tgz

--- a/langchain-chromadb/example/README.md
+++ b/langchain-chromadb/example/README.md
@@ -1,0 +1,150 @@
+# `@cerbos/langchain-chromadb` example application
+
+A runnable program that installs the adapter **as a published package** and uses it the way a
+consumer would, against the shared [demo domain](../../demo/README.md).
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh langchain-chromadb
+```
+
+Needs `docker` (with compose), `jq` and Node 22+. The runner starts the pinned Cerbos PDP; this
+directory's `run.sh` starts ChromaDB, packs the adapter, installs the tarball, builds, and runs.
+
+It follows [`prisma/example/`](../../prisma/example/), which is the reference implementation.
+
+## What it proves
+
+Not what the adapter translates. [`../src/translator.test.ts`](../src/translator.test.ts) pins the
+`Where` document every corpus shape emits, and
+[`../src/adversarial.test.ts`](../src/adversarial.test.ts) proves those documents return what a
+live PDP's `check()` allows. This proves the two things neither of them structurally can:
+
+**Packaging.** `run.sh` builds the artifact `npm publish` would upload and installs *that*, so the
+import in [`src/main.ts`](src/main.ts) resolves through the published surface — the `exports` map,
+`types`, the `files` allowlist, and the `@cerbos/core` peer range against the copy this example
+declares. Both suites import from `"."` and touch none of it. See
+[ADR 0002](../../docs/adr/0002-examples-install-the-packed-artifact.md).
+
+`tsconfig.json` sets `moduleResolution: "nodenext"` for the `exports` half specifically: the legacy
+`node10` resolver ignores `exports` entirely and falls back to `main`/`types`, so a broken
+`exports` map would compile clean here and only fail for a consumer. `run.sh` deletes `lib/` and
+`tsconfig.tsbuildinfo` before compiling for the same reason — `tsc --build` keys its incremental
+state on this example's own sources, which do not change when the adapter's packaging does, so on a
+warm tree a broken `exports` map compiles clean and the break surfaces only at runtime. CI is
+always cold; the tree where someone checks the break by hand is not.
+
+**Usage shape.** Both suites run one flat filtered query. This runs all
+[five shapes](../../demo/README.md#the-five-usage-shapes), including a limit walked to the end of
+the result set and — the one that earns the exercise — the adapter's filter ANDed with the
+application's own predicate, across all three plan kinds.
+
+## Layout
+
+| Path                | What it is                                                              |
+| ------------------- | ----------------------------------------------------------------------- |
+| `run.sh`            | start ChromaDB → pack → install → compile cold → run. Prints the JSON document on stdout. |
+| `src/main.ts`       | The example itself: one function per usage shape.                       |
+| `package.json`      | The client and SDK pins Renovate manages.                               |
+| `package-lock.json` | Committed. See below.                                                   |
+
+There is no schema file: a Chroma collection has none. The four flat attributes the demo domain
+carries become four metadata keys on each record, and the collection is scratch state `main.ts`
+deletes and recreates on every run.
+
+The ChromaDB container is started by this directory's `run.sh` rather than by the shared runner,
+on **18234** rather than the 8234 `npm run chroma` and this adapter's CI bind. A demo server
+holding that port would let this example create and delete collections inside the server a
+conformance run is using — the same collision `demo/docker-compose.yml` avoids by publishing the
+PDP on 13592/13593. The image is read from [`../CHROMA_IMAGE`](../CHROMA_IMAGE), the one constant
+this adapter's suites and workflow already share, so there is no second pin to bump.
+
+## Two things that look odd and are not
+
+**`@cerbos/langchain-chromadb` is not in `package.json`.** `npm pack`'s tarball gets a fresh
+integrity hash on every build, so a committed lockfile naming it would break `npm ci` the moment
+the adapter changed. `run.sh` runs `npm ci` for the pinned tree and then installs the tarball on
+top with `--no-save --no-package-lock`, which leaves both manifests exactly as committed while
+still resolving the adapter and its peers the way a consumer's install does.
+
+**The lockfile is committed anyway,** because it is what makes the CI job load-bearing.
+`renovate.json` automerges every non-major bump, so a `chromadb` bump arrives as one PR touching
+both `langchain-chromadb/package.json` and this file — and the `example` job on that PR is what
+blocks the automerge when the new client breaks real usage. That only works while the job stays in
+[`.github/workflows/chromadb.yaml`](../../.github/workflows/chromadb.yaml); there is a comment on
+the job saying so.
+
+## The mapper
+
+Cerbos attribute names are not Chroma metadata keys, so a consumer always writes one of these:
+
+```ts
+const FIELD_NAME_MAPPER: FieldMapper = {
+  "request.resource.attr.ownerId": "ownerId",
+  "request.resource.attr.public": "public",
+};
+```
+
+Without an entry the adapter falls back to the attribute path verbatim, and
+`request.resource.attr.ownerId` is not a key any record in this collection carries — so the filter
+would be well-formed, accepted by Chroma, and select nothing.
+
+`archived` and `region` are deliberately absent: they are the application's metadata keys, never
+referenced by [`demo/policies/document.yaml`](../../demo/policies/document.yaml), and composing
+them with the adapter's filter is shape 5. Nothing declares `required: true` either — that
+assertion exists to permit `$ne` and `$nin`, and the demo policy produces neither.
+
+## `{}` is not Chroma's word for "no constraint"
+
+The one place the three plan kinds do not land cleanly, and the reason shape 2 and shape 5 are
+worth running here rather than assumed:
+
+```ts
+type Filter = Where | undefined | "denied";
+```
+
+`ALWAYS_ALLOWED` comes back from the adapter as `filters: {}` — an empty clause, a faithful
+spelling of "there is nothing to filter on". Chroma's own validator rejects it:
+
+```
+ChromaValueError: Expected 'where' to have exactly one operator, but got 0
+```
+
+So `undefined` — omitting `where` altogether — is what "no constraint" is spelled as on this
+store, and the caller drops the empty clause rather than forwarding it. The same applies one level
+in: `{ $and: [{}, applicationFilter] }` is rejected for the same reason, which is why `conjoin`
+returns the application's predicate alone instead of wrapping both. This is a loud failure rather
+than a silent over-grant — the first unconditional plan an application meets raises it — but it is
+the kind of thing only a program that actually calls the store finds.
+
+`ALWAYS_DENIED` is a string sentinel rather than a second `undefined` precisely because the two
+must not collapse: a denial that reached a query as "no constraint" would return the whole
+collection.
+
+## Two query methods, on purpose
+
+Shapes 1, 2, 3 and 5 use `collection.query` — the similarity search LangChain's Chroma vector
+store calls underneath `similaritySearch`, with the adapter's clause passed as its `where`
+argument. "No limit" has to be spelled as `nResults: <collection size>`, because a vector search
+always caps its neighbours.
+
+Shape 4 leaves it behind. `nResults` is a limit but there is no offset to go with it, so
+`collection.query` can return the first page and no other; the second page needs `collection.get`,
+Chroma's metadata-only retrieval path, which takes the same `where` clause plus `limit` and
+`offset`. Exercising both is the point: the clause this adapter emits has to be accepted by
+whichever of the two a consumer reaches for.
+
+Pages are asserted by their sizes and by the sorted union of their ids, never by per-page order —
+`demo/expected.json` is shared by every store and several have no total order to paginate by.
+
+## Scope
+
+This example is a JSON-printing CLI, not an onboarding artifact — that is
+[`spring-data/example/`](../../spring-data/example/), and the floor/ceiling rule in
+[ADR 0001](../../docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md) is why both exist.
+
+It talks to `chromadb` directly rather than through `@langchain/community`'s Chroma vector store.
+That store is a wrapper over the same client and the same `where` argument, and reaching for it
+would add an embedding provider — a network call and an API key — to a program whose subject is
+the packaging of this adapter. The dependency this example has to pin is the one the adapter
+declares, and that is `chromadb`.

--- a/langchain-chromadb/example/package-lock.json
+++ b/langchain-chromadb/example/package-lock.json
@@ -1,0 +1,548 @@
+{
+  "name": "cerbos-langchain-chromadb-example",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cerbos-langchain-chromadb-example",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/core": "^0.33.0",
+        "@cerbos/grpc": "^0.29.0",
+        "chromadb": "^3.2.2"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cerbos/api": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-Wk9SrcwI75tWFxk065y95+4gFQKCUD7yd0q+OYbW2we9APeBWkJd0voFh2RbPvk4QR23Sz9ozowsZd4Vwtf90Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.13.0"
+      },
+      "engines": {
+        "node": ">= 22"
+      }
+    },
+    "node_modules/@cerbos/core": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/core/-/core-0.33.0.tgz",
+      "integrity": "sha512-cf7oZlbLY2+p9pkDgpZycv1xZ8ZmPI5pJJgcm0ct4uCut3m1EzRWSBIfkRBIhEKhL3apPuSVQzevH4Pis0f7Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/api": "^0.11.0",
+        "uuid": "^14.0.1"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.13.0"
+      }
+    },
+    "node_modules/@cerbos/grpc": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@cerbos/grpc/-/grpc-0.29.0.tgz",
+      "integrity": "sha512-qo2D7UPqvGp8+/tp8uIN+lCgVd+LVp8thHaVQa07/gSQ1xI7scvZTsmiA49dV3L40gYkmx+942RVWxoCzyfI0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cerbos/core": "^0.33.0",
+        "@grpc/grpc-js": "^1.14.4"
+      },
+      "engines": {
+        "node": ">= 22"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.13.0",
+        "@cerbos/api": "^0.11.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chromadb": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chromadb/-/chromadb-3.5.0.tgz",
+      "integrity": "sha512-A68f2RQjY3R95Pzy0j3ykOu6fi+WWCN1tjbvzrZXZoYQ1d7ZjgWr1FyzitZCeaz/0qmc8y2LEK7QmlxloOAs9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^7.7.1"
+      },
+      "bin": {
+        "chroma": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "chromadb-js-bindings-darwin-arm64": "^1.3.4",
+        "chromadb-js-bindings-darwin-x64": "^1.3.4",
+        "chromadb-js-bindings-linux-arm64-gnu": "^1.3.4",
+        "chromadb-js-bindings-linux-x64-gnu": "^1.3.4",
+        "chromadb-js-bindings-win32-x64-msvc": "^1.3.4"
+      }
+    },
+    "node_modules/chromadb-js-bindings-darwin-arm64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/chromadb-js-bindings-darwin-arm64/-/chromadb-js-bindings-darwin-arm64-1.3.4.tgz",
+      "integrity": "sha512-pDdWCcR0hCz3pSDiIijBito7YG6FumewfzYE2mIjSwjrO1CKSfQKLwDdTVK4ZNpVGQa16ePoMX+pg7ShSUARJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chromadb-js-bindings-darwin-x64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/chromadb-js-bindings-darwin-x64/-/chromadb-js-bindings-darwin-x64-1.3.4.tgz",
+      "integrity": "sha512-5vKVFXSFo+S9qC9by/7oofjcXqQK4IGHiUnPrvTfc7B52gNlPSKeyDO1wha556COc3KtXSZjICEH0nYBJ8UXng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chromadb-js-bindings-linux-arm64-gnu": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/chromadb-js-bindings-linux-arm64-gnu/-/chromadb-js-bindings-linux-arm64-gnu-1.3.4.tgz",
+      "integrity": "sha512-ELiqDZzU5mZd1BvZugGrhoMkVeNyQaa+PGizd06WIpIJVoHY+S+9ZBjdeM6ZkRnL3vTxD79XBrosxNWhzqy/kg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chromadb-js-bindings-linux-x64-gnu": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/chromadb-js-bindings-linux-x64-gnu/-/chromadb-js-bindings-linux-x64-gnu-1.3.4.tgz",
+      "integrity": "sha512-HmTUe7PEIaBngCQ70Yyle81z2wYyg9OMgJYyRUNBYCBp4ED6zTmdaOro41Vs/c/h2UyQeBXFIKNmHDeD2Nr2fw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chromadb-js-bindings-win32-x64-msvc": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/chromadb-js-bindings-win32-x64-msvc/-/chromadb-js-bindings-win32-x64-msvc-1.3.4.tgz",
+      "integrity": "sha512-punrofQRzKspNMxHmv24qoPeRycV2T3KfedekGV4lOuPPG14i6qggS4x/OWLSAK7ozPfBbrzCejvCa5wfvujhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/langchain-chromadb/example/package.json
+++ b/langchain-chromadb/example/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cerbos-langchain-chromadb-example",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example application for @cerbos/langchain-chromadb, run against the shared demo domain",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsc --build",
+    "start": "node lib/main.js"
+  },
+  "//": "@cerbos/langchain-chromadb is deliberately ABSENT from these dependencies. run.sh installs it from `npm pack`'s tarball, whose integrity hash changes on every build and would make a committed lockfile unusable with `npm ci`. The vector store client and the SDK ARE pinned here, which is the half Renovate manages: a chromadb bump lands as one PR touching both langchain-chromadb/package.json and this file, and the example job on that PR is what blocks automerge if the new client broke real usage.",
+  "//peer": "@cerbos/core is declared because the adapter declares it as a PEER dependency, not because this example imports it directly — it is the copy of the query-plan types the Cerbos client and the adapter have to share, and the adapter's README tells a consumer to `npm install @cerbos/langchain-chromadb @cerbos/core` for exactly that reason. npm 7+ would install the missing peer on its own; pnpm and Yarn would not, so a consumer declares it and so does this. @cerbos/grpc pulls core ^0.33.0, so one copy resolves rather than two.",
+  "dependencies": {
+    "@cerbos/core": "^0.33.0",
+    "@cerbos/grpc": "^0.29.0",
+    "chromadb": "^3.2.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^6.0.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/langchain-chromadb/example/run.sh
+++ b/langchain-chromadb/example/run.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# The langchain-chromadb half of `demo/scripts/run-example.sh langchain-chromadb`: start ChromaDB,
+# pack the adapter, install THAT, build the example against it, run it. The PDP is already up and
+# reachable at $CERBOS_HOST — the shared runner owns it.
+#
+# The ChromaDB container is this script's job rather than the runner's. demo/docker-compose.yml
+# holds the one thing every example genuinely shares, and every store past that is somebody else's;
+# putting them there would grow it into the language switch the split exists to avoid. Starting it
+# here is also what keeps `demo/scripts/run-example.sh langchain-chromadb` a single command on a
+# laptop.
+#
+# The image is READ from ../CHROMA_IMAGE rather than restated here — the same constant this
+# adapter's suites, its `npm run chroma` helper and its workflow already share. A second copy is a
+# second thing to bump, and conformance/scripts/validate-corpus.sh requires every reference to a
+# service image to carry the same tag AND digest; a reference that reads the file cannot drift from
+# it at all.
+#
+# Everything this script prints for a human goes to stderr. stdout carries exactly one JSON
+# document, which the shared runner diffs against demo/expected.json.
+
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_DIR="$(cd "${EXAMPLE_DIR}/.." && pwd)"
+
+# 18234, not the 8234 `npm run chroma` and this adapter's CI bind: a demo ChromaDB holding that
+# port would let this example create and delete collections inside the server a conformance run is
+# using. demo/docker-compose.yml publishes the PDP on 13592/13593 for exactly the same reason.
+# src/main.ts reaches this through $CHROMA_URL, so the number is not written down twice.
+CHROMA_PORT=18234
+CHROMA_URL="http://127.0.0.1:${CHROMA_PORT}"
+# Named rather than anonymous so the trap below can dump its logs and remove it. The name is
+# demo-specific for the same reason the port is: `docker rm -f` on a shared name would take out a
+# container a conformance run had started.
+CHROMA_CONTAINER="cerbos-demo-chromadb"
+
+cd "${EXAMPLE_DIR}"
+rm -f cerbos-langchain-chromadb-*.tgz
+
+cleanup() {
+  local status=$?
+  if (( status != 0 )); then
+    echo "==> langchain-chromadb example failed (exit ${status}): ChromaDB logs" >&2
+    docker logs "${CHROMA_CONTAINER}" >&2 2>&1 || true
+  fi
+  docker rm -f "${CHROMA_CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+# 1. Start ChromaDB. First, so it warms up while the adapter is packed and installed — the
+#    readiness wait below is what actually gates the run, not this line.
+echo "==> starting ChromaDB on ${CHROMA_PORT}" >&2
+docker rm -f "${CHROMA_CONTAINER}" >/dev/null 2>&1 || true
+docker run -d --name "${CHROMA_CONTAINER}" -p "${CHROMA_PORT}:8000" \
+  "$(cat "${ADAPTER_DIR}/CHROMA_IMAGE")" >/dev/null
+
+# 2. Build and pack the adapter into the artifact npm would publish.
+echo "==> packing @cerbos/langchain-chromadb" >&2
+(cd "${ADAPTER_DIR}" && npm run build) >&2
+TARBALL="$(cd "${ADAPTER_DIR}" && npm pack --silent --pack-destination "${EXAMPLE_DIR}")"
+echo "==> packed ${TARBALL}" >&2
+
+# 3. Install the example's own pinned tree from the committed lockfile, then the tarball on top.
+#
+# The tarball is NOT a package.json dependency and NOT in the lockfile: its integrity hash changes
+# on every build, which would make `npm ci` fail on a lockfile that was correct when committed.
+# `--no-save --no-package-lock` keeps both files exactly as committed while still resolving the
+# adapter — and its `@cerbos/core` peer range against the copy this example declares — the way a
+# consumer's install would.
+echo "==> npm ci" >&2
+npm ci >&2
+echo "==> installing the packed adapter" >&2
+npm install --no-save --no-package-lock "./${TARBALL}" >&2
+
+# 4. Compile, from cold. This is half of the packaging proof: `moduleResolution: nodenext` reads
+#    the adapter's `exports` map, so a broken one fails HERE rather than shipping to a consumer.
+#
+#    `tsc --build` is incremental, and the state it reuses is keyed on this example's own sources
+#    — which do not change when the adapter's packaging does. A warm lib/ and tsconfig.tsbuildinfo
+#    therefore let a broken `exports` map compile clean, which is the exact break this step exists
+#    to catch. CI is always cold; a developer's tree is not, and it is the tree where someone
+#    checks the break by hand.
+echo "==> tsc" >&2
+rm -rf lib tsconfig.tsbuildinfo
+npm run build >&2
+
+# 5. Wait for ChromaDB. Deliberately after the install: the container has been starting underneath
+#    steps 2-4, so by here there is usually nothing left to wait for.
+echo "==> waiting for ChromaDB" >&2
+for _ in $(seq 1 60); do
+  if curl -sf "${CHROMA_URL}/api/v2/heartbeat" >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+curl -sf "${CHROMA_URL}/api/v2/heartbeat" >/dev/null || {
+  echo "ChromaDB did not become ready at ${CHROMA_URL}" >&2
+  # The trap dumps its logs, which are empty when the container never got as far as running. The
+  # container's own state is the other half of that answer.
+  docker ps -a --filter "name=${CHROMA_CONTAINER}" >&2 || true
+  exit 1
+}
+
+# 6. Run. stdout is the JSON document and nothing else.
+echo "==> node lib/main.js" >&2
+CHROMA_URL="${CHROMA_URL}" node lib/main.js

--- a/langchain-chromadb/example/src/main.ts
+++ b/langchain-chromadb/example/src/main.ts
@@ -1,0 +1,417 @@
+/**
+ * Example application for `@cerbos/langchain-chromadb`, run against the shared demo domain.
+ *
+ * This is NOT a test of what the adapter translates — `../src/adversarial.test.ts` proves that
+ * against a hostile corpus with a live PDP oracle and a real ChromaDB server, and
+ * `../src/translator.test.ts` pins the `Where` document each shape emits. This proves the two
+ * things neither of those structurally can:
+ *
+ *   1. Packaging. The import below resolves through the PUBLISHED package — `exports`, `types`,
+ *      the `files` allowlist, the `@cerbos/core` peer range against the copy this example
+ *      declares — because run.sh installs `npm pack`'s tarball rather than linking the source
+ *      directory. Both suites import from `"."` and touch none of it. See
+ *      docs/adr/0002-examples-install-the-packed-artifact.md.
+ *   2. Usage shape. A harness runs one flat filtered query. Consumers also paginate, and compose
+ *      the adapter's filter with predicates of their own. Shape 5 below is the one that earns
+ *      the exercise.
+ *
+ * Prints one JSON document to stdout; everything a human might want to read goes to stderr.
+ * demo/scripts/run-example.sh diffs that document against demo/expected.json.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { GRPC as Cerbos } from "@cerbos/grpc";
+import {
+  PlanKind,
+  queryPlanToChromaDB,
+  type FieldMapper,
+  type QueryPlanToChromaDBResult,
+} from "@cerbos/langchain-chromadb";
+import {
+  ChromaClient,
+  ChromaNotFoundError,
+  type Collection,
+  type Where,
+} from "chromadb";
+
+const DEMO_DIR = resolve(__dirname, "../../../demo");
+const RESOURCE_KIND = "document";
+const COLLECTION_NAME = "cerbos-demo-documents";
+
+interface Seeds {
+  principals: { id: string; roles: string[] }[];
+  applicationFilter: { description: string; archived: boolean; region: string };
+  documents: {
+    id: string;
+    ownerId: string;
+    public: boolean;
+    region: string;
+    archived: boolean;
+  }[];
+}
+
+// demo/seeds.json is a repository-controlled corpus file, checked structurally by
+// demo/scripts/validate-demo.sh before this ever runs — not untrusted input.
+const seeds = JSON.parse(
+  readFileSync(resolve(DEMO_DIR, "seeds.json"), "utf8")
+) as Seeds;
+
+/**
+ * Cerbos attribute names are not Chroma metadata keys, so a consumer always writes one of these.
+ * Without an entry the adapter falls back to the attribute path verbatim, and
+ * `request.resource.attr.ownerId` is not a key any document in this collection carries.
+ *
+ * `archived` and `region` are deliberately absent: they are the APPLICATION's metadata keys, never
+ * referenced by demo/policies/document.yaml, and composing them with the adapter's filter is
+ * shape 5. Nothing declares `required: true` either, because the demo policy never produces a
+ * `$ne`/`$nin` — the operators that assertion exists to permit.
+ */
+const FIELD_NAME_MAPPER: FieldMapper = {
+  "request.resource.attr.ownerId": "ownerId",
+  "request.resource.attr.public": "public",
+};
+
+/**
+ * The application's OWN predicate. Never expressed in policy; declared in demo/seeds.json.
+ *
+ * Spelled as an explicit `$and` rather than as two keys on one object: Chroma's validator rejects
+ * a `where` carrying more than one operator ("Expected 'where' to have exactly one operator, but
+ * got 2"), so the conjunction has to be written out even before anything is composed with it.
+ */
+const APPLICATION_FILTER: Where = {
+  $and: [
+    { archived: { $eq: seeds.applicationFilter.archived } },
+    { region: { $eq: seeds.applicationFilter.region } },
+  ],
+};
+
+/** Both addresses below are supplied, and neither has a fallback. See each in turn. */
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set — run this example through demo/scripts/run-example.sh langchain-chromadb`
+    );
+  }
+  return value;
+}
+
+/**
+ * The shared runner sets this, and a fallback would be actively harmful. The obvious default —
+ * Cerbos's own 3592/3593 — is the address every adapter's `cerbos run` test sidecar binds, so an
+ * unset CERBOS_HOST would not fail: it would quietly plan against the conformance corpus that
+ * sidecar serves, and produce a diff against demo/expected.json that reads as an adapter bug.
+ * demo/README.md requires reaching the PDP at $CERBOS_HOST, "never a hardcoded address", for
+ * exactly that reason.
+ */
+const cerbosHost = requiredEnv("CERBOS_HOST");
+
+/**
+ * Set by this example's own run.sh, which owns the ChromaDB container the way the shared runner
+ * owns the PDP. No fallback here either, for a weaker but real version of the same reason: 8234 is
+ * the port `npm run chroma` and this adapter's CI bind, and a default pointing at it would let a
+ * demo run create and delete collections inside a conformance run's server.
+ */
+const chromaEndpoint = new URL(requiredEnv("CHROMA_URL"));
+const chroma = new ChromaClient({
+  host: chromaEndpoint.hostname,
+  port: Number(chromaEndpoint.port),
+});
+
+const cerbos = new Cerbos(cerbosHost, { tls: false });
+
+/** Exactly `PlanResourcesResponse`, without depending on a package this example never imports. */
+type QueryPlan = Awaited<ReturnType<Cerbos["planResources"]>>;
+
+function principal(id: string): { id: string; roles: string[] } {
+  const found = seeds.principals.find((p) => p.id === id);
+  if (!found) throw new Error(`demo/seeds.json declares no principal '${id}'`);
+  return found;
+}
+
+async function plan(principalId: string, action: string): Promise<QueryPlan> {
+  return cerbos.planResources({
+    principal: principal(principalId),
+    resource: { kind: RESOURCE_KIND },
+    action,
+  });
+}
+
+async function translate(
+  principalId: string,
+  action: string
+): Promise<QueryPlanToChromaDBResult> {
+  return queryPlanToChromaDB({
+    queryPlan: await plan(principalId, action),
+    fieldNameMapper: FIELD_NAME_MAPPER,
+  });
+}
+
+/**
+ * What a consumer actually writes at the call site.
+ *
+ * `undefined` is Chroma's word for "no metadata constraint" — every query method takes `where` as
+ * an optional argument, and leaving it off matches every document. `ALWAYS_DENIED` is a string
+ * sentinel rather than a second `undefined` precisely because the two must not collapse: a denial
+ * that reached a query as "no constraint" would return the whole collection.
+ */
+type Filter = Where | undefined | "denied";
+
+/**
+ * The three plan kinds, mapped onto what Chroma's query methods accept.
+ *
+ * `ALWAYS_ALLOWED` needs the one line of translation in this file. The adapter returns
+ * `filters: {}` for it — an empty clause, which is a faithful spelling of "no constraint" — but
+ * Chroma's own validator rejects `{}` outright: `Expected 'where' to have exactly one operator,
+ * but got 0`. So the caller drops the empty clause instead of forwarding it, both here and inside
+ * `conjoin` below. Getting this wrong is not a silent over-grant; it is a loud `ChromaValueError`
+ * on the first unconditional plan the application meets.
+ *
+ * A `CONDITIONAL` plan with no filter is refused rather than defaulted to "no constraint": the
+ * published type makes `filters` optional across all three kinds, and reading a missing one as
+ * "match everything" is exactly the over-grant this adapter throws to avoid everywhere else.
+ *
+ * There is no `default` arm. The three cases are every `PlanKind`, so a fourth would fail to
+ * compile here rather than reaching a runtime branch nothing exercises.
+ */
+function toFilter(result: QueryPlanToChromaDBResult): Filter {
+  switch (result.kind) {
+    case PlanKind.ALWAYS_DENIED:
+      return "denied";
+    case PlanKind.ALWAYS_ALLOWED:
+      return undefined;
+    case PlanKind.CONDITIONAL: {
+      const filters = result.filters;
+      if (!filters || Object.keys(filters).length === 0) {
+        throw new Error(
+          "a KIND_CONDITIONAL plan carried no filter — refusing to query without one"
+        );
+      }
+      return filters;
+    }
+  }
+}
+
+/**
+ * The adapter's filter ANDed with the application's own. Chroma composes with `$and` over a list
+ * of clauses, so this is one object literal — except that the list must not contain the empty
+ * clause an unconditional plan produces, which is the whole reason `undefined` is handled first
+ * rather than being wrapped like any other operand.
+ */
+function conjoin(
+  adapterFilter: Where | undefined,
+  applicationFilter: Where
+): Where {
+  if (adapterFilter === undefined) return applicationFilter;
+  return { $and: [adapterFilter, applicationFilter] };
+}
+
+/**
+ * A deterministic vector per document.
+ *
+ * The demo domain is about metadata filtering rather than similarity ranking, so nothing below
+ * depends on the distances — but a collection holding one embedding eight times over would not be
+ * exercising the query path a consumer's `where` clause actually travels.
+ */
+function embeddingFor(index: number): number[] {
+  return [0.1, 0.2, 0.3, index / 100];
+}
+
+/** The vector every search below is run from — the first document's own, so it names no constant
+ * the seeding does not already use. */
+const QUERY_EMBEDDING = embeddingFor(0);
+
+/**
+ * A similarity search with the filter attached — `collection.query` is what LangChain's Chroma
+ * vector store calls underneath `similaritySearch`, and `where` is the argument it forwards.
+ *
+ * `nResults` is Chroma's cap on how many neighbours come back, so "no limit" has to be spelled as
+ * the collection size; shape 4 is what varies it. The returned ids are sorted before they are
+ * asserted, because a vector search ranks by distance and demo/expected.json is shared by stores
+ * that have no notion of one.
+ */
+async function findIds(
+  collection: Collection,
+  filter: Filter
+): Promise<string[]> {
+  if (filter === "denied") return [];
+  const results = await collection.query({
+    queryEmbeddings: [QUERY_EMBEDDING],
+    where: filter,
+    nResults: seeds.documents.length,
+  });
+  return [...(results.ids[0] ?? [])].sort();
+}
+
+interface ShapeResult {
+  kind: PlanKind;
+  ids: string[];
+}
+
+interface PaginatedShapeResult extends ShapeResult {
+  pageSize: number;
+  pageSizes: number[];
+}
+
+// ---------------------------------------------------------------------------------------------
+// The five usage shapes
+// ---------------------------------------------------------------------------------------------
+
+/** Shapes 1, 2 and 3: a plain filtered list. The adapter's filter is the whole query. */
+async function filtered(
+  collection: Collection,
+  principalId: string,
+  action: string
+): Promise<ShapeResult> {
+  const result = await translate(principalId, action);
+  return { kind: result.kind, ids: await findIds(collection, toFilter(result)) };
+}
+
+/**
+ * Shape 4: a limit applied on top of the filter, walked to the end of the result set.
+ *
+ * This is the one shape that leaves `collection.query` behind. A vector search takes `nResults` —
+ * a limit — but has no offset, so it can return the first page and no other; the second page needs
+ * `collection.get`, Chroma's metadata-only retrieval path, which takes the same `where` clause plus
+ * `limit` and `offset`. Both halves are worth exercising: the filter this adapter emits has to be
+ * accepted by whichever of the two a consumer reaches for.
+ *
+ * Reported as page SIZES plus the sorted union of the ids, never as per-page order —
+ * demo/expected.json is shared by every store and several of them have no total order to paginate
+ * by. Disjointness still falls out: overlapping pages would shrink the union below the sum.
+ *
+ * There is no ordering argument to add, unlike the SQL-backed examples, which sort by id so that
+ * limit/offset cannot repeat or omit a row between pages. `collection.get` takes `limit` and
+ * `offset` and nothing to order by, so the pages arrive in whatever order the store walks the
+ * collection in. That is enough for what is asserted here, and it is the assertion rather than a
+ * documented guarantee that makes it enough: a walk that reordered between two calls would show up
+ * as a union shorter than the sum of the page sizes, which is a failure, not a silent pass.
+ */
+async function paginated(
+  collection: Collection,
+  principalId: string,
+  action: string,
+  pageSize: number
+): Promise<PaginatedShapeResult> {
+  const result = await translate(principalId, action);
+  const filter = toFilter(result);
+
+  const pageSizes: number[] = [];
+  const ids: string[] = [];
+  if (filter !== "denied") {
+    for (let offset = 0; ; offset += pageSize) {
+      const page = await collection.get({
+        where: filter,
+        limit: pageSize,
+        offset,
+      });
+      if (page.ids.length === 0) break;
+      pageSizes.push(page.ids.length);
+      ids.push(...page.ids);
+      if (page.ids.length < pageSize) break;
+    }
+  }
+
+  return { kind: result.kind, pageSize, pageSizes, ids: ids.sort() };
+}
+
+/**
+ * Shape 5: the adapter's filter ANDed with the application's own predicate. All three plan kinds
+ * go through here on purpose — an `ALWAYS_ALLOWED` plan has no clause to AND with, and an
+ * `ALWAYS_DENIED` one must not have its denial undone by the application's predicate.
+ */
+async function composed(
+  collection: Collection,
+  principalId: string,
+  action: string
+): Promise<ShapeResult> {
+  const result = await translate(principalId, action);
+  const filter = toFilter(result);
+  if (filter === "denied") {
+    return { kind: result.kind, ids: [] };
+  }
+  return {
+    kind: result.kind,
+    ids: await findIds(collection, conjoin(filter, APPLICATION_FILTER)),
+  };
+}
+
+// ---------------------------------------------------------------------------------------------
+// The collection
+// ---------------------------------------------------------------------------------------------
+
+async function seed(): Promise<Collection> {
+  try {
+    await chroma.deleteCollection({ name: COLLECTION_NAME });
+  } catch (error: unknown) {
+    if (!(error instanceof ChromaNotFoundError)) throw error;
+  }
+
+  // `embeddingFunction: null` because this example supplies its own vectors. Left unset, the
+  // client reaches for @chroma-core/default-embed, which is not installed and which an example
+  // proving packaging has no business downloading a model for.
+  const collection = await chroma.createCollection({
+    name: COLLECTION_NAME,
+    embeddingFunction: null,
+  });
+
+  await collection.add({
+    ids: seeds.documents.map(({ id }) => id),
+    embeddings: seeds.documents.map((_, index) => embeddingFor(index)),
+    // Two of these four keys are what the policy's conditions resolve to through the mapper above;
+    // the other two are the application's, and exist only to be composed with in shape 5.
+    metadatas: seeds.documents.map((document) => ({
+      ownerId: document.ownerId,
+      public: document.public,
+      region: document.region,
+      archived: document.archived,
+    })),
+    documents: seeds.documents.map(
+      (document) => `Document ${document.id}, owned by ${document.ownerId}.`
+    ),
+  });
+
+  return collection;
+}
+
+async function main(): Promise<void> {
+  const collection = await seed();
+  console.error(`seeded ${seeds.documents.length} documents`);
+
+  const shapes = {
+    filtered: {
+      "alice/view": await filtered(collection, "alice", "view"),
+      "bob/view": await filtered(collection, "bob", "view"),
+    },
+    alwaysAllowed: {
+      "admin/admin-view": await filtered(collection, "admin", "admin-view"),
+    },
+    alwaysDenied: {
+      "alice/publish": await filtered(collection, "alice", "publish"),
+    },
+    paginated: {
+      "alice/view": await paginated(collection, "alice", "view", 2),
+      "admin/admin-view": await paginated(collection, "admin", "admin-view", 3),
+    },
+    composed: {
+      "alice/view": await composed(collection, "alice", "view"),
+      "bob/view": await composed(collection, "bob", "view"),
+      "admin/admin-view": await composed(collection, "admin", "admin-view"),
+      "alice/publish": await composed(collection, "alice", "publish"),
+    },
+  };
+
+  process.stdout.write(
+    `${JSON.stringify({ adapter: "langchain-chromadb", shapes }, null, 2)}\n`
+  );
+}
+
+void (async () => {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/langchain-chromadb/example/tsconfig.json
+++ b/langchain-chromadb/example/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  // `nodenext` resolution is load-bearing, not a style choice: it is what makes TypeScript read
+  // the adapter's `exports` map. The legacy `node10` resolver ignores `exports` entirely and
+  // falls back to `main`/`types`, so a broken `exports` map would compile clean here and only
+  // fail for a consumer.
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/langchain-chromadb/src/index.ts
+++ b/langchain-chromadb/src/index.ts
@@ -23,12 +23,18 @@ export type FieldMapper =
   | Record<string, FieldNameMapperValue>
   | ((key: string) => FieldNameMapperValue);
 
-interface QueryPlanToChromaDBArgs {
+export interface QueryPlanToChromaDBArgs {
   queryPlan: PlanResourcesResponse;
   fieldNameMapper: FieldMapper;
 }
 
-interface QueryPlanToChromaDBResult {
+// Exported so a consumer can name what it is handed, as prisma and drizzle already do for theirs.
+// A caller that passes the result to a function of its own — which is what composing the clause
+// with an application-owned one looks like — otherwise has to write it out or reach for
+// `ReturnType<typeof queryPlanToChromaDB>`. Found by `example/`, which is the only thing here that
+// resolves this package through its published surface
+// (docs/adr/0002-examples-install-the-packed-artifact.md).
+export interface QueryPlanToChromaDBResult {
   kind: PlanKind;
   filters?: Where;
 }


### PR DESCRIPTION
Adds `langchain-chromadb/example/`: a program taking no arguments that installs
`@cerbos/langchain-chromadb` from `npm pack`'s tarball, exercises the five usage shapes against
the shared demo domain, and prints the JSON document `demo/scripts/run-example.sh` diffs against
`demo/expected.json`. Plus the `example` job in `.github/workflows/chromadb.yaml`.

Adapter affected: **langchain-chromadb**. No translation behaviour changes — the only `src/`
change is additive (see "One adapter change" below).

Fixes #354. Part of #349.

## How each of the five shapes is expressed

| # | Shape | Expressed as |
|---|---|---|
| 1 | Plain filtered list | `collection.query({ queryEmbeddings, where: filters, nResults: <collection size> })` — the similarity search LangChain's Chroma vector store calls underneath `similaritySearch`, with the adapter's clause as its `where`. `nResults` is Chroma's cap on neighbours, so "no limit" has to be spelled as the collection size. |
| 2 | `KIND_ALWAYS_ALLOWED` | The same call with `where` **omitted**. See below — the adapter returns `filters: {}` and Chroma rejects an empty clause. |
| 3 | `KIND_ALWAYS_DENIED` | Short-circuits to `[]` without touching Chroma at all, which is what `expected.json` asks for ("must return no rows without querying for a filter that does not exist"). |
| 4 | Pagination / limit | `collection.get({ where, limit, offset })`, walked to exhaustion. Page sizes `[2,2,1]` and `[3,3,2]` come off the server. |
| 5 | Composition with an application-owned filter | `{ $and: [adapterFilter, applicationFilter] }`, across all three plan kinds. |

### Shape 4 — a note for #349

The issue says "Shape 4 is `nResults`". `nResults` alone cannot satisfy `demo/expected.json`:
`validate-demo.sh` requires `pageSizes` to span more than one page and to sum to the full id list,
and Chroma's vector search takes a limit with **no offset beside it**, so it can return the first
page and no other.

The second page needs `collection.get` — Chroma's metadata-only retrieval path, which takes the
same `where` clause plus `limit` and `offset`. So the example uses `query` for shapes 1/2/3/5 and
`get` for shape 4. That is not a carve-out and `demo/expected.json` is untouched: both are real
ChromaDB calls carrying the same adapter-produced clause, and exercising both is arguably the
better coverage — the clause has to be accepted by whichever of the two a consumer reaches for.

`collection.get` also takes nothing to order by, unlike the SQL-backed examples which sort by id
so limit/offset cannot repeat or omit a row. The assertion is on page **sizes** and the sorted
union, so a walk that reordered between calls would show up as a union shorter than the sum of the
sizes — a failure, not a silent pass. That reasoning is a comment on `paginated`.

### Shape 5 — how it composes

`APPLICATION_FILTER` is built from `seeds.applicationFilter` (`archived == false AND region ==
'emea'`), never restated, and spelled as an explicit `$and` because Chroma's validator rejects a
`where` carrying more than one top-level operator. Composition is then
`{ $and: [adapterFilter, APPLICATION_FILTER] }` — with two exceptions that are the point of the
shape:

- `KIND_ALWAYS_DENIED` returns before a clause is built, so the application's predicate cannot
  resurrect a denied row.
- `KIND_ALWAYS_ALLOWED` yields the application's predicate **alone**, not `{ $and: [{}, ...] }`.

### The one place the plan kinds do not land cleanly

The adapter returns `filters: {}` for `KIND_ALWAYS_ALLOWED` — an empty clause, a faithful spelling
of "there is nothing to filter on". Chroma's own validator rejects it:

```
ChromaValueError: Expected 'where' to have exactly one operator, but got 0
```

…and rejects `{ $and: [{}, applicationFilter] }` for the same reason. So `undefined` — omitting
`where` — is what "no constraint" is spelled as on this store, and the caller drops the empty
clause rather than forwarding it, at the top level and inside `$and`. This is a loud failure rather
than a silent over-grant, but it is the kind of thing only a program that actually calls the store
finds, which is the case for `demo/` in one paragraph. Documented in the example's README and in
`toFilter`/`conjoin`.

`KIND_ALWAYS_DENIED` is a string sentinel rather than a second `undefined` precisely so the two
cannot collapse: a denial reaching a query as "no constraint" would return the whole collection.

## One adapter change

`QueryPlanToChromaDBArgs` and `QueryPlanToChromaDBResult` are now **exported**. They were declared
without `export`, while prisma and drizzle both export theirs and both of their examples import the
name. Shape 5 is what surfaced it: passing the adapter's result to a function of your own is
exactly what composing a clause looks like, and there was no name to write — the first draft used
`ReturnType<typeof queryPlanToChromaDB>`.

Additive to the published surface, no behaviour change, no corpus or golden-expectation impact.
This is the class of defect ADR 0002 says a harness importing from `"."` structurally cannot see.

## Peer dependency arrangement (#420 / #419)

The packed artifact works as a consumer's install, both ways:

- **Example declares `@cerbos/core`** (following `convex/example/` and the adapter's own README,
  which tells a consumer to `npm install @cerbos/langchain-chromadb @cerbos/core`). `npm ls` shows
  **one deduped copy** — `@cerbos/grpc@0.29.0` pulls `@cerbos/core@0.33.0` and the adapter's peer
  resolves to the same one. No second copy, so no #419-shaped `instanceof` hazard (which the
  adapter is shape-matching-immune to anyway).
- **A bare consumer declaring nothing** also resolves: installing the tarball alone into an empty
  package gives `@cerbos/langchain-chromadb@0.1.0 -> @cerbos/core@0.33.0` from npm's automatic peer
  install, with no unmet-peer warning, and `require("@cerbos/langchain-chromadb")` returns
  `['PlanKind', 'queryPlanToChromaDB']` and translates.

Same finding as convex: nothing to fix.

## CI

The `example` job lives in `.github/workflows/chromadb.yaml`, path-gated on `langchain-chromadb/**`
plus `demo/**`, one Node leg. The comment on it says why it must stay there: `renovate.json`
automerges non-major bumps, so a `chromadb` bump arrives as one PR touching both
`langchain-chromadb/package.json` and the example's manifest, and this job — a check on that PR —
is what blocks the automerge when the new client breaks real usage. A nightly or standalone
workflow silently restores that gap. The example's lockfile is committed for the same reason.

ChromaDB is started by the example's own `run.sh` on **18234** rather than 8234, from the image
`langchain-chromadb/CHROMA_IMAGE` already pins (read at runtime, so there is no second pin to
drift). A demo server on 8234 would let this example create and delete collections inside the
server a conformance run is using — the collision `demo/docker-compose.yml` avoids by publishing
the PDP on 13592/13593.

## Reproducing locally

Needs `docker`, `jq` and Node 22+. Nothing else — the runner starts the pinned PDP and `run.sh`
starts ChromaDB.

```bash
demo/scripts/run-example.sh langchain-chromadb
```

## Commands run

| Command | Result |
|---|---|
| `demo/scripts/run-example.sh langchain-chromadb` | **pass** — "matched demo/expected.json across 5 usage shapes" |
| `demo/scripts/validate-demo.sh` | **pass** — all five checks; example coverage now 5/10 |
| `conformance/scripts/validate-demo.sh` → `conformance/scripts/validate-corpus.sh` | **pass** — 199 actions, 21 seeds |
| `conformance/scripts/check-docs.sh` | **pass** — TOC in sync, no roster counts in prose |
| `langchain-chromadb$ npm run build` | **pass** |
| `langchain-chromadb$ npm run typecheck` | **pass** |
| `langchain-chromadb$ npm test` | **pass** — 222 tests (offline translator unit test; no sidecar, no ChromaDB) |
| `npm pack --dry-run` | 10 files, `example/` excluded from the artifact (ADR 0002) |

Everything was run against the **pinned** PDP — `ghcr.io/cerbos/cerbos:0.54.0@sha256:211c261f…537ef`,
started from `demo/docker-compose.yml`, verified by container label `org.opencontainers.image.version=0.54.0`
— not the local `cerbos` CLI, which is 0.55.0 on this machine.
