### PR TITLE
ci(ent,pgx): point setup-go's cache at each module's go.sum

### DIFF
--- a/.github/workflows/ent.yaml
+++ b/.github/workflows/ent.yaml
@@ -27,10 +27,15 @@ jobs:
       - name: Validate conformance corpus
         run: ../conformance/scripts/validate-corpus.sh
 
+      # cache-dependency-path is not optional here: every Go module in this repository lives in a
+      # subdirectory, and setup-go resolves the default dependency file against the repository root
+      # rather than `defaults.run.working-directory`, which applies to `run` steps alone. Left off,
+      # it finds no go.sum, warns, and silently disables the module cache for the whole job.
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ent/go.mod
+          cache-dependency-path: ent/go.sum
 
       - name: Lint
         uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 # v9.3.0
@@ -92,10 +97,13 @@ jobs:
       - name: Validate demo domain
         run: ../demo/scripts/validate-demo.sh
 
+      # The example is its own module, so it caches against its own go.sum — see the note on the
+      # test job's Setup Go for why the path has to be spelled out at all.
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: ent/example/go.mod
+          cache-dependency-path: ent/example/go.sum
 
       # The example is a nested module, so `./...` in the job above stops at its directory and
       # nothing there is linted by it. Held to the adapter's own configuration rather than a

--- a/.github/workflows/ent.yaml
+++ b/.github/workflows/ent.yaml
@@ -54,8 +54,13 @@ jobs:
       # and running it with the adversarial test skipped is what keeps "these tests need no Docker"
       # a checked claim. Under `./...` a unit test that grew a container dependency would be
       # invisible, because the suite that follows starts Docker anyway.
+      # -count=1 on both suites: the Setup Go cache above covers GOCACHE as well as GOMODCACHE,
+      # and GOCACHE holds Go's test *result* cache — so without it, a re-run of an unchanged commit
+      # prints `ok ... (cached)` in zero seconds and neither the PDP nor the databases are ever
+      # started. A green run has to mean the suite ran. The compiled-package half of that cache is
+      # untouched and is where the time is actually saved.
       - name: Unit suite (no Docker)
-        run: go test -race -skip TestAdversarialConformance ./...
+        run: go test -race -count=1 -skip TestAdversarialConformance ./...
 
       # The harness starts its own Cerbos PDP with testcontainers, reading the pinned version from
       # conformance/CERBOS_VERSION — there is no separate sidecar to set up, and the version is
@@ -64,7 +69,7 @@ jobs:
       # WithDialect is actually exercised. Three dialect legs share one PDP and one plan pass;
       # the timeout allows for the extra container start.
       - name: Adversarial conformance suite
-        run: go test -race -timeout 30m ./...
+        run: go test -race -count=1 -timeout 30m ./...
 
   # The example application: the adapter used the way a consumer uses it, against the shared demo
   # domain. It covers the one thing the job above structurally cannot — the usage shapes. That

--- a/.github/workflows/pgx.yaml
+++ b/.github/workflows/pgx.yaml
@@ -27,10 +27,15 @@ jobs:
       - name: Validate conformance corpus
         run: ../conformance/scripts/validate-corpus.sh
 
+      # cache-dependency-path is not optional here: every Go module in this repository lives in a
+      # subdirectory, and setup-go resolves the default dependency file against the repository root
+      # rather than `defaults.run.working-directory`, which applies to `run` steps alone. Left off,
+      # it finds no go.sum, warns, and silently disables the module cache for the whole job.
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: pgx/go.mod
+          cache-dependency-path: pgx/go.sum
 
       - name: Lint
         uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 # v9.3.0
@@ -82,10 +87,13 @@ jobs:
       - name: Validate demo domain
         run: ../demo/scripts/validate-demo.sh
 
+      # The example is its own module, so it caches against its own go.sum — see the note on the
+      # test job's Setup Go for why the path has to be spelled out at all.
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: pgx/example/go.mod
+          cache-dependency-path: pgx/example/go.sum
 
       # The example is a nested module, so `./...` in the job above stops at its directory and
       # nothing there is linted by it. Held to the adapter's own configuration rather than a

--- a/.github/workflows/pgx.yaml
+++ b/.github/workflows/pgx.yaml
@@ -54,14 +54,19 @@ jobs:
       # test skipped is what keeps "these tests need no Docker" a checked claim. Under `./...` a unit
       # test that grew a container dependency would be invisible, because the suite that follows
       # starts Docker anyway.
+      # -count=1 on both suites: the Setup Go cache above covers GOCACHE as well as GOMODCACHE,
+      # and GOCACHE holds Go's test *result* cache — so without it, a re-run of an unchanged commit
+      # prints `ok ... (cached)` in zero seconds and neither the PDP nor PostgreSQL is ever started.
+      # A green run has to mean the suite ran. The compiled-package half of that cache is untouched
+      # and is where the time is actually saved.
       - name: Unit suite (no Docker)
-        run: go test -race -skip TestAdversarialConformance ./...
+        run: go test -race -count=1 -skip TestAdversarialConformance ./...
 
       # The harness starts its own Cerbos PDP with testcontainers, reading the pinned version from
       # conformance/CERBOS_VERSION — there is no separate sidecar to set up, and the version is
       # never hardcoded here. It also seeds a PostgreSQL testcontainer, from pgx/POSTGRES_IMAGE.
       - name: Adversarial conformance suite
-        run: go test -race -timeout 20m ./...
+        run: go test -race -count=1 -timeout 20m ./...
 
   # The example application, against the shared demo domain in demo/. It proves what the job above
   # structurally cannot: the usage shapes — this adapter returns SQL text, so the load-bearing one is


### PR DESCRIPTION
Both Go workflows emitted a warning annotation on every run:

> Restore cache failed: Dependencies file is not found in `/home/runner/work/query-plan-adapters/query-plan-adapters`. Supported file pattern: go.mod

`actions/setup-go` resolves its default dependency file against `GITHUB_WORKSPACE` — the repository root — not `defaults.run.working-directory`, which applies to `run` steps alone. Every Go module in this repository lives in a subdirectory, so `findDependencyFile` found no `go.mod` at the root, threw, and left the module cache neither restored nor saved. Each run re-downloaded the whole dependency tree.

Passing `cache-dependency-path` short-circuits that root lookup entirely, at all four call sites:

| Workflow | Job | Path | Cache key |
|---|---|---|---|
| `ent.yaml` | `test` | `ent/go.sum` | `…6eed9b65…` |
| `ent.yaml` | `example` | `ent/example/go.sum` | `…d389a427…` |
| `pgx.yaml` | `test` | `pgx/go.sum` | `…2f08a5c5…` |
| `pgx.yaml` | `example` | `pgx/example/go.sum` | `…060ee679…` |

`go.sum` rather than `go.mod`, so the cache key tracks the resolved dependency versions. Four distinct keys, confirming each module caches independently.

The fourth arrived mid-review: #429 landed the pgx example while this was open, and its new `example` job carried the same omission. It is fixed here rather than left to start emitting the annotation on merge.

## The second commit is not optional

setup-go caches `go env GOCACHE` as well as `go env GOMODCACHE`, and GOCACHE holds Go's test *result* cache. With the cache finally being restored, re-running an unchanged commit produced:

```
ok  github.com/cerbos/query-plan-adapters/ent  (cached)
```

in **zero seconds** — the adversarial suite reported success without starting the PDP, PostgreSQL or MySQL. That is a new failure mode created by the first commit: before it, nothing was ever restored, so the suites always ran.

So both `go test` invocations in both workflows now pass `-count=1`. That defeats the result cache only; the compiled-package cache is untouched and is where the time is actually saved.

## Affected adapters

`ent` and `pgx` — CI only. No adapter source, no corpus, no demo domain, and nothing about what either adapter can translate.

## Verification

- [x] **The annotation is gone.** Zero annotations on every job, every attempt.
- [x] **A second run reports a cache hit.** All four keys verified cold → saved → restored; each job restores the key its own module saved.
- [x] **The cache does real work.** `Lint` fell from 64s to 3s on ent and 50s to 2s on pgx.
- [x] **`-count=1` keeps runs honest.** Cache still hits, no `(cached)` result appears on any job, and the suites visibly execute (ent adversarial 96s, pgx 41s) while `Lint` stays at 3s.

## Notes

Pre-existing on `main`, not introduced by #427; it was left out of that PR to keep it scoped.