### PR TITLE
feat(elasticsearch-java): example application for the shared demo domain

### DIFF
--- a/.github/workflows/elasticsearch-java.yaml
+++ b/.github/workflows/elasticsearch-java.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - "elasticsearch-java/**"
       - "conformance/**"
+      - "demo/**"
       - ".github/workflows/elasticsearch-java.yaml"
   push:
     tags:
@@ -37,3 +38,78 @@ jobs:
 
       - name: Build and test
         run: gradle build --no-daemon
+
+  # The example application, against the shared demo domain in demo/. It proves what the job above
+  # structurally cannot, and for this adapter the two halves are unusually separable:
+  #
+  #   1. The PUBLISHED package surface. Every suite in `test` compiles against the adapter's own
+  #      source set, so its POM and Gradle module metadata — dependency scopes included — are
+  #      executed nowhere. The example resolves `dev.cerbos:cerbos-elasticsearch` from mavenLocal as
+  #      a real Maven coordinate instead, which is why the step below publishes it first. NOT a
+  #      Gradle composite build: that substitutes the local source tree for the coordinate and
+  #      resolves neither file. See docs/adr/0002-examples-install-the-packed-artifact.md;
+  #      cerbos-sdk-java declaring protobuf at runtime-only scope is the shape of bug this exists for,
+  #      and elasticsearch-java/example/README.md records the break-tests that prove the arrangement
+  #      is load-bearing rather than decorative.
+  #   2. The Elasticsearch Java CLIENT. This adapter hands back a `Map<String, Object>` of plain JDK
+  #      values with no client type in its signature, so nothing in `test` ever asks the client
+  #      library to parse what it emits — the translator suite compares the map to a golden asset and
+  #      the conformance harness posts it as raw JSON over a bare HttpClient. The example is the only
+  #      place a generated `Query` is built from an emitted clause, paginated with `from`/`size`, and
+  #      composed with a `bool` clause the application owns.
+  #
+  # THIS JOB MUST STAY IN THIS WORKFLOW. renovate.json sets `automerge: true` for every non-major
+  # bump, and that is the path an Elasticsearch-client or Cerbos-SDK regression takes into `main`
+  # today: the bump arrives as one PR touching this adapter's manifest and the example's, and this
+  # job, being a check on that PR, is what blocks the automerge when the new version breaks real
+  # usage. Moved to a nightly run or a workflow of its own it would still pass or fail eventually,
+  # but not before the merge, which silently restores the gap it exists to close.
+  #
+  # What makes that bite is that every version the example resolves is an exact literal in a file
+  # under elasticsearch-java/, and example/build.gradle.kts calls `failOnDynamicVersions()` so it
+  # stays that way. There is deliberately no gradle.lockfile: Renovate can only maintain one by
+  # executing `./gradlew`, which this repository has no wrapper for and which the hosted app will not
+  # run without `allowedUnsafeExecutions`, so a committed lockfile would go stale on the first bump
+  # and fail this job for a reason that is not the bump. example/README.md has the full argument.
+  #
+  # One language-version leg on purpose: the demo domain discriminates the adapter's packaging and
+  # usage shapes, not the JDK. It runs on 17, the floor the adapter declares, which is the leg where a
+  # post-17 API reference in either the adapter or the example would surface.
+  example:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The example reaches a pinned PDP through demo/docker-compose.yml and a pinned Elasticsearch
+      # through elasticsearch-java/ELASTICSEARCH_IMAGE, and these two scripts are what assert those
+      # pins still agree with conformance/CERBOS_VERSION and conformance/CERBOS_IMAGE_DIGEST. Without
+      # them the run below would happily execute the whole end-to-end flow against a drifted PDP.
+      - name: Validate conformance corpus
+        run: ../conformance/scripts/validate-corpus.sh
+
+      - name: Validate demo domain
+        run: ../demo/scripts/validate-demo.sh
+
+      - name: Setup JDK
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          # Pinned rather than taking the runner's floating preinstall, which is what the `test` job
+          # above does: this job's assertions are about resolution and publication, the two things a
+          # Gradle major is most likely to change the behaviour of. The version matches the Gradle
+          # container image the adapter's README documents building in.
+          gradle-version: "8.12"
+
+      # The PDP is a container the runner starts from demo/docker-compose.yml, pinned to
+      # conformance/CERBOS_VERSION and conformance/CERBOS_IMAGE_DIGEST — no cerbos-setup-action here,
+      # because an example must reach the PDP the way a deployed application does. Elasticsearch is
+      # example/run.sh's own, from elasticsearch-java/ELASTICSEARCH_IMAGE, and run.sh also publishes
+      # the adapter to mavenLocal for itself so that this is one command on a laptop too.
+      - name: Run the example against the demo domain
+        run: ../demo/scripts/run-example.sh elasticsearch-java

--- a/elasticsearch-java/ELASTICSEARCH_IMAGE
+++ b/elasticsearch-java/ELASTICSEARCH_IMAGE
@@ -1,0 +1,1 @@
+docker.elastic.co/elasticsearch/elasticsearch:8.15.3@sha256:01c1732062b4a846c5ca687b0094b89bad0bfed00c6d71626db32fb8f3131a78

--- a/elasticsearch-java/README.md
+++ b/elasticsearch-java/README.md
@@ -32,6 +32,12 @@ An adapter library that takes a [Cerbos](https://cerbos.dev) Query Plan ([PlanRe
 
 This adapter is not published to Maven Central. Copy the source files directly into your project:
 
+> The build does configure `publishToMavenLocal`, and [`example/`](example/) resolves
+> `dev.cerbos:cerbos-elasticsearch` from mavenLocal as a real Maven coordinate. That exists so the
+> example executes the POM and Gradle module metadata a consumer would resolve
+> ([ADR 0002](../docs/adr/0002-examples-install-the-packed-artifact.md)); it is **not** a release, and
+> nothing configures the POM metadata or signing Maven Central requires.
+
 1. Copy `ElasticsearchQueryPlanAdapter.java` and `OperatorFunction.java` from [`src/main/java/dev/cerbos/queryplan/elasticsearch/`](src/main/java/dev/cerbos/queryplan/elasticsearch/) into your project.
 2. Adjust the `package` declaration to match your project structure.
 3. Add the required dependencies:
@@ -550,6 +556,25 @@ Four suites, and which of them needs a container is the useful distinction:
 | `ElasticsearchAdversarialConformanceTest` | the documents those queries return, against per-row `check()` | a pinned Cerbos PDP and Elasticsearch (Testcontainers) |
 | `ElasticsearchSurfaceTest` | what a real server does with an emitted clause, and the store facts the corpus reasons cite — an unindexed empty array, an unindexed JSON null, an analyzed field, Lucene regex, date precision | Elasticsearch (Testcontainers) |
 | `ElasticsearchQueryPlanAdapterTest` | the shapes no policy can produce — malformed operands, caller-supplied arguments, literal validation — plus a handful of shapes the corpus does not carry yet, each labelled | nothing |
+
+The Elasticsearch server the two container-backed suites start is pinned in
+[`ELASTICSEARCH_IMAGE`](ELASTICSEARCH_IMAGE), as `repo:tag@sha256:...`, and read by
+`ElasticsearchTestImage` — and by [`example/run.sh`](example/run.sh), which is why it is a file rather
+than a Java constant. `conformance/scripts/validate-corpus.sh` holds one digest per tag repository
+wide, so a second spelling of the reference could be left behind on an older server and stay green.
+
+## Example application
+
+[`example/`](example/README.md) is a runnable program over the shared
+[demo domain](../demo/README.md). It covers the two things none of the suites above can: the
+**published** package surface — the example resolves the adapter as a Maven coordinate rather than
+compiling its source set, so the POM's dependency scopes are executed — and the **Elasticsearch Java
+client**, which nothing above ever hands an emitted clause to.
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh elasticsearch-java
+```
 
 ### Regenerating the golden expectations
 

--- a/elasticsearch-java/build.gradle.kts
+++ b/elasticsearch-java/build.gradle.kts
@@ -1,5 +1,12 @@
 plugins {
     java
+    // For `publishToMavenLocal`. example/ resolves the adapter as a real Maven coordinate rather
+    // than through a Gradle composite build, so the example executes the POM and the Gradle module
+    // metadata a consumer resolves — dependency scopes included. That is the whole point of
+    // docs/adr/0002-examples-install-the-packed-artifact.md, and it is not hypothetical here:
+    // cerbos-sdk-java declares protobuf at runtime-only scope in its own module metadata, which a
+    // composite build hides and a coordinate exposes.
+    `maven-publish`
 }
 
 group = "dev.cerbos"
@@ -57,6 +64,12 @@ tasks.test {
     inputs.dir(project.file("golden"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
         .withPropertyName("goldenExpectations")
+    // Same again for the pinned Elasticsearch reference, which ElasticsearchTestImage reads from
+    // `user.dir` at runtime. Undeclared, bumping the server would leave `:test` UP-TO-DATE and the
+    // two container-backed suites would report a pass they never ran.
+    inputs.file(project.file("ELASTICSEARCH_IMAGE"))
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+        .withPropertyName("elasticsearchImage")
 }
 
 // Rewrites golden/expectations.json from the Query DSL the translator emits today, then asserts
@@ -83,5 +96,43 @@ tasks.register<Test>("goldenUpdate") {
     testLogging {
         events("failed")
         showStandardStreams = true
+    }
+}
+
+// One publication, `dev.cerbos:cerbos-elasticsearch:<version>`, from the `java` component.
+//
+// What it publishes is the point: the `implementation` dependencies (cerbos-sdk-java,
+// protobuf-java) land at RUNTIME scope, which is what example/ resolves and therefore executes. That
+// scope is not a formality — it is why example/build.gradle.kts has to declare cerbos-sdk-java for
+// itself in order to compile against `PlanResourcesResult`, and it is the half a Gradle composite
+// build substitutes away.
+//
+// The protobuf-java version here is the pin README.md's Install section tells a consumer to add.
+// Measured rather than assumed while example/ was being written: at cerbos-sdk-java 0.19.0 the SDK's
+// own POM already requires protobuf-java 4.35.1 at runtime scope, so for a consumer who declares the
+// SDK — as the example does, and as anyone calling `cerbos.plan(...)` must — this line changes
+// nothing today. It is a floor against the SDK relaxing that requirement and letting the older
+// protobuf-java gRPC drags in transitively win, which throws
+// RuntimeVersion$ProtobufRuntimeVersionException at first message decode. Worth knowing before
+// reading it as the thing example/ proves: what example/ proves about this metadata is that it is
+// resolved at all, and example/README.md records the break-test that establishes it.
+//
+// The example is never part of the artifact: it is a separate Gradle build under example/ with its
+// own settings file, so it is not a source set here and cannot reach the jar. example/run.sh
+// asserts that rather than leaving it to inspection — ADR 0002's "examples must stay out of the
+// published artifacts they exercise", which for Java is a deliberate check rather than a `files`
+// allowlist.
+//
+// This is `publishToMavenLocal` only. Nothing here configures a Maven Central release, which
+// additionally requires POM `name`, `description`, `url`, `licenses`, `developers` and `scm`, plus
+// signing — Central rejects a POM without them. README.md's Install section still tells a consumer
+// to copy the two source files, because that is what this adapter ships today; what the example
+// resolves is the dependency metadata, which is what it exists to exercise. Wiring up the
+// `elasticsearch-java/v*` release is separate work, and it will change this block.
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
     }
 }

--- a/elasticsearch-java/example/.gitignore
+++ b/elasticsearch-java/example/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/elasticsearch-java/example/README.md
+++ b/elasticsearch-java/example/README.md
@@ -1,0 +1,271 @@
+# elasticsearch-java adapter example application
+
+A runnable program that uses the adapter the way a consumer would — handing the Query DSL map it
+returns to the official Elasticsearch Java client — over the shared
+[demo domain](../../demo/README.md), against a real Elasticsearch server.
+
+```bash
+# from the repository root
+demo/scripts/run-example.sh elasticsearch-java
+```
+
+Needs `docker` (with compose), `curl`, `jq`, Gradle 8.x and a JDK 17+. The runner starts the pinned
+Cerbos PDP; this directory's `run.sh` publishes the adapter to mavenLocal, starts Elasticsearch,
+builds this example against the published coordinate and runs the program.
+
+## What this example covers that the adapter's own suites cannot
+
+**Packaging.** All four suites under [`../src/test`](../src/test) compile against the adapter's own
+source set, so its POM and Gradle module metadata — dependency scopes included — are executed
+nowhere. This example resolves `dev.cerbos:cerbos-elasticsearch` from mavenLocal as a real Maven
+coordinate instead. See
+[ADR 0002](../../docs/adr/0002-examples-install-the-packed-artifact.md).
+
+**Not a Gradle composite build**, which is the shortcut this arrangement exists to refuse.
+`includeBuild("..")` substitutes the adapter's local project for the declared coordinate and
+resolves neither its POM nor its module metadata, so the dependency scopes go unexecuted while
+everything still compiles and passes. `cerbos-sdk-java` declaring protobuf at runtime-only scope is
+the precedent ADR 0002 names, and this adapter's own POM puts *both* of its dependencies at runtime
+scope:
+
+```xml
+<dependency>
+  <groupId>dev.cerbos</groupId><artifactId>cerbos-sdk-java</artifactId>
+  <version>0.19.0</version><scope>runtime</scope>
+</dependency>
+<dependency>
+  <groupId>com.google.protobuf</groupId><artifactId>protobuf-java</artifactId>
+  <version>4.35.1</version><scope>runtime</scope>
+</dependency>
+```
+
+That is why [`build.gradle.kts`](build.gradle.kts) declares `cerbos-sdk-java` for itself — the
+program names `PlanResourcesResult`, and a runtime-scoped transitive is not on its compile classpath
+— and why it deliberately does **not** declare `protobuf-java`, which reaches the runtime classpath
+through the adapter's metadata alone.
+
+**Usage shape.** A harness runs one flat filtered query. This runs all
+[five shapes](../../demo/README.md#the-five-usage-shapes), and for this adapter the second half of
+that is unusually load-bearing, because the adapter's signature contains no Elasticsearch type at
+all: it returns a `Map<String, Object>` of plain JDK values. Nothing in `../src/test` ever asks the
+client library to parse one — `ElasticsearchTranslatorTest` compares the map to a golden asset, and
+`ElasticsearchAdversarialConformanceTest` posts it as raw JSON over a bare `HttpClient`. This is the
+only place a generated `Query` is built from an emitted clause.
+
+## The break-tests
+
+Every claim above was checked by breaking it. Each row is one deliberate edit, reverted afterwards;
+the middle column is what `demo/scripts/run-example.sh elasticsearch-java` did, and the right-hand
+column is what the adapter's own `gradle build` did with the same edit in place.
+
+| Break                                                                     | The example                                                                        | `gradle build` |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------- |
+| Adapter source made to throw, republished at the **same version** `0.1.0` | fails — `UnsupportedOperationException` from inside the published jar               | fails too (it compiles the same source) |
+| Adapter's `protobuf-java` given a `strictly("3.25.5")` downgrade          | fails at resolution, naming `'dev.cerbos:cerbos-elasticsearch:0.1.0' (runtimeElements) --> 'com.google.protobuf:protobuf-java:{strictly 3.25.5}'` | unaffected — the adapter itself resolves fine at 3.25.5 |
+| The example's compiled classes added to the adapter's `jar`               | fails — `run.sh` step 2 refuses the artifact before starting anything               | unaffected |
+| `includeBuild("..")` added to `settings.gradle.kts`                       | **builds and resolves happily**, then fails at startup: the adapter was loaded from `../build/libs/` | unaffected |
+| A dependency version changed to the dynamic `8.15.+`                      | fails at resolution: "Resolution strategy disallows usage of dynamic versions"       | unaffected |
+| The Elasticsearch client version changed to `9.0.0`                       | fails at `run.sh` step 3, before the server starts: "the majors must match"           | unaffected |
+
+Row 2 is the one that proves the published *metadata* is resolved rather than merely present: the
+downgrade exists only in the adapter's POM and Gradle module file, and the resolution failure names
+the adapter's `runtimeElements` variant as the path it came in on. Row 4 is the one that proves the
+coordinate is not being quietly substituted, and it is the row worth reading twice — a composite
+build produces a green build and a passing resolution, so nothing except the runtime check in
+[`DemoApplication`](src/main/java/dev/cerbos/example/demo/DemoApplication.java) notices.
+
+### What row 2 also measured, and it is not what the comments used to say
+
+The protobuf pin's usual justification is that gRPC drags an older `protobuf-java` in transitively
+and an older runtime throws `RuntimeVersion$ProtobufRuntimeVersionException` at first message decode.
+The transitive graph does contain them — the failure above lists `grpc-protobuf` asking for 3.25.8,
+`protovalidate` for 4.34.1, `dev.cel` for 4.33.5 — but at **cerbos-sdk-java 0.19.0 the SDK's own POM
+already requires `protobuf-java:4.35.1` at runtime scope**, and that requirement is what wins. So for
+a consumer who declares the SDK — as this example does, and as anyone calling `cerbos.plan(...)` must
+— the adapter's own declaration changes nothing today. It is a floor against the SDK relaxing that
+requirement, not the thing standing between the example and a broken runtime. Stated here because the
+opposite claim is easy to copy from the other Java adapter's comments.
+
+### The same-version hazard that bit the Python example does not reproduce here
+
+[`sqlalchemy/example/`](../../sqlalchemy/example/README.md) found that pip treats an installed
+distribution of the same version as satisfying a local wheel path, so a rebuilt-but-unbumped artifact
+was skipped and the **previous** build stayed installed — turning a hand-checked packaging break into
+a green run. Both halves of that were measured here rather than assumed:
+
+- **Publishing.** `publishToMavenLocal` overwrites `0.1.0` unconditionally. There is no
+  already-satisfied path to skip.
+- **Resolving.** Gradle re-reads a `mavenLocal()` module on every build. With
+  `isChanging = true` and the zero cache TTL both removed, warming the cache with a good build and
+  then republishing a deliberately broken one *still* failed.
+
+`isChanging` and `cacheChangingModulesFor(0, "seconds")` stay in `build.gradle.kts` anyway: the second
+finding is a Gradle behaviour rather than something this build states, and it stops holding the moment
+`mavenLocal` is swapped for any other repository. They cost nothing, and the measurement is recorded
+so nobody has to re-derive it.
+
+### The client version is a second spelling, and something holds it to the pin
+
+`build.gradle.kts` has to name the Elasticsearch client version as a literal, or the Renovate bump
+carrying it never touches this directory (below). That makes it a second spelling of a version this
+directory already knows — [`../ELASTICSEARCH_IMAGE`](../ELASTICSEARCH_IMAGE)'s tag — with nothing
+holding the two together, which is precisely the hazard that file exists to remove for the *server*.
+`run.sh` step 3 closes it, doing the same job `pgx/example/run.sh`'s DSN-port check does.
+
+It compares **majors**, not exact versions. A major mismatch is the real hazard — an 8.x client
+refuses a 9.x server outright, and the adapter's README declares Elasticsearch 8.x — while within a
+major Elastic supports a client at or below the server's minor. Requiring exact equality would turn
+every client bump red until someone bumped the image too, and `renovate.json` extends
+`docker:disable`, so image bumps are made by hand: that is a gate failing for a reason that is not the
+bump, the same state the lockfile argument below rejects.
+
+## The example stays out of the published artifact
+
+ADR 0002 asks for this to be checked deliberately in Java, which has no equivalent of a `files`
+allowlist or Go's nested-module exclusion. What keeps it true is that `example/` is a **separate
+Gradle build** with its own [`settings.gradle.kts`](settings.gradle.kts): it is not a source set of
+the adapter, so `../build.gradle.kts`'s `jar` task cannot reach it.
+
+That is exactly the kind of fact that stops being true without anyone noticing, so `run.sh` asserts
+it on every run — and in **both** directions. The negative half refuses an artifact containing
+`dev/cerbos/example/`; the positive half requires the artifact to contain
+`ElasticsearchQueryPlanAdapter.class`, because otherwise an empty or wrongly-named jar would satisfy
+the negative one and "no example classes in there" would be true of a jar with nothing in it at all.
+
+## How each shape is expressed
+
+| Shape | Expression |
+| ----- | ---------- |
+| 1 — filtered list | the adapter's clause, parsed into a `Query` with `withJson`, as the single entry of `bool.filter` |
+| 2 — `KIND_ALWAYS_ALLOWED` | `Result.AlwaysAllowed` carries no clause; the application supplies `match_all` |
+| 3 — `KIND_ALWAYS_DENIED` | `Result.AlwaysDenied` carries no clause; the application supplies `match_none` |
+| 4 — pagination | the same `bool.filter`, plus Elasticsearch `from`/`size` and a `sort` on the `id` keyword field |
+| 5 — composition | two more entries in the same `bool.filter` array, built with the client's own `TermQuery` builders |
+
+`bool.filter` rather than `bool.must` throughout: an authorization condition is an access control
+filter, not a relevance signal, so it belongs in a filter context where Elasticsearch skips scoring
+and can cache the result. It is also what makes shape 5 a list append.
+
+### `KIND_ALWAYS_ALLOWED` is accepted, unlike ChromaDB's empty filter
+
+Worth stating because the sibling case is a real bug found the same way: on
+[`langchain-chromadb/example/`](../../langchain-chromadb/example/README.md) an unconditional allow
+comes back as `filters: {}` — an empty clause, a faithful spelling of "nothing to filter on" — which
+Chroma's own validator then **rejects** (`Expected 'where' to have exactly one operator, but got 0`),
+and only a program that calls the store discovers it.
+
+This adapter cannot land in that position: an unconditional allow is the distinct sealed variant
+`Result.AlwaysAllowed`, which carries no clause at all rather than an empty one, so there is nothing
+for the caller to forward by mistake. And the empty spelling would have been fine anyway — measured
+against the pinned server rather than assumed: `{"query":{"bool":{"filter":[]}}}` is accepted and
+returns every document.
+
+The explicit `{"match_all":{}}` is used instead, for shape 5's sake: the property that shape exists to
+check is that the application's own predicate cannot resurrect a denied document, and only a search
+that actually runs with both halves in place demonstrates it. An `ALWAYS_DENIED` plan therefore also
+runs its search here, with `match_none`, rather than taking the skip-the-round-trip optimisation the
+[adapter's README](../README.md#handling-different-result-types) shows.
+
+### One construct the client nearly refuses
+
+The adapter emits `bool.minimum_should_match` as the integer `1`, which is what Elasticsearch's own
+JSON accepts. The client models that field as a *string*, and it turns out to parse the integer
+anyway — but it is the sort of mismatch that has no other place to surface in this repository, since
+the golden asset and the raw-JSON harness both bypass the client's generated types entirely. The
+demo domain's policy is `public || ownerId == principal.id`, so shape 1 exercises it on the first
+query rather than leaving it to a hostile shape.
+
+## The index mapping is the consumer's half of the contract
+
+`DemoIndex.recreate` writes the mapping out and sets `dynamic: strict`, and both halves are this
+adapter's own documented hazard — see
+[Analyzed (`text`) field mapping](../README.md#why-an-analyzed-mapping-is-not-something-the-adapter-can-reject).
+Dynamic mapping gives a string field the `text` type, which is tokenized and lowercased before it is
+indexed, and the `term` query the adapter emits for `ownerId == "alice"` would then run against those
+tokens rather than against the stored value. The adapter is handed a plan and never an index, so it
+cannot see the difference. An example is the right place to show a consumer writing the mapping that
+makes the emitted queries mean what the policy said.
+
+## The field map
+
+Cerbos attribute names are not Elasticsearch field names, so a consumer always writes one of these:
+
+```java
+private static final Map<String, String> DOCUMENT_FIELDS = Map.of(
+        "request.resource.attr.ownerId", "ownerId",
+        "request.resource.attr.public", "isPublic");
+```
+
+Without it the adapter has nothing to resolve `request.resource.attr.ownerId` to and throws — which
+is itself worth seeing in an example. `public` maps to `isPublic` because the policy's name for the
+attribute and the index's name for the field are allowed to differ, which is the point of having a
+map at all.
+
+`region` and `archived` are deliberately absent: they are the application's own fields, never
+referenced by [`demo/policies/document.yaml`](../../demo/policies/document.yaml), and composing them
+with the adapter's clause is shape 5.
+
+## Layout
+
+| Path                   | What it is                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| `run.sh`               | publish → check the artifact → start Elasticsearch → build → run. Prints the JSON document on stdout. |
+| `build.gradle.kts`     | The coordinate, the exact dependency versions Renovate manages, and `writeRuntimeClasspath`. |
+| `settings.gradle.kts`  | The file whose *absence* of `includeBuild("..")` is the whole packaging argument.        |
+| `DemoApplication.java` | Entry point: the three inputs it is handed, the provenance check, the emitted document.  |
+| `DemoShapes.java`      | One method per usage shape, plus the field map and the plan call.                        |
+| `DemoIndex.java`       | The store: client wiring, the explicit mapping, and `Map` → `Query`.                     |
+| `DemoSeeds.java`       | `demo/seeds.json`, parsed. The principals are looked up here, never written out.         |
+
+There is no `gradle.lockfile`; see below. The program is launched with `java -cp` from a classpath
+Gradle writes out, rather than through `installDist`, a fat jar or a `JavaExec` task —
+`build.gradle.kts` explains what each of those three loses.
+
+## Why the Renovate gate bites, and why there is no lockfile
+
+`renovate.json` sets `automerge: true` for every non-major bump, so an Elasticsearch-client or
+Cerbos-SDK regression's path into `main` is a PR that nobody looks at. The `example` job in
+[`.github/workflows/elasticsearch-java.yaml`](../../.github/workflows/elasticsearch-java.yaml) is
+what blocks that automerge when the new version breaks real usage — and only while it stays in that
+workflow, which is why there is a comment on the job saying so.
+
+For the job to gate anything, the bump has to **touch this adapter's directory**. Two things make it:
+
+1. **Every version is an exact literal**, in `build.gradle.kts` here or in `../build.gradle.kts` for
+   the adapter's own dependencies — both under `elasticsearch-java/**`, which is the workflow's path
+   filter. Renovate only opens a PR when a release falls outside the declared constraint, so this is
+   the half that matters: `sqlalchemy>=2.0` absorbing every future 2.x silently is the hole
+   [#424](https://github.com/cerbos/query-plan-adapters/issues/424) found, and Gradle's equivalents
+   are the dynamic selectors — `8.15.+`, `latest.release`, `[8.15,8.16)`.
+2. **`failOnDynamicVersions()`**, so that stays a checked property rather than a convention. A
+   dynamic selector fails resolution instead of quietly reopening the hole; the break-test table
+   above has the message it produces.
+
+**There is deliberately no `gradle.lockfile`.** Every example on a toolchain whose lockfile Renovate
+maintains commits one — `package-lock.json`, `pdm.lock`, `go.sum` — and Gradle does have dependency
+locking, so the omission is a decision rather than an oversight. (`spring-data/example/` has no
+lockfile either, and predates the question being asked.)
+
+Renovate can maintain a Gradle lockfile only by executing `./gradlew … --write-locks`, and only when a
+self-hosted administrator has enabled `allowedUnsafeExecutions: ["gradleWrapper"]` — which the hosted
+app is not, and this repository has no wrapper for in any case. A committed lockfile would therefore
+go stale on the very first bump, and this job would fail every bump PR for a reason that is not the
+bump: a gate that is always red distinguishes nothing, which is worse than the gap it closes.
+
+What that leaves uncovered is honest to name: **transitive** versions are not pinned. It is a smaller
+gap in Gradle than in npm or Python, because a Maven POM declares one soft-required version rather
+than a range, so a new transitive release does not enter a build on its own — but it is not zero, and
+locking becomes the right answer the day this repository grows a Gradle wrapper.
+
+## Scope
+
+This example is a JSON-printing CLI, not an onboarding artifact — that is
+[`spring-data/example/`](../../spring-data/example/), and the floor/ceiling rule in
+[ADR 0001](../../docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md) is why both exist.
+
+It runs one Elasticsearch major under one JDK, compiled with `options.release = 17` because 17 is the
+floor the [adapter's README](../README.md#requirements) declares. One consequence is visible in
+[`DemoShapes.authorization`](src/main/java/dev/cerbos/example/demo/DemoShapes.java): the sealed
+`Result` type is matched with an `instanceof` chain rather than the exhaustive `switch` the adapter's
+README shows, because pattern matching for `switch` is standard only from Java 21. Both are correct;
+a consumer on the declared floor gets the first.

--- a/elasticsearch-java/example/build.gradle.kts
+++ b/elasticsearch-java/example/build.gradle.kts
@@ -1,0 +1,129 @@
+plugins {
+    java
+}
+
+group = "dev.cerbos.example"
+version = "0.0.1"
+
+// Java 17 is the adapter's floor (README.md "Requirements"), and `options.release` — unlike
+// source/targetCompatibility — also constrains the JDK API surface, so this example is compiled
+// against exactly the class library a consumer on that floor has. A post-17 API reference fails here
+// instead of with NoSuchMethodError on their JVM.
+tasks.withType<JavaCompile> {
+    options.release = 17
+}
+
+repositories {
+    // The adapter, and only the adapter. `mavenLocal()` unrestricted would let any stale artifact in
+    // ~/.m2 shadow the Central copy of an unrelated dependency, and the resulting build is
+    // reproducible on exactly one machine. The filter keeps mavenLocal answering for the one
+    // coordinate this example deliberately resolves locally.
+    //
+    // `dev.cerbos:cerbos-sdk-java` is NOT in that filter on purpose: it is a published artifact and
+    // must come from Central like any other third-party dependency.
+    mavenLocal {
+        content { includeModule("dev.cerbos", "cerbos-elasticsearch") }
+    }
+    mavenCentral()
+}
+
+dependencies {
+    // Resolved from mavenLocal as a real Maven coordinate: `gradle -p .. publishToMavenLocal` first,
+    // which run.sh does for itself. Why a coordinate and not a composite build is
+    // settings.gradle.kts's subject.
+    //
+    // `isChanging` because the version is fixed while the contents are not: every republish
+    // overwrites 0.1.0 in place, and a repository whose modules are cached is entitled to keep
+    // serving the copy it resolved first. That hazard is what bit the Python example
+    // (cerbos/query-plan-adapters#424, where pip skipped installing a same-version wheel and the
+    // PREVIOUS build stayed in place), so it was measured here rather than assumed, in both halves:
+    //
+    //   - `publishToMavenLocal` overwrites unconditionally. There is no already-satisfied path.
+    //   - Gradle re-reads a `mavenLocal()` module on every build. Removing this declaration and the
+    //     TTL below, warming the cache with a good build and then republishing a DELIBERATELY broken
+    //     one, still failed — so the caching half of the hazard does not reproduce here either.
+    //
+    // Both lines stay: the second finding is a Gradle behaviour rather than a guarantee this build
+    // states, and it stops holding the moment mavenLocal is swapped for any other repository. They
+    // cost nothing, and the measurement is recorded so nobody has to re-derive it.
+    implementation("dev.cerbos:cerbos-elasticsearch:0.1.0") { isChanging = true }
+
+    // The application calls the SDK itself — `cerbos.plan(...)` returns the `PlanResourcesResult` it
+    // hands to the adapter — so it declares the SDK itself. The adapter's own metadata puts
+    // cerbos-sdk-java at RUNTIME scope, which is correct (a consumer that never names an SDK type
+    // should not compile against one) and is why this line is not redundant. It is also the exact
+    // shape of coupling a composite build papers over.
+    implementation("dev.cerbos:cerbos-sdk-java:0.19.0")
+
+    // The Elasticsearch Java client — the "ORM" for this adapter, and the thing the adapter's
+    // README tells a consumer to hand the emitted map to. Matched to the server major this example
+    // runs (../ELASTICSEARCH_IMAGE); the adapter supports Elasticsearch 8.x.
+    implementation("co.elastic.clients:elasticsearch-java:8.15.3")
+
+    // Two jobs, both real. `JacksonJsonpMapper` is how the client is given a jakarta.json
+    // implementation without pulling in Parsson, and the same ObjectMapper serialises the adapter's
+    // `Map<String, Object>` on its way into a typed `Query` and writes the JSON document on stdout.
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.22.1")
+
+    // No protobuf-java declaration, deliberately: the adapter publishes it at runtime scope, pinned
+    // to the gencode cerbos-sdk-java was generated against, and restating the version here would make
+    // this example pass whether or not the adapter still declares it — which is the coverage
+    // docs/adr/0002-examples-install-the-packed-artifact.md exists to buy. What that pin is worth is
+    // measured rather than assumed; see the comment on the `publishing` block in ../build.gradle.kts
+    // and the break-test table in README.md.
+}
+
+configurations.all {
+    resolutionStrategy {
+        // The other half of `isChanging` above: without a zero TTL, "changing" still means
+        // "re-check once a day".
+        cacheChangingModulesFor(0, "seconds")
+
+        // What makes the `example` job in .github/workflows/elasticsearch-java.yaml actually gate a
+        // dependency bump.
+        //
+        // renovate.json automerges every non-major bump, and Renovate only opens a PR when a new
+        // release falls OUTSIDE the declared constraint. A version RANGE therefore absorbs future
+        // releases silently — the hole cerbos/query-plan-adapters#424 found in a Python `>=` floor —
+        // and nothing ever touches this directory, so the job has nothing to gate. Gradle's
+        // equivalents are the dynamic selectors: `8.15.+`, `latest.release`, `[8.15,8.16)`. Every
+        // version above is therefore an exact literal, and this line is what keeps it that way: a
+        // dynamic selector fails resolution rather than quietly reopening the hole.
+        //
+        // `failOnChangingVersions()` is deliberately NOT enabled — the adapter coordinate above is
+        // declared changing on purpose, for the republish-in-place reason given there.
+        failOnDynamicVersions()
+    }
+}
+
+// Writes the RESOLVED runtime classpath, one `java -cp` string, for run.sh to launch with.
+//
+// Three alternatives were tried and each loses something this needs:
+//
+//   - The `application` plugin's `installDist` COPIES every dependency into
+//     `build/install/<name>/lib`, so by the time the program runs, every jar on its classpath sits
+//     under this directory whatever it was resolved from. That defeats
+//     DemoApplication.assertAdapterCameFromThePublishedArtifact, whose whole job is to tell a jar
+//     resolved from mavenLocal apart from one a Gradle composite build substituted in.
+//   - A fat jar has the same problem, plus a ServiceLoader merge this example has no reason to
+//     take on: both the Elasticsearch client and gRPC look implementations up that way.
+//   - Running the program from a Gradle `JavaExec` task puts Gradle's lifecycle output — and
+//     whatever deprecation notice it decides to print that day — on the same stdout that has to
+//     carry exactly one JSON document.
+//
+// So the classpath is written out and `java` is launched directly, with no Gradle in the process and
+// every dependency still at the absolute path it was resolved from.
+val runtimeClasspathFile = layout.buildDirectory.file("runtime-classpath.txt")
+
+tasks.register("writeRuntimeClasspath") {
+    group = "build"
+    description = "Write the resolved runtime classpath for demo/scripts/run-example.sh to launch."
+    val classpath = sourceSets.main.get().runtimeClasspath
+    // Also what wires the compile tasks in: a source set's runtimeClasspath carries the tasks that
+    // build it, so declaring it as an input is the task dependency as well as the up-to-date check.
+    inputs.files(classpath)
+    outputs.file(runtimeClasspathFile)
+    doLast {
+        runtimeClasspathFile.get().asFile.writeText(classpath.asPath)
+    }
+}

--- a/elasticsearch-java/example/run.sh
+++ b/elasticsearch-java/example/run.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# The elasticsearch-java half of `demo/scripts/run-example.sh elasticsearch-java`: publish the
+# adapter, start the store, build this example against the published coordinate, run it. The PDP is
+# already up and reachable at $CERBOS_HOST — the shared runner owns it.
+#
+# The Elasticsearch server is this script's job rather than the runner's. demo/docker-compose.yml
+# holds the one thing every example genuinely shares, and every store is somebody else's; putting
+# them there would grow it into the language switch the split exists to avoid. Starting it here is
+# also what keeps `demo/scripts/run-example.sh elasticsearch-java` a single command on a laptop.
+#
+# Everything this script prints for a human goes to stderr. stdout carries exactly one JSON
+# document, which the shared runner diffs against demo/expected.json.
+#
+# Pre-reqs: docker, curl, gradle (8.x), JDK 17+.
+
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_DIR="$(cd "${EXAMPLE_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${ADAPTER_DIR}/.." && pwd)"
+
+# The coordinate this example resolves. Spelled once, and used for both the publish check below and
+# the artifact the run is asserted to have loaded.
+ARTIFACT_ID="cerbos-elasticsearch"
+ADAPTER_PACKAGE_PATH="dev/cerbos/queryplan/elasticsearch"
+EXAMPLE_PACKAGE_PATH="dev/cerbos/example"
+
+# The server the adapter is proved against, read rather than restated: ../ELASTICSEARCH_IMAGE is the
+# same file ../src/test/java/.../ElasticsearchTestImage.java reads, so the Elasticsearch this example
+# sends queries to is the one the conformance corpus is replayed against, and bumping it is one edit.
+ES_IMAGE="$(cat "${ADAPTER_DIR}/ELASTICSEARCH_IMAGE")"
+ES_CONTAINER="cerbos-demo-elasticsearch-java"
+# 19200, not Elasticsearch's default 9200: the adapter's two container-backed suites start
+# Elasticsearch servers of their own, and a machine running one on the default port would otherwise
+# have this example seeding and searching somebody else's index. Nothing else names this number —
+# it is passed to the program as -Delasticsearch.url.
+ES_PORT=19200
+ES_URL="http://127.0.0.1:${ES_PORT}"
+
+cleanup() {
+  local status=$?
+  if (( status != 0 )); then
+    # Only if there is a container to ask, because the checks below run before it is started and
+    # `docker logs` on a missing container prints an error that reads as the cause.
+    if docker container inspect "${ES_CONTAINER}" >/dev/null 2>&1; then
+      echo "==> elasticsearch-java example failed (exit ${status}): Elasticsearch container logs" >&2
+      # Tailed rather than dumped whole: Elasticsearch logs a few hundred lines of structured JSON
+      # on a healthy start, and the reason a run failed is at the end of them or not in them at all.
+      # `>&2` alone carries both streams: it points this command's stdout — which is where the image
+      # logs — at stderr, and stderr is already there.
+      docker logs --tail 40 "${ES_CONTAINER}" >&2 || true
+    else
+      echo "==> elasticsearch-java example failed (exit ${status}) before the store was started" >&2
+    fi
+  fi
+  docker rm -f "${ES_CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+cd "${EXAMPLE_DIR}"
+
+# 1. Build the adapter and install it into mavenLocal.
+#
+# The Java form of "pack the adapter into a real distributable and install THAT"
+# (docs/adr/0002-examples-install-the-packed-artifact.md). Why a coordinate rather than the Gradle
+# composite build that would be one line shorter is settings.gradle.kts's subject, and README.md has
+# the break-tests that establish it; step 7's provenance check is what enforces it on every run.
+#
+# `publishToMavenLocal` overwrites the version in place, so unlike pip there is no already-satisfied
+# path that could leave the PREVIOUS build installed. See build.gradle.kts on `isChanging` for the
+# consuming side of that, which was measured too.
+echo "==> gradle publishToMavenLocal (dev.cerbos:${ARTIFACT_ID})" >&2
+gradle -p "${ADAPTER_DIR}" publishToMavenLocal --no-daemon >&2
+
+# 2. The example must stay OUT of the artifact it exercises. TypeScript adapters get this from their
+#    `files` allowlist and Go from nested-module exclusion; Java has neither, so ADR 0002 asks for it
+#    to be checked deliberately. It holds today because example/ is a separate Gradle build rather
+#    than a source set of the adapter — which is exactly the kind of fact that stops being true
+#    without anyone noticing.
+#
+#    Both directions are asserted. Without the positive half an empty or wrongly-named jar would sail
+#    through the negative one, and "no example classes in there" would be true of a jar with nothing
+#    in it at all.
+found_jar=0
+for jar in "${ADAPTER_DIR}"/build/libs/"${ARTIFACT_ID}"-*.jar; do
+  [[ -f "${jar}" ]] || continue
+  found_jar=1
+  # Listed into a variable rather than piped into grep: under `set -o pipefail`, a `grep -q` that
+  # matches early closes the pipe, `jar` dies of SIGPIPE, and the pipeline reports failure — so the
+  # `if` would read as "no example classes" in exactly the case this exists to catch.
+  entries="$(jar tf "${jar}")"
+  if grep -q "^${EXAMPLE_PACKAGE_PATH}/" <<<"${entries}"; then
+    echo "$(basename "${jar}") contains example classes — the example must not ship inside the" \
+      "adapter (docs/adr/0002-examples-install-the-packed-artifact.md)" >&2
+    exit 1
+  fi
+  if ! grep -q "^${ADAPTER_PACKAGE_PATH}/ElasticsearchQueryPlanAdapter.class$" <<<"${entries}"; then
+    echo "$(basename "${jar}") does not contain the adapter itself, so the check above proved" \
+      "nothing about what it excludes" >&2
+    exit 1
+  fi
+done
+if (( found_jar == 0 )); then
+  echo "no adapter jar under ${ADAPTER_DIR}/build/libs" >&2
+  exit 1
+fi
+
+# 3. The client and the server agree on a major.
+#
+#    The Elasticsearch Java client version is a literal in build.gradle.kts — it has to be, or the
+#    Renovate bump that carries it never touches this directory and the `example` job gates nothing
+#    (README.md, "Why the Renovate gate bites") — so it is a second spelling of a version this
+#    directory already knows, with nothing holding the two together. This is that something, and it
+#    is the same job pgx/example/run.sh's DSN-port check does.
+#
+#    MAJOR, not the exact version. A major mismatch is the real hazard: the 8.x client refuses a 9.x
+#    server outright, and the adapter's README declares Elasticsearch 8.x. Within a major Elastic
+#    supports a client at or below the server's minor, and requiring exact equality would turn every
+#    client bump red until someone bumped the image too — a gate failing for a reason that is not the
+#    bump, which is the state README.md argues against for the lockfile.
+# The digest comes off FIRST. It is introduced by `@` but contains a colon of its own
+# (`@sha256:<hex>`), so taking the last colon-delimited field of the whole reference yields the hex.
+es_image_tag="${ES_IMAGE%%@*}"
+es_image_tag="${es_image_tag##*:}"
+es_client_version="$(sed -n 's/.*co\.elastic\.clients:elasticsearch-java:\([0-9][^"]*\)".*/\1/p' \
+  "${EXAMPLE_DIR}/build.gradle.kts")"
+if [[ -z "${es_client_version}" ]]; then
+  echo "no co.elastic.clients:elasticsearch-java version found in build.gradle.kts — the check" \
+    "below has stopped describing anything" >&2
+  exit 1
+fi
+if [[ "${es_client_version%%.*}" != "${es_image_tag%%.*}" ]]; then
+  echo "the Elasticsearch client is ${es_client_version} and ${ADAPTER_DIR}/ELASTICSEARCH_IMAGE" \
+    "pins server ${es_image_tag} — the majors must match" >&2
+  exit 1
+fi
+echo "==> client ${es_client_version} against server ${es_image_tag}" >&2
+
+# 4. Start the store. First, so it warms up while this example is resolved and built — the readiness
+#    wait below is what actually gates the run, not this line.
+#
+#    Security off and plain HTTP, the same configuration the adapter's own container-backed suites
+#    use: what this example proves is packaging and usage shapes, and TLS would only add a
+#    certificate to trust.
+echo "==> starting ${ES_IMAGE} on ${ES_PORT}" >&2
+docker rm -f "${ES_CONTAINER}" >/dev/null 2>&1 || true
+docker run -d --name "${ES_CONTAINER}" -p "${ES_PORT}:9200" \
+  -e discovery.type=single-node \
+  -e xpack.security.enabled=false \
+  -e "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+  "${ES_IMAGE}" >/dev/null
+
+# 5. Build this example against the published coordinate, and write out the resolved runtime
+#    classpath for step 6 to launch with.
+#
+#    The classpath is written rather than laid out as a directory of jars (`installDist`) or packed
+#    into a fat jar, because both of those COPY every dependency — and then the program cannot tell a
+#    jar resolved from mavenLocal apart from one a composite build substituted in, which is the check
+#    step 7 rests on. build.gradle.kts has the longer version.
+#
+#    Gradle's own output goes to stderr, and step 7 launches without Gradle in the process, which is
+#    what keeps stdout the program's alone. DemoApplication does the other half by redirecting
+#    System.out.
+echo "==> gradle writeRuntimeClasspath" >&2
+gradle writeRuntimeClasspath --no-daemon >&2
+
+CLASSPATH_FILE="${EXAMPLE_DIR}/build/runtime-classpath.txt"
+[[ -s "${CLASSPATH_FILE}" ]] || { echo "no resolved classpath at ${CLASSPATH_FILE}" >&2; exit 1; }
+
+# What actually got resolved, on stderr where a human reading a CI log will see it — full paths,
+# because for the adapter the path IS the finding: `.../.m2/repository/...` is the published artifact,
+# anything under ${ADAPTER_DIR} is a substituted local build. DemoApplication refuses to run on the
+# second, and this is the same fact in a form a human can read on a green run.
+#
+# Taken into a variable and checked, rather than piped straight to stderr. `grep` that matches nothing
+# exits non-zero, and under `set -o pipefail` that would end the run here with no message at all —
+# which is also the case worth reporting, since a classpath naming none of these artifacts means this
+# diagnostic has silently stopped describing anything.
+resolved="$(tr ':' '\n' <"${CLASSPATH_FILE}" \
+  | grep -E "/(${ARTIFACT_ID}|cerbos-sdk-java|elasticsearch-java|protobuf-java)-[0-9]" || true)"
+if [[ -z "${resolved}" ]]; then
+  echo "the resolved classpath in ${CLASSPATH_FILE} names none of the expected artifacts" >&2
+  exit 1
+fi
+printf '%s\n' "${resolved}" >&2
+
+# 6. Wait for the store. Deliberately after the build: the container has been starting underneath
+#    step 5, so by here there is usually nothing left to wait for, and a build error reports itself
+#    without first blocking on a server it will never use.
+echo "==> waiting for Elasticsearch" >&2
+ready=0
+for _ in {1..90}; do
+  if curl -fsS "${ES_URL}/_cluster/health?wait_for_status=yellow&timeout=1s" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+(( ready == 1 )) || { echo "Elasticsearch failed to start" >&2; exit 1; }
+
+# 7. Run. stdout is the JSON document and nothing else.
+#
+#    demo/ and the adapter directory are passed in rather than derived inside the program: how many
+#    directories up the repository root sits is this script's business, not the application's.
+#    CERBOS_HOST comes from the runner and is inherited; the program refuses to start without it.
+echo "==> java DemoApplication" >&2
+java \
+  "-Ddemo.dir=${REPO_ROOT}/demo" \
+  "-Dadapter.dir=${ADAPTER_DIR}" \
+  "-Delasticsearch.url=${ES_URL}" \
+  -cp "$(cat "${CLASSPATH_FILE}")" \
+  dev.cerbos.example.demo.DemoApplication

--- a/elasticsearch-java/example/settings.gradle.kts
+++ b/elasticsearch-java/example/settings.gradle.kts
@@ -1,0 +1,16 @@
+rootProject.name = "cerbos-elasticsearch-example"
+
+// No `includeBuild("..")`, deliberately.
+//
+// A Gradle composite build substitutes the adapter's local source tree for the declared coordinate,
+// and therefore resolves neither the POM nor the Gradle module metadata the adapter publishes. That
+// metadata is half of what an example exists to prove
+// (docs/adr/0002-examples-install-the-packed-artifact.md), and the class of bug it hides is not
+// hypothetical: cerbos-sdk-java declares protobuf at runtime-only scope in its own module metadata,
+// and this adapter's own POM does the same for both of its dependencies.
+//
+// The adapter is resolved from mavenLocal instead — see the filtered repository in
+// build.gradle.kts — so `gradle -p .. publishToMavenLocal` is a prerequisite of every entry point
+// here. run.sh does it itself, and then asserts that what got loaded was the published jar rather
+// than a substituted source tree, because a composite build would put this file back in a way
+// nothing else would notice.

--- a/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoApplication.java
+++ b/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoApplication.java
@@ -1,0 +1,184 @@
+package dev.cerbos.example.demo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import dev.cerbos.queryplan.elasticsearch.ElasticsearchQueryPlanAdapter;
+import dev.cerbos.sdk.CerbosBlockingClient;
+import dev.cerbos.sdk.CerbosClientBuilder;
+
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSource;
+import java.util.Map;
+
+/**
+ * The elasticsearch-java example: the program {@code demo/scripts/run-example.sh elasticsearch-java}
+ * runs.
+ *
+ * <p>It takes no arguments, exercises the
+ * <a href="https://github.com/cerbos/query-plan-adapters/issues/349">five shared usage shapes</a>
+ * against {@code demo/}'s policies and seed rows, and prints exactly one JSON document to stdout for
+ * the shared runner to diff against {@code demo/expected.json}.
+ *
+ * <p>Three things it is handed, and where each comes from:
+ *
+ * <ul>
+ *   <li>{@code CERBOS_HOST} — the environment variable the shared runner sets. There is deliberately
+ *       no fallback; see {@link #cerbosHost()}.</li>
+ *   <li>{@code -Ddemo.dir} — the shared corpus directory. The path arithmetic lives in
+ *       {@code run.sh}: how many directories up the repository root sits is the launcher's business,
+ *       not the application's.</li>
+ *   <li>{@code -Delasticsearch.url} — the store {@code run.sh} started. Also the launcher's, and for
+ *       a sharper reason: {@code run.sh} owns the container and publishes the port, so a second
+ *       spelling of the address in here would be a constant nothing holds equal to the first.</li>
+ * </ul>
+ */
+public final class DemoApplication {
+
+    /**
+     * The real stdout, captured before {@link #main} redirects {@link System#out}.
+     *
+     * <p>The contract is one JSON document on stdout and everything else on stderr. Nothing here logs
+     * to stdout today, but the Elasticsearch REST client, gRPC and Jackson all sit on this classpath
+     * and any of them is free to print without a logging configuration. Rather than configuring each,
+     * stdout is redirected to stderr for the whole JVM and the one line that must reach the runner is
+     * written through this handle.
+     */
+    private static final PrintStream STDOUT = System.out;
+
+    private DemoApplication() {}
+
+    public static void main(String[] args) throws Exception {
+        // Before anything can print, and before anything can connect: a misinvocation costs one clear
+        // message rather than a connection failure part-way through seeding.
+        System.setOut(System.err);
+
+        Path demoDir = demoDir();
+        String cerbosHost = cerbosHost();
+        String elasticsearchUrl = requiredProperty("elasticsearch.url");
+        assertAdapterCameFromThePublishedArtifact();
+
+        DemoSeeds seeds = DemoSeeds.read(demoDir.resolve("seeds.json"));
+
+        // CerbosBlockingClient is not AutoCloseable, so only the store is closed here. The JVM exits
+        // immediately after the document is written, which takes the gRPC channel with it.
+        CerbosBlockingClient cerbos = cerbosClient(cerbosHost);
+
+        try (DemoIndex index = new DemoIndex(elasticsearchUrl)) {
+            Map<String, Object> document = Map.of(
+                    // The runner checks this against the adapter it was asked for, so a stale build
+                    // directory or a copied run.sh fails there instead of quietly passing on the
+                    // shared expectations.
+                    "adapter", "elasticsearch-java",
+                    "shapes", new DemoShapes(cerbos, index, seeds).run());
+
+            // Map keys sorted, which is the same canonical form demo/scripts/run-example.sh puts both
+            // sides of its diff into (`jq -S`). Java's Map.of has no defined iteration order, so
+            // without this the document a human reads on a failure is shuffled differently on every
+            // run while the diff stays stable — the worst of both. Record components are unaffected
+            // and stay in declaration order.
+            STDOUT.println(new ObjectMapper()
+                    .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(document));
+            STDOUT.flush();
+        }
+    }
+
+    private static CerbosBlockingClient cerbosClient(String host)
+            throws CerbosClientBuilder.InvalidClientConfigurationException {
+        return new CerbosClientBuilder(host).withPlaintext().buildBlockingClient();
+    }
+
+    /**
+     * The shared corpus directory, passed as {@code -Ddemo.dir} by {@code run.sh}.
+     */
+    private static Path demoDir() {
+        Path demoDir = Path.of(requiredProperty("demo.dir"));
+        if (!Files.isRegularFile(demoDir.resolve("seeds.json"))) {
+            throw new IllegalStateException(
+                    "-Ddemo.dir=" + demoDir + " does not contain seeds.json");
+        }
+        return demoDir;
+    }
+
+    /**
+     * The runner sets {@code CERBOS_HOST}, and there is deliberately no fallback anywhere in this
+     * example. The obvious default — Cerbos's own 3592/3593 — is what every adapter's
+     * {@code cerbos run} test sidecar binds, so an unset {@code CERBOS_HOST} would not fail: it would
+     * quietly plan against whichever policy suite that sidecar serves, and produce a diff against
+     * {@code demo/expected.json} that reads as an adapter bug. Two examples shipped that exact
+     * default, which is why {@code demo/scripts/validate-demo.sh} now fails the build on a hardcoded
+     * PDP address rather than trusting prose.
+     */
+    private static String cerbosHost() {
+        String host = System.getenv("CERBOS_HOST");
+        if (host == null || host.isBlank()) {
+            throw new IllegalStateException(
+                    "CERBOS_HOST is not set — run this program through"
+                            + " demo/scripts/run-example.sh elasticsearch-java");
+        }
+        return host;
+    }
+
+    private static String requiredProperty(String name) {
+        String value = System.getProperty(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(
+                    "-D" + name + " is not set — run this program through"
+                            + " demo/scripts/run-example.sh elasticsearch-java");
+        }
+        return value;
+    }
+
+    /**
+     * Asserts the adapter class this program just linked against came out of the published jar and
+     * not out of the adapter's own build directory.
+     *
+     * <p>This is the Java analogue of the {@code sys.path} guard in {@code sqlalchemy/example/}, and
+     * it exists because the failure it catches is silent. A single line in
+     * {@code settings.gradle.kts} — {@code includeBuild("..")} — turns the declared coordinate into a
+     * Gradle composite build, which substitutes the adapter's local project for it. Everything still
+     * compiles, every shape still passes, and the POM and module metadata this example exists to
+     * execute are never resolved at all
+     * ({@code docs/adr/0002-examples-install-the-packed-artifact.md}).
+     *
+     * <p>Two conditions, because the substitutions do not all look the same. A composite build puts
+     * the adapter's own {@code build/libs/*.jar} on the classpath, which is a jar; a project
+     * dependency or a source set puts {@code build/classes/java/main}, which is a directory. Naming
+     * the adapter directory rather than asserting a location inside the local Maven repository keeps
+     * this independent of where that repository is configured to live — and it covers one more case
+     * for free, since {@code example/build} is under it too: a launcher that COPIES the resolved jars
+     * somewhere before running (which is exactly what the {@code application} plugin's
+     * {@code installDist} does) would erase the distinction this checks, and is caught here rather
+     * than passing.
+     */
+    private static void assertAdapterCameFromThePublishedArtifact() {
+        CodeSource source =
+                ElasticsearchQueryPlanAdapter.class.getProtectionDomain().getCodeSource();
+        if (source == null || source.getLocation() == null) {
+            throw new IllegalStateException(
+                    "cannot tell where dev.cerbos:cerbos-elasticsearch was loaded from");
+        }
+        Path location = Path.of(URI.create(source.getLocation().toString())).toAbsolutePath()
+                .normalize();
+        Path adapterDir = Path.of(requiredProperty("adapter.dir")).toAbsolutePath().normalize();
+
+        if (!location.getFileName().toString().endsWith(".jar")) {
+            throw new IllegalStateException(
+                    "the adapter was loaded from " + location + ", which is not a jar — this example"
+                            + " must execute the published artifact"
+                            + " (docs/adr/0002-examples-install-the-packed-artifact.md)");
+        }
+        if (location.startsWith(adapterDir)) {
+            throw new IllegalStateException(
+                    "the adapter was loaded from " + location + ", inside its own build directory —"
+                            + " the declared coordinate has been substituted with the local project,"
+                            + " so neither its POM nor its Gradle module metadata was resolved"
+                            + " (docs/adr/0002-examples-install-the-packed-artifact.md)");
+        }
+        System.err.println("==> dev.cerbos:cerbos-elasticsearch resolved from " + location);
+    }
+}

--- a/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoIndex.java
+++ b/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoIndex.java
@@ -1,0 +1,178 @@
+package dev.cerbos.example.demo;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The store: one Elasticsearch index holding the demo domain's seed rows, reached through the
+ * official Elasticsearch Java client.
+ *
+ * <p>The client is the point. This adapter hands back a {@code Map<String, Object>} of plain JDK
+ * values with no Elasticsearch type in its signature, so the step a consumer actually has to make
+ * work — turning that map into something the client will send — happens nowhere in the adapter's own
+ * suites: {@code ElasticsearchTranslatorTest} compares the map to a golden asset, and
+ * {@code ElasticsearchAdversarialConformanceTest} posts it as raw JSON over a bare
+ * {@link java.net.http.HttpClient}. Neither ever asks the client library to parse it. That is what
+ * {@link #query(Map)} does here, the way {@code elasticsearch-java/README.md} documents it under
+ * "Sending the query to Elasticsearch".
+ */
+final class DemoIndex implements AutoCloseable {
+
+    /** The index the demo rows live in. Created here, so its mapping is this example's own. */
+    private static final String INDEX = "demo-documents";
+
+    /**
+     * The keyword field pagination sorts on. It is a real field rather than Elasticsearch's
+     * {@code _id} metadata, which is not sortable without fielddata.
+     */
+    private static final String SORT_FIELD = "id";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * One indexed document.
+     *
+     * <p>The field names are Elasticsearch's, and they are deliberately not the Cerbos attribute
+     * names: {@code isPublic} carries {@code request.resource.attr.public}. That is what makes
+     * {@link DemoShapes}'s field map necessary rather than decorative.
+     */
+    record IndexedDocument(String id, String ownerId, boolean isPublic, String region,
+                           boolean archived) {}
+
+    private final RestClient restClient;
+    private final RestClientTransport transport;
+    private final ElasticsearchClient client;
+
+    DemoIndex(String url) {
+        this.restClient = RestClient.builder(HttpHost.create(url)).build();
+        this.transport = new RestClientTransport(restClient, new JacksonJsonpMapper(MAPPER));
+        this.client = new ElasticsearchClient(transport);
+    }
+
+    /**
+     * Drops and recreates the index, then indexes the corpus rows and refreshes so a search sees
+     * them.
+     *
+     * <p>The mapping is written out rather than left to Elasticsearch's dynamic mapping, and
+     * {@code dynamic: strict} makes that a requirement rather than a preference. Both halves are
+     * this adapter's own hazard, catalogued in its README under "Analyzed ({@code text}) field
+     * mapping": dynamic mapping gives a string field the {@code text} type, which is tokenized and
+     * lowercased before it is indexed, and the {@code term} query the adapter emits for
+     * {@code ownerId == "alice"} would then run against those tokens rather than against the stored
+     * value. The adapter is handed a plan and never an index, so it cannot see the difference — the
+     * mapping is the consumer's half of the contract, and an example is the right place to show a
+     * consumer writing it.
+     */
+    void recreate(List<DemoSeeds.Document> rows) throws IOException {
+        if (client.indices().exists(e -> e.index(INDEX)).value()) {
+            client.indices().delete(d -> d.index(INDEX));
+        }
+        client.indices().create(c -> c.index(INDEX).mappings(m -> m
+                .dynamic(DynamicMapping.Strict)
+                .properties(SORT_FIELD, p -> p.keyword(k -> k))
+                .properties("ownerId", p -> p.keyword(k -> k))
+                .properties("isPublic", p -> p.boolean_(b -> b))
+                .properties("region", p -> p.keyword(k -> k))
+                .properties("archived", p -> p.boolean_(b -> b))));
+
+        for (DemoSeeds.Document row : rows) {
+            IndexedDocument document = new IndexedDocument(
+                    row.id(), row.ownerId(), row.isPublic(), row.region(), row.archived());
+            client.index(i -> i.index(INDEX).id(row.id()).document(document));
+        }
+        client.indices().refresh(r -> r.index(INDEX));
+    }
+
+    /**
+     * The ids every clause in {@code filters} selects, sorted.
+     *
+     * <p>{@code bool.filter} rather than {@code bool.must}: an authorization condition is an access
+     * control filter, not a relevance signal, so it belongs in a filter context where Elasticsearch
+     * skips scoring and can cache the result. It is also what makes composition in usage shape 5 a
+     * list append — one more clause in the same array.
+     *
+     * <p>{@code size} is passed in rather than left to Elasticsearch's default page of 10, which
+     * would silently truncate a filter that selected more.
+     */
+    List<String> search(List<Query> filters, int size) throws IOException {
+        return ids(client.search(s -> s
+                .index(INDEX)
+                .size(size)
+                .query(q -> q.bool(b -> b.filter(filters))), IndexedDocument.class));
+    }
+
+    /**
+     * One page of the same query — usage shape 4, expressed as Elasticsearch's {@code from}/{@code
+     * size}.
+     *
+     * <p>The {@code sort} is required for the paging itself to be correct: without a total order,
+     * successive pages may repeat or omit documents. How the RESULT is asserted is a separate
+     * question, and {@code demo/expected.json} asserts page sizes plus the sorted union rather than
+     * per-page order, because several of the stores behind the shared expectations have no total
+     * order to paginate by.
+     */
+    List<String> page(List<Query> filters, int from, int size) throws IOException {
+        return ids(client.search(s -> s
+                .index(INDEX)
+                .from(from)
+                .size(size)
+                .sort(so -> so.field(f -> f.field(SORT_FIELD).order(SortOrder.Asc)))
+                .query(q -> q.bool(b -> b.filter(filters))), IndexedDocument.class));
+    }
+
+    /**
+     * The adapter's emitted clause, as a client {@link Query}.
+     *
+     * <p>This is the plumbing step an example exists to execute. The adapter returns plain JDK
+     * collections, so the client has to parse them, and {@code withJson} is the documented way in.
+     * It is not a formality: the client models the Query DSL as generated types, and a construct the
+     * adapter emits that no generated type accepts would fail here and nowhere else in this
+     * repository. {@code bool.minimum_should_match} is the concrete instance — the adapter emits it
+     * as the integer {@code 1}, which is what Elasticsearch's own JSON accepts, while the client
+     * models the field as a string.
+     */
+    static Query query(Map<String, Object> clause) {
+        String json;
+        try {
+            json = MAPPER.writeValueAsString(clause);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException("Cannot serialise the adapter's clause: " + clause, e);
+        }
+        return Query.of(q -> q.withJson(new StringReader(json)));
+    }
+
+    private static List<String> ids(SearchResponse<IndexedDocument> response) {
+        return response.hits().hits().stream()
+                .map(hit -> {
+                    IndexedDocument source = hit.source();
+                    if (source == null) {
+                        throw new IllegalStateException("hit " + hit.id() + " carried no _source");
+                    }
+                    return source.id();
+                })
+                .sorted()
+                .toList();
+    }
+
+    @Override
+    public void close() throws IOException {
+        transport.close();
+        restClient.close();
+    }
+}

--- a/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoSeeds.java
+++ b/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoSeeds.java
@@ -1,0 +1,64 @@
+package dev.cerbos.example.demo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * {@code demo/seeds.json}, parsed. The rows every example application indexes and the principals
+ * every one of them plans for, read from the shared corpus rather than restated here — a copy per
+ * example would be one more thing to update when the domain gains a row, and
+ * {@code demo/scripts/validate-demo.sh} fails the build on a principal written out inline.
+ *
+ * <p>Corpus files are repository-controlled and structurally checked by
+ * {@code demo/scripts/validate-demo.sh} before this program ever runs; this is not untrusted input.
+ *
+ * @param principals the demo principals
+ * @param applicationFilter the predicate the APPLICATION owns, never expressed in policy
+ * @param documents the seed rows
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DemoSeeds(List<Principal> principals,
+                        ApplicationFilter applicationFilter,
+                        List<Document> documents) {
+
+    /** A demo principal: an id and the roles the policy's rules are keyed on. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Principal(String id, List<String> roles) {}
+
+    /**
+     * {@code archived == false AND region == 'emea'} — the application's own predicate. It lives in
+     * the corpus so {@code demo/scripts/validate-demo.sh} can recompute usage shape 5 from it and
+     * prove that shape discriminates: applying this predicate alone, or the adapter's query alone,
+     * must both give the wrong answer.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ApplicationFilter(boolean archived, String region) {}
+
+    /** One seed row. {@code public} is a Java keyword, hence the rename. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Document(String id, String ownerId, @JsonProperty("public") boolean isPublic,
+                           String region, boolean archived) {}
+
+    static DemoSeeds read(Path seedsFile) {
+        try {
+            return new ObjectMapper().readValue(seedsFile.toFile(), DemoSeeds.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot read the demo corpus at " + seedsFile, e);
+        }
+    }
+
+    /** The named principal, or a failure naming the corpus — never a silently anonymous plan. */
+    Principal principal(String id) {
+        return principals.stream()
+                .filter(p -> id.equals(p.id()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "demo/seeds.json declares no principal '" + id + "'"));
+    }
+}

--- a/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoShapes.java
+++ b/elasticsearch-java/example/src/main/java/dev/cerbos/example/demo/DemoShapes.java
@@ -1,0 +1,246 @@
+package dev.cerbos.example.demo;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import dev.cerbos.queryplan.elasticsearch.ElasticsearchQueryPlanAdapter;
+import dev.cerbos.queryplan.elasticsearch.ElasticsearchQueryPlanAdapter.Result;
+import dev.cerbos.sdk.CerbosBlockingClient;
+import dev.cerbos.sdk.PlanResourcesResult;
+import dev.cerbos.sdk.builders.Principal;
+import dev.cerbos.sdk.builders.Resource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The five usage shapes of the shared demo domain, against a real Elasticsearch index reached
+ * through the official Elasticsearch Java client.
+ *
+ * <p>This is not a test of what the adapter translates —
+ * {@code ../src/test/java/.../ElasticsearchAdversarialConformanceTest.java} proves that against a
+ * hostile corpus with a live PDP as the oracle. It proves the two things that harness structurally
+ * cannot:
+ *
+ * <ol>
+ *   <li><b>Packaging.</b> The adapter imports above resolve through its real Maven coordinate rather
+ *       than through its source set, so its POM and Gradle module metadata are executed —
+ *       {@code settings.gradle.kts} and {@code README.md} are where that argument lives.</li>
+ *   <li><b>Usage shape.</b> A harness runs one flat filtered query, and posts it as raw JSON over a
+ *       bare HTTP client. Consumers paginate, compose the adapter's clause with clauses of their
+ *       own, and hand the result to the client library. Shape 5 below is the one that earns the
+ *       exercise.</li>
+ * </ol>
+ *
+ * <p>The plan kind is reported alongside the ids because {@code demo/expected.json} pins it: that is
+ * what stops this program returning all the rows for {@code admin-view} without ever having reached
+ * the PDP. It is read off the adapter's own {@link Result}, not off the SDK's plan predicates,
+ * because the {@code Result} variant is what the rest of this class actually branches on — deriving
+ * it from the plan instead would leave the adapter free to classify a plan one way and this program
+ * to report it another.
+ */
+final class DemoShapes {
+
+    private static final String RESOURCE_KIND = "document";
+
+    /**
+     * Cerbos attribute names are not Elasticsearch field names, so a consumer always writes one of
+     * these. Both entries are load-bearing: an unmapped attribute makes the adapter throw rather
+     * than guess a field, and {@code public} maps to {@code isPublic} because the policy's name for
+     * the attribute and the index's name for the field are allowed to differ — which is the point of
+     * having a map at all.
+     *
+     * <p>{@code region} and {@code archived} are deliberately absent: no rule in
+     * {@code demo/policies/document.yaml} names them, and they exist so the application can own a
+     * predicate the policy never sees.
+     */
+    private static final Map<String, String> DOCUMENT_FIELDS = Map.of(
+            "request.resource.attr.ownerId", "ownerId",
+            "request.resource.attr.public", "isPublic");
+
+    /**
+     * One shape's answer, as {@code demo/expected.json} spells it: the plan kind, and the ids the
+     * search returned. Typed rather than a {@code Map<String, Object>} so a mistyped key is a
+     * compile error here instead of a diff in the shared runner.
+     */
+    record ShapeResult(String kind, List<String> ids) {}
+
+    /** Shape 4 additionally reports the page size it asked for and the size of each page read. */
+    record PaginatedShapeResult(String kind, List<String> ids, int pageSize,
+                                List<Integer> pageSizes) {}
+
+    private final CerbosBlockingClient cerbos;
+    private final DemoIndex index;
+    private final DemoSeeds seeds;
+
+    DemoShapes(CerbosBlockingClient cerbos, DemoIndex index, DemoSeeds seeds) {
+        this.cerbos = cerbos;
+        this.index = index;
+        this.seeds = seeds;
+    }
+
+    /** Seeds the index, runs every shape, and returns the {@code shapes} object to emit. */
+    Map<String, Object> run() throws IOException {
+        index.recreate(seeds.documents());
+
+        return Map.of(
+                "filtered", Map.of(
+                        "alice/view", filtered("alice", "view"),
+                        "bob/view", filtered("bob", "view")),
+                "alwaysAllowed", Map.of(
+                        "admin/admin-view", filtered("admin", "admin-view")),
+                "alwaysDenied", Map.of(
+                        "alice/publish", filtered("alice", "publish")),
+                "paginated", Map.of(
+                        "alice/view", paginated("alice", "view", 2),
+                        "admin/admin-view", paginated("admin", "admin-view", 3)),
+                "composed", Map.of(
+                        "alice/view", composed("alice", "view"),
+                        "bob/view", composed("bob", "view"),
+                        "admin/admin-view", composed("admin", "admin-view"),
+                        "alice/publish", composed("alice", "publish")));
+    }
+
+    // -- the five usage shapes --
+
+    /** Shapes 1, 2 and 3: a plain filtered list — the adapter's clause is the whole query. */
+    private ShapeResult filtered(String principalId, String action) throws IOException {
+        Authorization authorization = authorize(principalId, action);
+        return new ShapeResult(
+                authorization.kind(),
+                index.search(List.of(authorization.clause()), everyRow()));
+    }
+
+    /**
+     * Shape 4: pagination applied on top of the filter, through Elasticsearch's {@code from} and
+     * {@code size}.
+     *
+     * <p>Reported as page SIZES plus the sorted union of the ids, never as per-page order:
+     * {@code demo/expected.json} is shared by every example and several of the stores behind it have
+     * no total order to paginate by. Pages are read until one comes back short, which is what stops
+     * the loop on a total that is an exact multiple of the page size as well as on one that is not.
+     */
+    private PaginatedShapeResult paginated(String principalId, String action, int pageSize)
+            throws IOException {
+        Authorization authorization = authorize(principalId, action);
+        List<Query> filters = List.of(authorization.clause());
+
+        List<Integer> pageSizes = new ArrayList<>();
+        List<String> ids = new ArrayList<>();
+        for (int from = 0; ; from += pageSize) {
+            List<String> page = index.page(filters, from, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            pageSizes.add(page.size());
+            ids.addAll(page);
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        return new PaginatedShapeResult(
+                authorization.kind(), ids.stream().sorted().toList(), pageSize, pageSizes);
+    }
+
+    /**
+     * Shape 5: the adapter's clause ANDed with the application's own, as two more entries in the
+     * same {@code bool.filter} array.
+     *
+     * <p>All three plan kinds go through here on purpose. An {@code ALWAYS_ALLOWED} plan has no
+     * clause to AND with, and an {@code ALWAYS_DENIED} one must not have its denial undone — the two
+     * cases that break first.
+     */
+    private ShapeResult composed(String principalId, String action) throws IOException {
+        Authorization authorization = authorize(principalId, action);
+        List<Query> filters = new ArrayList<>();
+        filters.add(authorization.clause());
+        filters.addAll(applicationFilter());
+        return new ShapeResult(authorization.kind(), index.search(filters, everyRow()));
+    }
+
+    /**
+     * The APPLICATION's own predicate — {@code archived == false AND region == 'emea'} — read from
+     * {@code demo/seeds.json} rather than written out here, so it cannot drift from the expectations
+     * {@code demo/scripts/validate-demo.sh} recomputes from the same field.
+     *
+     * <p>Written with the client's own typed builders, unlike the adapter's clause, which arrives as
+     * a map and is parsed. That asymmetry is the shape of the composition a consumer actually makes,
+     * and it is why shape 5 is the one that earns the exercise: nothing in
+     * {@code demo/policies/document.yaml} mentions either field.
+     */
+    private List<Query> applicationFilter() {
+        DemoSeeds.ApplicationFilter filter = seeds.applicationFilter();
+        return List.of(
+                Query.of(q -> q.term(t -> t.field("archived").value(filter.archived()))),
+                Query.of(q -> q.term(t -> t.field("region").value(filter.region()))));
+    }
+
+    // -- plumbing --
+
+    /**
+     * The plan for one principal and one action.
+     *
+     * <p>The action is passed as a single-element list because {@code plan(Principal, Resource,
+     * String)} is deprecated in cerbos-sdk-java 0.19.0 — a detail an example is exactly the wrong
+     * place to hide, since it is the code a consumer copies.
+     */
+    private PlanResourcesResult plan(String principalId, String action) {
+        DemoSeeds.Principal principal = seeds.principal(principalId);
+        return cerbos.plan(
+                Principal.newInstance(principal.id(), principal.roles().toArray(String[]::new)),
+                Resource.newInstance(RESOURCE_KIND),
+                List.of(action));
+    }
+
+    /**
+     * The adapter's answer, in the two forms every shape here needs: the plan kind as
+     * {@code demo/expected.json} spells it, and one {@code bool.filter} entry.
+     *
+     * @param kind the plan kind, for the emitted document
+     * @param clause the authorization half of the query
+     */
+    private record Authorization(String kind, Query clause) {}
+
+    /**
+     * Translates a plan into both halves at once.
+     *
+     * <p>One cascade over the sealed {@link Result} rather than two — a kind and a clause read off the
+     * same variant in one place cannot disagree about which variant it was.
+     *
+     * <p>Both unconditional kinds are given an explicit clause rather than being special-cased out of
+     * the search. {@code ALWAYS_ALLOWED} could equally be an empty filter list — Elasticsearch accepts
+     * {@code {"bool":{"filter":[]}}} and returns every document — and a denial could skip the round
+     * trip entirely, which is the optimisation the adapter's README shows. Neither is what shape 5
+     * needs: the property it exists to check is that the application's own predicate cannot resurrect
+     * a denied document, and only a search that actually runs with both halves in place demonstrates
+     * that.
+     *
+     * <p>An if-chain rather than an exhaustive {@code switch} over the sealed type: pattern matching
+     * for {@code switch} is standard from Java 21, and this example is compiled against the adapter's
+     * declared floor of Java 17 (see {@code build.gradle.kts}).
+     */
+    private Authorization authorize(String principalId, String action) {
+        Result result = ElasticsearchQueryPlanAdapter.toElasticsearchQuery(
+                plan(principalId, action), DOCUMENT_FIELDS);
+        if (result instanceof Result.Conditional conditional) {
+            return new Authorization("KIND_CONDITIONAL", DemoIndex.query(conditional.query()));
+        }
+        if (result instanceof Result.AlwaysAllowed) {
+            return new Authorization("KIND_ALWAYS_ALLOWED", Query.of(q -> q.matchAll(m -> m)));
+        }
+        if (result instanceof Result.AlwaysDenied) {
+            return new Authorization("KIND_ALWAYS_DENIED", Query.of(q -> q.matchNone(m -> m)));
+        }
+        throw new IllegalStateException("Unknown adapter result: " + result);
+    }
+
+    /**
+     * A page big enough for the whole index, so an unpaginated shape is never silently truncated to
+     * Elasticsearch's default page of 10. Derived from the corpus rather than a constant, so a seed
+     * row added to {@code demo/seeds.json} does not quietly start being dropped.
+     */
+    private int everyRow() {
+        return seeds.documents().size();
+    }
+}

--- a/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchTestImage.java
+++ b/elasticsearch-java/src/test/java/dev/cerbos/queryplan/elasticsearch/ElasticsearchTestImage.java
@@ -2,14 +2,25 @@ package dev.cerbos.queryplan.elasticsearch;
 
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 /**
- * Single source of truth for the Elasticsearch container image used by this harness.
+ * Single source of truth for the Elasticsearch container image used by this adapter, read from
+ * {@code elasticsearch-java/ELASTICSEARCH_IMAGE}.
  *
- * <p><b>Why one constant.</b> {@link ElasticsearchSurfaceTest} and
+ * <p><b>Why one reference.</b> {@link ElasticsearchSurfaceTest} and
  * {@link ElasticsearchAdversarialConformanceTest} both start a server, and the adversarial suite
  * is a differential against the PDP. If the two suites run different Elasticsearch builds, the
  * store facts the surface suite measures and the oracle comparison stop describing the same
  * engine, and a version-sensitive divergence surfaces in one suite only.
+ *
+ * <p><b>Why a file rather than a constant here.</b> {@code example/run.sh} starts a server too, and
+ * a shell script cannot read a Java constant. The same argument that put the PostgreSQL pin in
+ * {@code pgx/POSTGRES_IMAGE}: {@code conformance/scripts/validate-corpus.sh} holds one digest per
+ * tag and nothing holds two tags equal, so a second spelling of the reference could be left behind
+ * on an older server and stay green.
  *
  * <p><b>Why the digest.</b> A tag is mutable — {@code 8.15.3} can be re-pushed — so a tag-only pin
  * records an intent, not a build. {@code conformance/scripts/validate-corpus.sh} asserts every
@@ -35,12 +46,23 @@ final class ElasticsearchTestImage {
 
     private static final String REPOSITORY = "docker.elastic.co/elasticsearch/elasticsearch";
 
-    // One line, deliberately: validate-corpus.sh reads image references line by line, and a
-    // reference split across a concatenation reads to it as an unpinned tag.
-    private static final String REFERENCE = "docker.elastic.co/elasticsearch/elasticsearch:8.15.3@sha256:01c1732062b4a846c5ca687b0094b89bad0bfed00c6d71626db32fb8f3131a78";
-
     static final DockerImageName IMAGE =
-            DockerImageName.parse(REFERENCE).asCompatibleSubstituteFor(REPOSITORY);
+            DockerImageName.parse(reference()).asCompatibleSubstituteFor(REPOSITORY);
 
     private ElasticsearchTestImage() {}
+
+    private static String reference() {
+        Path pinFile = Path.of(System.getProperty("user.dir"), "ELASTICSEARCH_IMAGE");
+        try {
+            String pinned = Files.readString(pinFile).strip();
+            if (!pinned.startsWith(REPOSITORY + ":")) {
+                throw new ExceptionInInitializerError(
+                        pinFile + " must pin " + REPOSITORY + ", got: " + pinned);
+            }
+            return pinned;
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(
+                    "Unable to read the pinned Elasticsearch image from " + pinFile + ": " + e);
+        }
+    }
 }


### PR DESCRIPTION
Adds `elasticsearch-java/example/` — the last adapter without one, so
`demo/scripts/validate-demo.sh` now reports 11/11 and `DEMO_REQUIRE_ALL_EXAMPLES=1` passes. #360 is
unblocked; nothing here enables it.

Fixes #358

No entry was added to `demo/expected.json`. ADR 0001 admits no per-adapter exceptions and none was
needed: the emitted document matches the shared expectations byte for byte.

## How each shape is expressed

The adapter returns a sealed `Result` — `AlwaysAllowed`, `AlwaysDenied`, or
`Conditional(Map<String, Object>)` — and no Elasticsearch type appears in its signature. The example
parses the conditional map into a client `Query` with `withJson` and supplies an explicit clause for
the two unconditional kinds, so every shape is one `bool.filter` array.

| Shape | Expression |
| --- | --- |
| 1 — filtered list | the parsed clause as the single entry of `bool.filter` |
| 2 — `KIND_ALWAYS_ALLOWED` | no clause from the adapter; the application supplies `match_all` |
| 3 — `KIND_ALWAYS_DENIED` | no clause from the adapter; the application supplies `match_none` |
| 4 — pagination | the same `bool.filter`, plus Elasticsearch `from`/`size` and a `sort` on the `id` keyword field |
| 5 — composition | two more entries in the same array, built with the client's own `TermQuery` builders from `seeds.json`'s `applicationFilter` |

`bool.filter` rather than `bool.must` throughout — an authorization condition is an access control
filter, not a relevance signal — which is also what makes shape 5 a list append.

Both unconditional kinds run their search rather than short-circuiting, because the property shape 5
exists to check is that the application's own predicate cannot resurrect a denied document, and only
a query that actually executes with both halves in place shows that.

### `KIND_ALWAYS_ALLOWED` is accepted here, unlike ChromaDB's empty filter

On langchain-chromadb an unconditional allow comes back as `filters: {}` and Chroma's validator
rejects it. This adapter cannot land there: an unconditional allow is a distinct sealed variant
carrying no clause at all, so there is nothing to forward by mistake. The empty spelling would have
been fine anyway — measured against the pinned server rather than assumed:
`{"query":{"bool":{"filter":[]}}}` is accepted and returns every document.

## `publishToMavenLocal`, and the break-tests that prove it executes the real POM

The adapter gains `maven-publish` (it had none) and publishes one `java` component as
`dev.cerbos:cerbos-elasticsearch:0.1.0`. The example declares a normal coordinate resolved from a
**filtered** `mavenLocal()` — the filter names that one module, so no stale artifact in `~/.m2` can
shadow Central for anything else. There is deliberately **no** `includeBuild("..")`;
`settings.gradle.kts` is a comment explaining why.

The published POM puts both dependencies at `runtime` scope, which is why the example declares
`cerbos-sdk-java` for itself (it names `PlanResourcesResult`) and deliberately does not declare
`protobuf-java`.

Every claim was checked by breaking it. Each row is one deliberate edit, reverted afterwards.

| Break | The example | The adapter's own `gradle build` |
| --- | --- | --- |
| Adapter source made to throw, republished at the **same version** `0.1.0` | fails — `UnsupportedOperationException` raised from inside the published jar | fails too (same source) |
| Adapter's `protobuf-java` given a `strictly("3.25.5")` downgrade | fails at resolution, naming `'dev.cerbos:cerbos-elasticsearch:0.1.0' (runtimeElements) --> 'com.google.protobuf:protobuf-java:{strictly 3.25.5}'` | unaffected |
| The example's compiled classes added to the adapter's `jar` | fails — `run.sh` step 2 refuses the artifact before starting anything | unaffected |
| `includeBuild("..")` added to `settings.gradle.kts` | **builds and resolves happily**, then fails at startup: the adapter was loaded from `../build/libs/` | unaffected |
| A version changed to the dynamic `8.15.+` | fails at resolution: "Resolution strategy disallows usage of dynamic versions" | unaffected |
| The Elasticsearch client version changed to `9.0.0` | fails at `run.sh` step 3, before the server starts: "the majors must match" | unaffected |

Row 2 is the one that proves the published *metadata* is resolved rather than merely present — the
downgrade exists only in the POM and Gradle module file, and the failure names the adapter's
`runtimeElements` variant as the path it arrived on.

Row 4 is the one worth reading twice, and it is why `DemoApplication` refuses to run when the adapter
class was loaded from anywhere under the adapter directory: a composite build produces a green build
**and** a successful resolution, so nothing except a runtime check notices.

### The Maven-local same-version hazard does not reproduce

#424 found that pip skips installing a same-version wheel, so a break-test silently ran the previous
build. Both halves were measured here:

- **Publishing** — `publishToMavenLocal` overwrites `0.1.0` unconditionally. No already-satisfied path.
- **Resolving** — Gradle re-reads a `mavenLocal()` module every build. With `isChanging = true` and the
  zero cache TTL both removed, warming the cache with a good build and then republishing a
  deliberately broken one *still* failed.

`isChanging` and `cacheChangingModulesFor(0, "seconds")` stay anyway: the second finding is a Gradle
behaviour rather than something this build states, and it stops holding the moment `mavenLocal` is
swapped for another repository. The measurement is recorded in the build file so nobody re-derives it.

## How `example/` is kept out of the published artifact

`example/` is a separate Gradle build with its own `settings.gradle.kts`, so it is not a source set of
the adapter and the `jar` task cannot reach it. ADR 0002 asks for that to be checked deliberately in
Java, so `run.sh` asserts it on every run in **both** directions: it refuses an artifact containing
`dev/cerbos/example/`, and it requires the artifact to contain
`ElasticsearchQueryPlanAdapter.class` — otherwise an empty or wrongly-named jar would satisfy the
negative half and "no example classes in there" would be true of a jar with nothing in it.

## What makes the Renovate gate bite, with no lockfile

Two things, and the second makes the first a checked property:

1. **Every version the example resolves is an exact literal**, in `example/build.gradle.kts` or in the
   adapter's `build.gradle.kts` — both under `elasticsearch-java/**`, the workflow's path filter.
   Renovate only opens a PR when a release falls outside the declared constraint, so the hole #424
   found in `sqlalchemy>=2.0` is the one to avoid; Gradle's equivalents are the dynamic selectors.
2. **`failOnDynamicVersions()`** in the example's resolution strategy, so a dynamic selector fails the
   build rather than quietly reopening it. Break-test row 5 above.

**There is deliberately no `gradle.lockfile`.** Renovate can maintain one only by executing
`./gradlew … --write-locks`, and only when a self-hosted administrator has enabled
`allowedUnsafeExecutions: ["gradleWrapper"]` — which this repository has no wrapper for and the hosted
app is not configured for. A committed lockfile would go stale on the first bump and fail this job for
a reason that is not the bump; a gate that is always red distinguishes nothing. What that leaves
uncovered, stated rather than glossed: **transitive** versions are not pinned. That is a smaller gap in
Gradle than in npm or Python — a Maven POM declares one soft-required version, not a range — and
locking becomes the right answer the day this repository grows a wrapper.

## From the code review

`/code-review` ran both axes. Standards found **no hard violations** and five judgement calls; Spec
found one partial criterion. Every confirmed finding is fixed, and two of them were the same defect
found independently from both sides:

- **The Elasticsearch client version was a second, unheld spelling of the server pin.** Both reviewers
  flagged it, and it was real: Renovate automerges non-major bumps while `renovate.json` extends
  `docker:disable`, so the client would drift to 8.16.x and the server pin never would, with nothing
  failing — exactly the hazard `ELASTICSEARCH_IMAGE` exists to remove for the server. Fixed:
  `run.sh` step 3 now asserts the client's **major** matches the pin's tag, and break-test row 6 above
  is the proof. Majors rather than exact versions, because image bumps are manual and exact equality
  would fail every client bump for a reason that is not the bump.
- **Repeated Switches** — two `instanceof` cascades over the same sealed `Result`, one for the kind and
  one for the clause, each with its own fall-through throw. Collapsed into one `authorize()` returning
  an `Authorization(kind, clause)` record, so a kind and a clause read off the same variant cannot
  disagree about which variant it was.
- **The ADR 0002 argument was restated in nine places** in the first draft. Trimmed to pointers
  everywhere except `settings.gradle.kts` (where the absence of `includeBuild` is the load-bearing
  fact) and `example/README.md` (the canonical version).
- **`ElasticsearchTestImage.REFERENCE` had been widened to package-private** with no reader outside the
  class. Back to private, inlined into the `IMAGE` initialiser.
- **`example/README.md` claimed "every other example commits a lockfile".** False —
  `spring-data/example/` does not. Reworded; the conclusion is unchanged.
- **Declined:** bundling the four launcher inputs into a config type (four lookups, all validated
  before anything connects, is not a clump worth a type). **Noted, not acted on:** the extra guards
  here — `failOnDynamicVersions()`, the provenance check, the positive half of the jar check — do not
  exist in `spring-data/example/`, so the two Java examples now differ in enforcement. Pulling
  spring-data up is a follow-up, not this ticket.

## The Elasticsearch pin moved to a file

`elasticsearch-java/ELASTICSEARCH_IMAGE`, in `repo:tag@sha256:...` form, read by
`ElasticsearchTestImage` and by `example/run.sh`. Same reason `pgx/POSTGRES_IMAGE` exists (#429): a
shell script cannot read a Java constant, and `validate-corpus.sh` holds one digest per tag while
nothing holds two tags equal, so a second spelling could be left behind on an older server and stay
green. The reference is unchanged (8.15.3, same digest). `tasks.test` now declares the file as an
input, for the same reason it already declares the corpus directory.

## Findings worth a reviewer's attention

- **The protobuf-scope argument is weaker than the comments in `spring-data/` imply.** At
  cerbos-sdk-java 0.19.0 the SDK's own POM already requires `protobuf-java:4.35.1` at runtime scope,
  and that requirement is what wins — the transitive graph does contain older ones (`grpc-protobuf`
  3.25.8, `protovalidate` 4.34.1, `dev.cel` 4.33.5), but the adapter's own declaration changes nothing
  for a consumer who declares the SDK. It is a floor, not the thing standing between the example and a
  broken runtime. Corrected in the comments here rather than copied across.
- **The adapter emits `bool.minimum_should_match` as the integer `1`.** Elasticsearch's own JSON
  accepts that; the client models the field as a *string* and turns out to parse the integer anyway.
  No change made — but it is a mismatch with no other place to surface in this repository, since the
  golden asset and the raw-JSON harness both bypass the client's generated types.
- **`README.md` shows a pattern-matching `switch` over the sealed `Result` under "Requirements: Java
  17+".** That switch is standard only from Java 21. The example is compiled with
  `options.release = 17`, the declared floor, and so uses an `instanceof` chain. Nothing is broken;
  worth deciding whether the README should say which Java the snippet needs.
- **`plan(Principal, Resource, String)` is deprecated in cerbos-sdk-java 0.19.0.** The example passes a
  single-element list instead. `spring-data/example/` still uses the deprecated overload.
- **No shape strained.** Every one of the five is expressible here, so there is no finding for #349.

## Commands run, with results

Local runs used Gradle 8.14.5 on Zulu JDK 17; the example build was additionally verified under
Gradle 8.12 (what CI pins) in the documented `gradle:8.12-jdk17` container.

| Command | Result |
| --- | --- |
| `demo/scripts/run-example.sh elasticsearch-java` | pass — matched `demo/expected.json` across 5 usage shapes, from a cold `example/build`, cold `elasticsearch-java/build` and an emptied `~/.m2/.../cerbos-elasticsearch` |
| `demo/scripts/validate-demo.sh` | pass — 5/5, example coverage 11/11, still missing: none |
| `DEMO_REQUIRE_ALL_EXAMPLES=1 demo/scripts/validate-demo.sh` | pass (check 4 enforced) |
| `conformance/scripts/validate-corpus.sh` | pass — 199 actions, 21 seeds |
| `conformance/scripts/check-docs.sh` | pass — TOC in sync, no roster counts in prose |
| the adapter's own suite, in `gradle:8.12-jdk17` from the repo root per `CLAUDE.md` | pass — `:test` executed (not `UP-TO-DATE`), BUILD SUCCESSFUL |

The PDP was the pinned one, and that was verified rather than assumed — the local `cerbos` CLI here is
0.55.0, the wrong version. `demo/docker-compose.yml` started
`ghcr.io/cerbos/cerbos:0.54.0@sha256:211c261f…`; the container's
`org.opencontainers.image.version` label reads `0.54.0` and `GET /api/server_info` reports
`{"version":"0.54.0","commit":"6b40a5f9…"}`.

Check 5 of `validate-demo.sh` (principal provenance) was proved live on this example rather than
vacuous: temporarily replacing `seeds.principal(principalId)` with an inline
`new DemoSeeds.Principal(...)` failed the build with the file and line, and reverting restored the
pass. `*.java` is in both validators' include lists and nothing excludes this path.
