### PR TITLE
ci(demo): enforce that every adapter has an example application

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1054,7 +1054,28 @@ unsupported before you have watched it fail is how a translatable shape gets per
    promotions — so onboarding an adapter without pinning its messages fails there rather than in
    the new harness alone.
 
-7. **Wire CI.** Copy an existing adapter workflow. It must: read the PDP version from
+7. **Write the example application.** Registering in the roster is what demands one:
+   `demo/scripts/validate-demo.sh` reads that same `adapters` key — there is deliberately no
+   second list — and fails the build for any adapter on it without a runnable
+   `<adapter>/example/run.sh`. So step 6 and this step land together or CI stays red.
+
+   An example implements the demo domain's five usage shapes against the adapter installed as a
+   **packed artifact** rather than imported from source
+   ([ADR 0002](../docs/adr/0002-examples-install-the-packed-artifact.md)). That is coverage this
+   corpus structurally cannot give you: every harness here imports its adapter from source, which
+   leaves the published surface — `exports` maps, type declarations, `files` allowlists, peer
+   ranges, POM scopes — executed nowhere, and asks only for one flat filtered query, never a
+   paginated one and never the adapter's filter composed with a predicate the application owns. An
+   adapter that cannot implement those five shapes has a packaging or ergonomics problem, and
+   finding it here is the point — before release rather than after.
+
+   There is no classification bucket to opt out with, and adding one is what
+   [ADR 0001](../docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md) rules out: a shape
+   that would need a per-adapter carve-out is wrong for the demo domain, and the argument belongs
+   back in this corpus, where the buckets already exist. Read
+   [demo/README.md](../demo/README.md) — "What an example must do" — before writing one.
+
+8. **Wire CI.** Copy an existing adapter workflow. It must: read the PDP version from
    `CERBOS_VERSION` and its digest from `CERBOS_IMAGE_DIGEST` (never hardcode either), run
    `scripts/validate-corpus.sh` in every job that replays the corpus **or** hardcodes the PDP
    image — a job that interpolates the two files at runtime cannot drift and does not need it,
@@ -1064,6 +1085,14 @@ unsupported before you have watched it fail is how a translatable shape gets per
    the translator and the datastore, so a separate job costs runner minutes for no extra
    coverage. Pin every service image the harness or the workflow starts, by tag **and** digest —
    see below.
+
+   It also carries the example job from step 7: trigger on `demo/**` too, run
+   `demo/scripts/validate-demo.sh` and `demo/scripts/run-example.sh <adapter>`, and keep that job
+   **in this adapter's own workflow**. `renovate.json` automerges non-major bumps, so an ORM bump
+   arrives as one PR touching both the adapter's manifest and the example's committed lockfile, and
+   the example job on that PR is what blocks the automerge when the new ORM breaks real usage. A
+   nightly or standalone workflow would still fail eventually, but not before the merge, which
+   silently restores the gap it exists to close.
 
 ### Pinning service images
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -154,18 +154,22 @@ The rot risk is real, and `validate-demo.sh` is what answers it:
    sidecar binds, and that failure is silent rather than loud. The scan is for a client address
    specifically: `docker-compose.yml`'s `"13592:3592"` names the PDP's own listen port on the
    container side, which is correct.
-4. **Example coverage.** Every adapter has an `example/`. **Currently disabled** — it cannot pass
-   until the last child of cerbos/query-plan-adapters#349 merges, and enabling it is
-   cerbos/query-plan-adapters#360's job. Run with `DEMO_REQUIRE_ALL_EXAMPLES=1` to see where it
-   stands. The roster it reads is `adapters` in `conformance/actions.json`; there is deliberately
-   no second list.
+4. **Example coverage.** Every adapter has a runnable `example/run.sh`. The roster it reads is
+   `adapters` in `conformance/actions.json`; there is deliberately no second list, so registering
+   an adapter in the corpus is what demands an example of it, and adding one without an example
+   fails the build rather than quietly shipping an adapter nothing has ever installed. There is no
+   opt-out and no environment variable to switch it off — an adapter that cannot implement the five
+   shared shapes has a packaging or ergonomics problem worth finding before release rather than
+   after, which is the argument of cerbos/query-plan-adapters#349, and it is the same reason
+   ADR 0001 gives this directory no classification buckets.
 5. **Principal provenance.** An example looks its principal up in `seeds.json` rather than writing
    one out. Unlike the hardcoded PDP address check 3 catches, a restated principal does **not** fail
    quietly — it matches the corpus until someone edits `seeds.json`, and then that example's frozen
    id lists mismatch and it fails loudly, as an adapter bug rather than as the misinvocation it is.
-   So this is a latency problem, and it earns a check only because six more examples are queued
-   (cerbos/query-plan-adapters#349): a rule constraining examples being *written* is worth more than
-   one added after they exist.
+   So this is a latency problem, and it earned a check only because six more examples were queued
+   behind it (cerbos/query-plan-adapters#349): a rule constraining examples being *written* is worth
+   more than one added after they exist. Those examples have since landed and check 4 now holds the
+   roster complete, so what this guards from here on is the next adapter to join it.
 
    The signal is an id **next to a role**: naming `alice` is unavoidable (it is the lookup key, the
    `expected.json` entry key, and the word a printed line uses), but naming `alice` alongside `user`
@@ -196,6 +200,10 @@ adapter's test workflow.
   second.
 - **Adding a usage shape** means implementing it in every example. There is no per-adapter
   classification to opt out with, and adding one is what ADR 0001 rules out.
+- **Adding an adapter** means adding an example for it, in the same sequence that registers it in
+  `conformance/actions.json` — that roster is what check 4 reads, so the two land together or CI
+  stays red. The step-by-step is in
+  [conformance/README.md](../conformance/README.md#adding-a-new-adapter).
 - **A shape that needs a carve-out for one adapter is wrong for this directory.** The argument
   belongs in `conformance/`, where the classification buckets exist.
 

--- a/demo/scripts/validate-demo.sh
+++ b/demo/scripts/validate-demo.sh
@@ -18,8 +18,9 @@
 #      in conformance/ — at $CERBOS_HOST, never at an address of its own. That second half is
 #      not fussiness: 3592/3593 are the ports every adapter's `cerbos run` test sidecar binds,
 #      so a hardcoded default does not fail, it silently plans against the wrong policy suite.
-#   4. Every adapter has an example/ directory. Landed DISABLED — it cannot pass until the last
-#      child of cerbos/query-plan-adapters#349 merges, and turning it on is #360's job.
+#   4. Every adapter has a runnable example/run.sh. The roster is `adapters` in
+#      conformance/actions.json — the one already there, never a second list — so registering an
+#      adapter is what demands an example of it, and adding one without an example fails here.
 #   5. Principal provenance: an example reads its principal out of seeds.json rather than
 #      restating one inline.
 
@@ -32,9 +33,6 @@ REPO_ROOT="$(cd "${DEMO_DIR}/.." && pwd)"
 SEEDS="${DEMO_DIR}/seeds.json"
 EXPECTED="${DEMO_DIR}/expected.json"
 ACTIONS="${REPO_ROOT}/conformance/actions.json"
-
-# Turning this on is cerbos/query-plan-adapters#360, once every adapter has an example.
-REQUIRE_ALL_EXAMPLES="${DEMO_REQUIRE_ALL_EXAMPLES:-0}"
 
 # The five usage shapes from cerbos/query-plan-adapters#349, in emission order.
 SHAPES=(filtered alwaysAllowed alwaysDenied paginated composed)
@@ -361,27 +359,34 @@ for adapter in $(jq -r '.adapters[]' "${ACTIONS}"); do
 done
 
 # ---------------------------------------------------------------------------------------------
-# 4. Every adapter has an example (DISABLED — see the header)
+# 4. Every adapter has a runnable example/run.sh
 # ---------------------------------------------------------------------------------------------
-missing=()
-have=()
+echo "==> [4/5] example coverage: every adapter has a runnable example/run.sh"
+
+# The roster is `adapters` in conformance/actions.json — the same one checks 3 and 5 iterate, and
+# the same rule that keeps the PDP pin in one place. A second list here would be a list that can
+# disagree with the corpus, and the adapter left off it is exactly the one nothing would demand an
+# example of. validate-corpus.sh already asserts that roster is non-empty and duplicate-free and
+# runs in the same job immediately before this script, so this cannot pass by iterating nothing.
+#
+# There is no per-adapter opt-out and no environment variable to switch it off: a gate with an
+# escape hatch is not a gate, and the reason there is nothing to opt out WITH is ADR 0001, the
+# same argument demo/README.md's check 4 states in full.
+#
+# Existence and the mode bit are separate failures because they need different fixes, and because
+# `-e` alone is not enough: run-example.sh executes the script directly, so a run.sh committed
+# without its mode bit is not a runnable example either. Testing existence alone would pass it
+# here and fail later in the example job, with a message about the runner rather than the mode bit.
 for adapter in $(jq -r '.adapters[]' "${ACTIONS}"); do
-  if [[ -x "${REPO_ROOT}/${adapter}/example/run.sh" ]]; then
-    have+=("${adapter}")
-  else
-    missing+=("${adapter}")
+  runner="${REPO_ROOT}/${adapter}/example/run.sh"
+  if [[ ! -e "${runner}" ]]; then
+    fail "${adapter} has no example/run.sh — every adapter in the actions.json roster needs an" \
+      "example application (demo/README.md)"
+  elif [[ ! -x "${runner}" ]]; then
+    fail "${adapter}/example/run.sh is not executable — demo/scripts/run-example.sh invokes it" \
+      "directly, so chmod +x it"
   fi
 done
-
-if [[ "${REQUIRE_ALL_EXAMPLES}" == "1" ]]; then
-  echo "==> [4/5] example coverage: enforced"
-  if (( ${#missing[@]} > 0 )); then
-    fail "no runnable example/run.sh for: ${missing[*]}"
-  fi
-else
-  echo "==> [4/5] example coverage: ${#have[@]}/$(( ${#have[@]} + ${#missing[@]} )) adapters" \
-    "(check disabled until cerbos/query-plan-adapters#360; still missing: ${missing[*]:-none})"
-fi
 
 # ---------------------------------------------------------------------------------------------
 # 5. Principal provenance
@@ -394,9 +399,11 @@ echo "==> [5/5] principal provenance: examples read their principal from seeds.j
 # Unlike the hardcoded PDP address check 3 catches, a restated principal does NOT fail quietly: it
 # matches what the corpus carries until someone edits seeds.json, and then that example's frozen
 # id lists stop matching and it fails loudly — as an adapter bug rather than as the misinvocation
-# it is. So this is a latency problem, not a correctness hole, and it earns a check only because
-# six more examples are queued (cerbos/query-plan-adapters#349): a rule constraining examples
-# being written is worth more than one added after they exist.
+# it is. So this is a latency problem, not a correctness hole, and it earned a check only because
+# six more examples were queued behind it (cerbos/query-plan-adapters#349): a rule constraining
+# examples being written is worth more than one added after they exist. Those examples have since
+# landed — check 4 above is what now holds the roster complete — so what this guards from here on
+# is the next adapter to join it.
 #
 # What makes it checkable is that a principal is an id AND its roles, and only the roles are
 # unobtainable any other way. An example naming `alice` is fine and unavoidable — it is the


### PR DESCRIPTION
## Summary

`demo/scripts/validate-demo.sh`'s check 4 — **every adapter has an example application** — landed
disabled behind `DEMO_REQUIRE_ALL_EXAMPLES`, because it could not pass until every example existed.
With `elasticsearch-java/example/` merged (#431) they all do, so this turns it on.

The escape hatch is **removed** rather than defaulted on. The point of the check is that registering
an adapter in `conformance/actions.json`'s roster is what demands an example of it, and a gate an
environment variable can switch off does not hold that. There is now no way to run
`validate-demo.sh` without check 4.

The roster is the `adapters` key already in `conformance/actions.json` — no second list, the same
rule that keeps the PDP pin in one place. `validate-corpus.sh` already asserts that roster is
non-empty and duplicate-free, and every adapter's `example` job runs it immediately before
`validate-demo.sh`, so check 4 cannot pass by iterating nothing.

## Affected adapters

**None in source.** This is a repo-wide CI gate: no adapter's translator, harness, example or
manifest is touched — the diff is three files, and `conformance/actions.json` is not one of them.
Because it lands under `demo/**` and `conformance/**` it re-runs every adapter's test and example
job, which is the fan-out, not the blast radius.

## What the check now stops

- Adding an adapter to the corpus roster without shipping an example application for it.
- Committing an `example/run.sh` without its mode bit — `run-example.sh` execs the script directly,
  so that is equally broken. It is reported as its own case because it needs a different fix.

An adapter that cannot implement the demo domain's five usage shapes has a packaging or ergonomics
problem worth finding before release rather than after, which is the argument of #349 and the same
reason [ADR 0001](docs/adr/0001-demo-domain-has-no-per-adapter-exceptions.md) gives the demo domain
no classification buckets.

## Changes

| File | What changed |
| --- | --- |
| `demo/scripts/validate-demo.sh` | `REQUIRE_ALL_EXAMPLES` / `DEMO_REQUIRE_ALL_EXAMPLES` deleted; check 4 unconditional, keeping the `==> [4/5] …` line format; missing file and missing mode bit reported as separate failures. Header comment item 4 and the section banner rewritten. |
| `demo/README.md` | Check 4's description matches the code again; new *Adding an adapter* bullet under **Changing the demo domain** pointing at the onboarding checklist. |
| `conformance/README.md` | *Adding a new adapter* gains **step 7, "Write the example application"**; the old step 7 (Wire CI) becomes step 8 and now states that the example job triggers on `demo/**` and must stay in that adapter's own workflow. |

No behaviour change for any adapter, and no corpus data changed: `Corpus valid: 199 actions, 21 seeds`
before and after.

## Evidence

**Negative test — the check fails when an example is missing.** `drizzle/example/run.sh` moved
aside:

```
==> [1/5] structural: five usage shapes, well-formed entries
==> [2/5] non-degeneracy: the expectations still discriminate
==> [3/5] PDP pin: one pin in the repository, reused, and reached at $CERBOS_HOST
==> [4/5] example coverage: every adapter has a runnable example/run.sh
  ✗ drizzle has no example/run.sh — every adapter in the actions.json roster needs an example application (demo/README.md)
==> [5/5] principal provenance: examples read their principal from seeds.json

demo domain validation failed with 1 problem(s)
exit=1
```

**And when one is present but not executable.** `chmod -x mongoose/example/run.sh`:

```
==> [4/5] example coverage: every adapter has a runnable example/run.sh
  ✗ mongoose/example/run.sh is not executable — demo/scripts/run-example.sh invokes it directly, so chmod +x it

demo domain validation failed with 1 problem(s)
exit=1
```

**Restored, and the full offline validation the example jobs run:**

```
==> [4/5] example coverage: every adapter has a runnable example/run.sh
==> demo domain OK
Corpus valid: 199 actions, 21 seeds
check-docs.sh: TOC in sync, no roster counts restated in prose
```

## For the reviewer

Three judgement calls worth a look:

1. **The env var is deleted, not defaulted to on.** The ticket says "adding an adapter without an
   example fails CI, which is the point"; a check an environment variable can disable does not
   deliver that. This does mean there is no supported way to skip check 4 locally.
2. **Missing file and missing mode bit are two separate failures.** Slightly beyond "turn it on",
   but `run-example.sh` execs `run.sh`, so a non-executable one is equally broken and the fix
   differs.
3. **Check 5's rationale was re-tensed** in both `demo/README.md` and `validate-demo.sh` — it said
   "six more examples are queued", which this PR makes false. Stale-state cleanup, not a
   behaviour change.

Closes #360
Parent: #349
